### PR TITLE
feat(cli): Add --no-security-check command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ This format provides a clean, readable structure that is both human-friendly and
 - `--copy`: Additionally copy generated output to system clipboard
 - `--remote <url>`: Process a remote Git repository
 - `--remote-branch <name>`: Specify the remote branch name, tag, or commit hash (defaults to repository default branch)
+- `--no-security-check`: Disable security check
 - `--verbose`: Enable verbose logging
 
 Examples:
@@ -512,6 +513,15 @@ By default, Repomix's security check feature is enabled. You can disable it by s
   }
 }
 ```
+
+Or using the `--no-security-check` command line option:
+
+```bash
+repomix --no-security-check
+```
+
+> [!NOTE]
+> Disabling security checks may expose sensitive information. Use this option with caution and only when necessary, such as when working with test files or documentation that contains example credentials.
 
 
 

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -112,6 +112,9 @@ const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
   if (options.style) {
     cliConfig.output = { ...cliConfig.output, style: options.style.toLowerCase() as RepomixOutputStyle };
   }
+  if (options.securityCheck !== undefined) {
+    cliConfig.security = { enableSecurityCheck: options.securityCheck };
+  }
 
   try {
     return repomixConfigCliSchema.parse(cliConfig);

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -25,6 +25,7 @@ export interface CliOptions extends OptionValues {
   global?: boolean;
   remote?: string;
   remoteBranch?: string;
+  securityCheck?: boolean;
 }
 
 export const run = async () => {
@@ -49,6 +50,7 @@ export const run = async () => {
         '--remote-branch <name>',
         'specify the remote branch name, tag, or commit hash (defaults to repository default branch)',
       )
+      .option('--no-security-check', 'disable security check')
       .action((directory = '.', options: CliOptions = {}) => executeAction(directory, process.cwd(), options));
 
     await program.parseAsync(process.argv);

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -123,4 +123,42 @@ describe('defaultAction', () => {
 
     await expect(runDefaultAction('.', process.cwd(), options)).rejects.toThrow('Test error');
   });
+
+  describe('security check flag', () => {
+    it('should handle --no-security-check flag', async () => {
+      const options: CliOptions = {
+        securityCheck: false,
+      };
+
+      await runDefaultAction('.', process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
+        expect.objectContaining({
+          security: {
+            enableSecurityCheck: false,
+          },
+        }),
+      );
+    });
+
+    it('should handle explicit --security-check flag', async () => {
+      const options: CliOptions = {
+        securityCheck: true,
+      };
+
+      await runDefaultAction('.', process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
+        expect.objectContaining({
+          security: {
+            enableSecurityCheck: true,
+          },
+        }),
+      );
+    });
+  });
 });

--- a/tests/cli/cliRun.test.ts
+++ b/tests/cli/cliRun.test.ts
@@ -115,4 +115,42 @@ describe('cliRun', () => {
       expect(defaultAction.runDefaultAction).not.toHaveBeenCalled();
     });
   });
+
+  describe('security check flag', () => {
+    test('should enable security check by default', async () => {
+      await executeAction('.', process.cwd(), {});
+
+      expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
+        '.',
+        process.cwd(),
+        expect.not.objectContaining({
+          securityCheck: false,
+        }),
+      );
+    });
+
+    test('should handle --no-security-check flag', async () => {
+      await executeAction('.', process.cwd(), { securityCheck: false });
+
+      expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
+        '.',
+        process.cwd(),
+        expect.objectContaining({
+          securityCheck: false,
+        }),
+      );
+    });
+
+    test('should handle explicit --security-check flag', async () => {
+      await executeAction('.', process.cwd(), { securityCheck: true });
+
+      expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
+        '.',
+        process.cwd(),
+        expect.objectContaining({
+          securityCheck: true,
+        }),
+      );
+    });
+  });
 });


### PR DESCRIPTION
<!-- Please include a summary of the changes -->
This PR adds a command line option to disable security checks, following commander.js's negatable boolean pattern.

related: #191 

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
