### PR TITLE
feat(rename): Add migration notice for repomix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -10,6 +10,25 @@ import { runInitAction } from './actions/initAction.js';
 import { runRemoteAction } from './actions/remoteAction.js';
 import { runVersionAction } from './actions/versionAction.js';
 
+const showMigrationNotice = () => {
+  logger.log('');
+  logger.log(pc.dim('───────────────────────────────────────────────'));
+  logger.warn(pc.yellow('📢 Important Notice: Project Renamed to Repomix'));
+  logger.log(pc.dim('───────────────────────────────────────────────'));
+  logger.log('');
+  logger.log(pc.white('Due to legal considerations, this project has been renamed from "Repopack" to "Repomix".'));
+  logger.log(pc.white('Please install the new package:'));
+  logger.log('');
+  logger.log(pc.cyan('  npx repomix'));
+  logger.log(pc.white('  or'));
+  logger.log(pc.cyan('  npm install -g repomix'));
+  logger.log('');
+  logger.log(pc.white('For more information, visit: https://github.com/yamadashy/repomix'));
+  logger.log('');
+  logger.log(pc.green('Thank you for using Repopack! We look forward to serving you as Repomix.'));
+  logger.log('');
+};
+
 export interface CliOptions extends OptionValues {
   version?: boolean;
   output?: string;
@@ -74,4 +93,7 @@ const executeAction = async (directory: string, cwd: string, options: CliOptions
   }
 
   await runDefaultAction(directory, cwd, options);
+
+  // Show migration notice before any other output
+  showMigrationNotice();
 };


### PR DESCRIPTION
This PR adds a migration notice to inform users about the project's rename from Repopack to Repomix.
