### PR TITLE
feat(cli): Add number formatting and fix statistics calculation

### DIFF
--- a/src/cli/cliPrint.ts
+++ b/src/cli/cliPrint.ts
@@ -15,7 +15,9 @@ export const printSummary = (
   let securityCheckMessage = '';
   if (config.security.enableSecurityCheck) {
     if (suspiciousFilesResults.length > 0) {
-      securityCheckMessage = pc.yellow(`${suspiciousFilesResults.length} suspicious file(s) detected and excluded`);
+      securityCheckMessage = pc.yellow(
+        `${suspiciousFilesResults.length.toLocaleString()} suspicious file(s) detected and excluded`,
+      );
     } else {
       securityCheckMessage = pc.white('✔ No suspicious files detected');
     }
@@ -25,9 +27,9 @@ export const printSummary = (
 
   logger.log(pc.white('📊 Pack Summary:'));
   logger.log(pc.dim('────────────────'));
-  logger.log(`${pc.white('  Total Files:')} ${pc.white(totalFiles.toString())}`);
-  logger.log(`${pc.white('  Total Chars:')} ${pc.white(totalCharacters.toString())}`);
-  logger.log(`${pc.white(' Total Tokens:')} ${pc.white(totalTokens.toString())}`);
+  logger.log(`${pc.white('  Total Files:')} ${pc.white(totalFiles.toLocaleString())} files`);
+  logger.log(`${pc.white('  Total Chars:')} ${pc.white(totalCharacters.toLocaleString())} chars`);
+  logger.log(`${pc.white(' Total Tokens:')} ${pc.white(totalTokens.toLocaleString())} tokens`);
   logger.log(`${pc.white('       Output:')} ${pc.white(outputPath)}`);
   logger.log(`${pc.white('     Security:')} ${pc.white(securityCheckMessage)}`);
 };
@@ -63,8 +65,9 @@ export const printTopFiles = (
   fileTokenCounts: Record<string, number>,
   topFilesLength: number,
 ) => {
+  const topFilesLengthStrLen = topFilesLength.toString().length;
   logger.log(pc.white(`📈 Top ${topFilesLength} Files by Character Count and Token Count:`));
-  logger.log(pc.dim('──────────────────────────────────────────────────────'));
+  logger.log(pc.dim(`─────────────────────────────────────────────────${'─'.repeat(topFilesLengthStrLen)}`));
 
   const topFiles = Object.entries(fileCharCounts)
     .sort((a, b) => b[1] - a[1])
@@ -74,7 +77,7 @@ export const printTopFiles = (
     const tokenCount = fileTokenCounts[filePath];
     const indexString = `${index + 1}.`.padEnd(3, ' ');
     logger.log(
-      `${pc.white(`${indexString}`)} ${pc.white(filePath)} ${pc.dim(`(${charCount} chars, ${tokenCount} tokens)`)}`,
+      `${pc.white(`${indexString}`)} ${pc.white(filePath)} ${pc.dim(`(${charCount.toLocaleString()} chars, ${tokenCount.toLocaleString()} tokens)`)}`,
     );
   });
 };

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -103,11 +103,11 @@ export const pack = async (
     },
   );
 
-  tokenCounter.free();
-
   const totalFiles = processedFiles.length;
-  const totalCharacters = fileMetrics.reduce((sum, fileMetric) => sum + fileMetric.charCount, 0);
-  const totalTokens = fileMetrics.reduce((sum, fileMetric) => sum + fileMetric.tokenCount, 0);
+  const totalCharacters = output.length;
+  const totalTokens = tokenCounter.countTokens(output);
+
+  tokenCounter.free();
 
   const fileCharCounts: Record<string, number> = {};
   const fileTokenCounts: Record<string, number> = {};

--- a/tests/core/packager.test.ts
+++ b/tests/core/packager.test.ts
@@ -95,8 +95,8 @@ describe('packager', () => {
 
     // Check the result of pack function
     expect(result.totalFiles).toBe(2);
-    expect(result.totalCharacters).toBe(38);
-    expect(result.totalTokens).toBe(20);
+    expect(result.totalCharacters).toBe(11);
+    expect(result.totalTokens).toBe(10);
     expect(result.fileCharCounts).toEqual({
       'file1.txt': 19,
       [file2Path]: 19,


### PR DESCRIPTION
This PR improves the readability of statistics output and fixes how total character and token counts are calculated. Previously, the totals were showing the sum of individual files rather than the metrics of the final output file.
