### PR TITLE
Add support for commit hashes along with branches

### DIFF
--- a/src/core/file/gitCommand.ts
+++ b/src/core/file/gitCommand.ts
@@ -21,10 +21,13 @@ export const isGitInstalled = async (
 export const execGitShallowClone = async (
   url: string,
   directory: string,
-  branch?: string,
+  branchOrCommit?: string,
   deps = {
     execAsync,
   },
 ) => {
-  await deps.execAsync(`git clone --depth 1 ${branch ? `-b ${branch} ` : ''}${url} ${directory}`);
+  await deps.execAsync(`git clone --depth 1 ${url} ${directory}`);
+  if (branchOrCommit) {
+    await deps.execAsync(`git -C ${directory} checkout ${branchOrCommit}`);
+  }
 };


### PR DESCRIPTION
This PR allows commit hashes to be supported for the branch arg when using a remote repo url.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
