### PR TITLE
Support commit SHA in --remote-branch option

### DIFF
--- a/src/cli/actions/remoteAction.ts
+++ b/src/cli/actions/remoteAction.ts
@@ -73,7 +73,7 @@ export const createTempDirectory = async (): Promise<string> => {
 export const cloneRepository = async (
   url: string,
   directory: string,
-  branch?: string,
+  remoteBranch?: string,
   deps = {
     execGitShallowClone,
   },
@@ -82,7 +82,7 @@ export const cloneRepository = async (
   logger.log('');
 
   try {
-    await deps.execGitShallowClone(url, directory, branch);
+    await deps.execGitShallowClone(url, directory, remoteBranch);
   } catch (error) {
     throw new RepomixError(`Failed to clone repository: ${(error as Error).message}`);
   }

--- a/src/core/file/gitCommand.ts
+++ b/src/core/file/gitCommand.ts
@@ -26,5 +26,14 @@ export const execGitShallowClone = async (
     execAsync,
   },
 ) => {
-  await deps.execAsync(`git clone --depth 1 ${branch ? `-b ${branch} ` : ''}${url} ${directory}`);
+  if(branch){
+    await deps.execAsync(`git -C ${directory} init`);
+    await deps.execAsync(`git -C ${directory} remote add origin ${url}`);
+    await deps.execAsync(`git -C ${directory} fetch --depth 1 origin ${branch}`);
+    await deps.execAsync(`git -C ${directory} checkout FETCH_HEAD`);
+    await deps.execAsync(`rm -rf ${directory}/.git 2>/dev/null || rmdir /s /q ${directory}\\.git`)
+
+  }else{
+    await deps.execAsync(`git clone --depth 1 ${url} ${directory}`);
+  }
 };

--- a/src/core/file/gitCommand.ts
+++ b/src/core/file/gitCommand.ts
@@ -26,14 +26,13 @@ export const execGitShallowClone = async (
     execAsync,
   },
 ) => {
-  if(branch){
+  if (branch) {
     await deps.execAsync(`git -C ${directory} init`);
     await deps.execAsync(`git -C ${directory} remote add origin ${url}`);
     await deps.execAsync(`git -C ${directory} fetch --depth 1 origin ${branch}`);
     await deps.execAsync(`git -C ${directory} checkout FETCH_HEAD`);
-    await deps.execAsync(`rm -rf ${directory}/.git 2>/dev/null || rmdir /s /q ${directory}\\.git`)
-
-  }else{
+    await deps.execAsync(`rm -rf ${directory}/.git 2>/dev/null || rmdir /s /q ${directory}\\.git`);
+  } else {
     await deps.execAsync(`git clone --depth 1 ${url} ${directory}`);
   }
 };

--- a/src/core/file/gitCommand.ts
+++ b/src/core/file/gitCommand.ts
@@ -1,4 +1,6 @@
 import { exec } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import { promisify } from 'node:util';
 import { logger } from '../../shared/logger.js';
 
@@ -31,7 +33,7 @@ export const execGitShallowClone = async (
     await deps.execAsync(`git -C ${directory} remote add origin ${url}`);
     await deps.execAsync(`git -C ${directory} fetch --depth 1 origin ${branch}`);
     await deps.execAsync(`git -C ${directory} checkout FETCH_HEAD`);
-    await deps.execAsync(`rm -rf ${directory}/.git 2>/dev/null || rmdir /s /q ${directory}\\.git`);
+    await fs.rm(path.join(directory, '.git'), { recursive: true, force: true });
   } else {
     await deps.execAsync(`git clone --depth 1 ${url} ${directory}`);
   }

--- a/src/core/file/gitCommand.ts
+++ b/src/core/file/gitCommand.ts
@@ -23,15 +23,15 @@ export const isGitInstalled = async (
 export const execGitShallowClone = async (
   url: string,
   directory: string,
-  branch?: string,
+  remoteBranch?: string,
   deps = {
     execAsync,
   },
 ) => {
-  if (branch) {
+  if (remoteBranch) {
     await deps.execAsync(`git -C ${directory} init`);
     await deps.execAsync(`git -C ${directory} remote add origin ${url}`);
-    await deps.execAsync(`git -C ${directory} fetch --depth 1 origin ${branch}`);
+    await deps.execAsync(`git -C ${directory} fetch --depth 1 origin ${remoteBranch}`);
     await deps.execAsync(`git -C ${directory} checkout FETCH_HEAD`);
     await fs.rm(path.join(directory, '.git'), { recursive: true, force: true });
   } else {

--- a/src/core/file/gitCommand.ts
+++ b/src/core/file/gitCommand.ts
@@ -31,10 +31,22 @@ export const execGitShallowClone = async (
   if (remoteBranch) {
     await deps.execAsync(`git -C ${directory} init`);
     await deps.execAsync(`git -C ${directory} remote add origin ${url}`);
-    await deps.execAsync(`git -C ${directory} fetch --depth 1 origin ${remoteBranch}`);
-    await deps.execAsync(`git -C ${directory} checkout FETCH_HEAD`);
-    await fs.rm(path.join(directory, '.git'), { recursive: true, force: true });
+
+    // Short SHA detection - matches 4-40 character hex string
+    const maybeShortSha = remoteBranch?.match(/^[0-9a-f]{4,39}$/i);
+
+    if (maybeShortSha) {
+      // Can't use --depth 1 here as we need to fetch the specific commit
+      await deps.execAsync(`git -C ${directory} fetch origin`);
+      await deps.execAsync(`git -C ${directory} checkout ${remoteBranch}`);
+    } else {
+      await deps.execAsync(`git -C ${directory} fetch --depth 1 origin ${remoteBranch}`);
+      await deps.execAsync(`git -C ${directory} checkout FETCH_HEAD`);
+    }
   } else {
     await deps.execAsync(`git clone --depth 1 ${url} ${directory}`);
   }
+
+  // Clean up .git directory
+  await fs.rm(path.join(directory, '.git'), { recursive: true, force: true });
 };

--- a/src/core/file/gitCommand.ts
+++ b/src/core/file/gitCommand.ts
@@ -39,15 +39,14 @@ export const execGitShallowClone = async (
       // If the string matches this regex, it MIGHT be a short SHA
       // If the string doesn't match, it is DEFINITELY NOT a short SHA
       const isNotShortSHA = !remoteBranch.match(/^[0-9a-f]{4,39}$/i);
-      if (isNotShortSHA) {
-        // If it's not a valid short SHA, rethrow the error as no further action can be taken
-        throw err;
-      }
+
+      // git fetch --depth 1 origin <short SHA> always throws "couldn't find remote ref" error
       const isRefNotfoundError =
         err instanceof Error && err.message.includes(`couldn't find remote ref ${remoteBranch}`);
 
-      if (!isRefNotfoundError) {
-        // If the error is not related to a missing remote reference, it could be due to authentication failure, network issues, or other errors
+      if (!isRefNotfoundError || isNotShortSHA) {
+        // Error is not related to a missing remote reference || Not a short SHA
+        // -> Rethrow error as nothing else we can do
         throw err;
       }
 

--- a/src/core/file/gitCommand.ts
+++ b/src/core/file/gitCommand.ts
@@ -38,17 +38,18 @@ export const execGitShallowClone = async (
       // Short SHA detection - matches 4-40 character hex string
       const maybeShortSha = remoteBranch?.match(/^[0-9a-f]{4,39}$/i);
       if (!maybeShortSha) {
-        // It's not even short SHA, there's nothing else we can do
+        // If it's not a short SHA, rethrow the error as we can't do anything further
         throw err;
       }
       const isRefNotfoundError =
         err instanceof Error && err.message.includes(`couldn't find remote ref ${remoteBranch}`);
 
       if (!isRefNotfoundError) {
-        // It's fetch failed error or something irrelevant to the commit hash
+        // If the error is not related to a missing remote reference, it could be due to authentication failure, network issues, or other errors
         throw err;
       }
-      // Maybe it fails because user used short SHA, let's try again
+
+      // Maybe the error is due to a short SHA, let's try again
       // Can't use --depth 1 here as we need to fetch the specific commit
       await deps.execAsync(`git -C ${directory} fetch origin`);
       await deps.execAsync(`git -C ${directory} checkout ${remoteBranch}`);

--- a/src/core/file/gitCommand.ts
+++ b/src/core/file/gitCommand.ts
@@ -1,4 +1,4 @@
-import { ExecException, exec } from 'node:child_process';
+import { exec } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';

--- a/src/core/file/gitCommand.ts
+++ b/src/core/file/gitCommand.ts
@@ -35,10 +35,12 @@ export const execGitShallowClone = async (
       await deps.execAsync(`git -C ${directory} fetch --depth 1 origin ${remoteBranch}`);
       await deps.execAsync(`git -C ${directory} checkout FETCH_HEAD`);
     } catch (err: unknown) {
-      // Short SHA detection - matches 4-40 character hex string
-      const maybeShortSha = remoteBranch?.match(/^[0-9a-f]{4,39}$/i);
-      if (!maybeShortSha) {
-        // If it's not a short SHA, rethrow the error as we can't do anything further
+      // Short SHA detection - matches a hexadecimal string of 4 to 39 characters
+      // If the string matches this regex, it MIGHT be a short SHA
+      // If the string doesn't match, it is DEFINITELY NOT a short SHA
+      const isNotShortSHA = !remoteBranch.match(/^[0-9a-f]{4,39}$/i);
+      if (isNotShortSHA) {
+        // If it's not a valid short SHA, rethrow the error as no further action can be taken
         throw err;
       }
       const isRefNotfoundError =

--- a/tests/core/file/gitCommand.test.ts
+++ b/tests/core/file/gitCommand.test.ts
@@ -74,6 +74,5 @@ describe('gitCommand', () => {
 
       expect(mockExecAsync).toHaveBeenCalledWith(`git clone --depth 1 ${url} ${directory}`);
     });
-
   });
 });

--- a/tests/core/file/gitCommand.test.ts
+++ b/tests/core/file/gitCommand.test.ts
@@ -74,5 +74,21 @@ describe('gitCommand', () => {
 
       expect(mockExecAsync).toHaveBeenCalledWith(`git clone --depth 1 ${url} ${directory}`);
     });
+
+    test('should initialize a shallow clone with a specific branch', async () => {
+      const mockExecAsync = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
+
+      const url = 'https://github.com/user/repo.git';
+      const directory = '/tmp/repo';
+      const branch = 'main';
+
+      await execGitShallowClone(url, directory, branch, { execAsync: mockExecAsync });
+
+      expect(mockExecAsync).toHaveBeenCalledTimes(4);
+      expect(mockExecAsync).toHaveBeenNthCalledWith(1, `git -C ${directory} init`);
+      expect(mockExecAsync).toHaveBeenNthCalledWith(2, `git -C ${directory} remote add origin ${url}`);
+      expect(mockExecAsync).toHaveBeenNthCalledWith(3, `git -C ${directory} fetch --depth 1 origin ${branch}`);
+      expect(mockExecAsync).toHaveBeenNthCalledWith(4, `git -C ${directory} checkout FETCH_HEAD`);
+    });
   });
 });

--- a/tests/core/file/gitCommand.test.ts
+++ b/tests/core/file/gitCommand.test.ts
@@ -44,24 +44,24 @@ describe('gitCommand', () => {
       const mockExecAsync = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
       const url = 'https://github.com/user/repo.git';
       const directory = '/tmp/repo';
-      const branch = 'master';
+      const branch = undefined;
 
       await execGitShallowClone(url, directory, branch, { execAsync: mockExecAsync });
 
-      expect(mockExecAsync).toHaveBeenCalledWith(`git clone --depth 1 -b ${branch} ${url} ${directory}`);
+      expect(mockExecAsync).toHaveBeenCalledWith(`git clone --depth 1 ${url} ${directory}`);
     });
 
     test('should throw error when git clone fails', async () => {
       const mockExecAsync = vi.fn().mockRejectedValue(new Error('Authentication failed'));
       const url = 'https://github.com/user/repo.git';
       const directory = '/tmp/repo';
-      const branch = 'master';
+      const branch = undefined;
 
       await expect(execGitShallowClone(url, directory, branch, { execAsync: mockExecAsync })).rejects.toThrow(
         'Authentication failed',
       );
 
-      expect(mockExecAsync).toHaveBeenCalledWith(`git clone --depth 1 -b ${branch} ${url} ${directory}`);
+      expect(mockExecAsync).toHaveBeenCalledWith(`git clone --depth 1 ${url} ${directory}`);
     });
 
     test('should execute without branch option if not specified by user', async () => {
@@ -74,5 +74,6 @@ describe('gitCommand', () => {
 
       expect(mockExecAsync).toHaveBeenCalledWith(`git clone --depth 1 ${url} ${directory}`);
     });
+
   });
 });

--- a/tests/core/file/gitCommand.test.ts
+++ b/tests/core/file/gitCommand.test.ts
@@ -98,5 +98,20 @@ describe('gitCommand', () => {
       expect(mockExecAsync).toHaveBeenLastCalledWith(`git -C ${directory} fetch --depth 1 origin ${remoteBranch}`);
       // The fourth call (e.g., git checkout) won't be made due to the error on the third call
     });
+
+    test('should handle short SHA correctly', async () => {
+      const mockExecAsync = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
+      const url = 'https://github.com/user/repo.git';
+      const directory = '/tmp/repo';
+      const shortSha = 'ce9b621';
+
+      await execGitShallowClone(url, directory, shortSha, { execAsync: mockExecAsync });
+
+      expect(mockExecAsync).toHaveBeenCalledTimes(4);
+      expect(mockExecAsync).toHaveBeenNthCalledWith(1, `git -C ${directory} init`);
+      expect(mockExecAsync).toHaveBeenNthCalledWith(2, `git -C ${directory} remote add origin ${url}`);
+      expect(mockExecAsync).toHaveBeenNthCalledWith(3, `git -C ${directory} fetch origin`);
+      expect(mockExecAsync).toHaveBeenNthCalledWith(4, `git -C ${directory} checkout ${shortSha}`);
+    });
   });
 });

--- a/tests/core/file/gitCommand.test.ts
+++ b/tests/core/file/gitCommand.test.ts
@@ -108,7 +108,9 @@ describe('gitCommand', () => {
         .mockResolvedValueOnce('Success on first call')
         .mockResolvedValueOnce('Success on second call')
         .mockRejectedValueOnce(
-          new Error(`Command failed: git fetch --depth 1 origin ${shortSha}\nfatal: couldn't find remote ref ${shortSha}`),
+          new Error(
+            `Command failed: git fetch --depth 1 origin ${shortSha}\nfatal: couldn't find remote ref ${shortSha}`,
+          ),
         );
 
       await execGitShallowClone(url, directory, shortSha, { execAsync: mockExecAsync });

--- a/tests/core/file/gitCommand.test.ts
+++ b/tests/core/file/gitCommand.test.ts
@@ -108,7 +108,7 @@ describe('gitCommand', () => {
         .mockResolvedValueOnce('Success on first call')
         .mockResolvedValueOnce('Success on second call')
         .mockRejectedValueOnce(
-          new Error(`Command failed: git fetch origin ${shortSha}\nfatal: couldn't find remote ref ${shortSha}`),
+          new Error(`Command failed: git fetch --depth 1 origin ${shortSha}\nfatal: couldn't find remote ref ${shortSha}`),
         );
 
       await execGitShallowClone(url, directory, shortSha, { execAsync: mockExecAsync });

--- a/tests/core/file/gitCommand.test.ts
+++ b/tests/core/file/gitCommand.test.ts
@@ -123,7 +123,7 @@ describe('gitCommand', () => {
       expect(mockExecAsync).toHaveBeenLastCalledWith(`git -C ${directory} checkout ${shortSha}`);
     });
 
-    test("should throw error when couldn't find remote ref even though it's not due to short SHA", async () => {
+    test("should throw error when remote ref is not found, and it's not due to short SHA", async () => {
       const url = 'https://github.com/user/repo.git';
       const directory = '/tmp/repo';
       const remoteBranch = 'b188a6cb39b512a9c6da7235b880af42c78ccd0d';


### PR DESCRIPTION
## Related:
 
- https://github.com/yamadashy/repomix/issues/195?notification_referrer_id=NT_kwDOByTsI7UxMzc1NzczNzE5ODoxMTk4NjAyNTk

- https://github.com/yamadashy/repomix/pull/196

- https://github.com/yamadashy/repomix/pull/199

The older PR claims to support branch names, tags, and commit hashes, but commit hashes are not actually supported.

## Checklist

- [ ] Run `npm run test`
- [ ] Run `npm run lint`
