### PR TITLE
Add production dependencies check to prevent dev dependencies leaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm run build
+    - name: Install only production dependencies
+      run: npm ci --omit=dev
     - run: node bin/repomix.cjs
     - name: Upload build artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Add production dependencies check to prevent dev dependencies leaks in v0.2.4

<!-- Please include a summary of the changes -->

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
