### PR TITLE
feat: re-add homebrew bump flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  homebrew:
+    runs-on: macos-latest
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          test-bot: false
+
+      - name: Configure Git user
+        uses: Homebrew/actions/git-user-config@master
+
+      - name: Bump packages
+        uses: Homebrew/actions/bump-packages@master
+        with:
+          token: ${{ secrets.COMMITTER_TOKEN }}
+          formulae: repomix


### PR DESCRIPTION
re-add homebrew bump flow per [formula rename](https://github.com/Homebrew/homebrew-core/pull/196439).

---

using official brew actions this time so that the npmjs artifact issue would be resolved see [here](https://github.com/Homebrew/homebrew-core/pull/196454) and [here](https://github.com/Homebrew/homebrew-core/pull/196430)