### PR TITLE
integrate strip-json-comments for JSON configuration parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Here's an explanation of the configuration options:
 
 Example configuration:
 
-```json
+```json5
 {
   "output": {
     "filePath": "repomix-output.xml",
@@ -389,6 +389,7 @@ Example configuration:
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,
+    // Patterns can also be specified in .repomixignore
     "customPatterns": ["additional-folder", "**/*.log"]
   },
   "security": {

--- a/biome.json
+++ b/biome.json
@@ -36,5 +36,10 @@
       "trailingCommas": "all",
       "semicolons": "always"
     }
+  },
+  "json": {
+    "parser": {
+      "allowComments": true
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "p-map": "^7.0.3",
         "picocolors": "^1.1.1",
         "strip-comments": "^2.0.1",
+        "strip-json-comments": "^5.0.1",
         "tiktoken": "^1.0.18",
         "zod": "^3.24.1"
       },
@@ -3638,6 +3639,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.1.tgz",
+      "integrity": "sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "p-map": "^7.0.3",
     "picocolors": "^1.1.1",
     "strip-comments": "^2.0.1",
+    "strip-json-comments": "^5.0.1",
     "tiktoken": "^1.0.18",
     "zod": "^3.24.1"
   },

--- a/repomix.config.json
+++ b/repomix.config.json
@@ -14,6 +14,7 @@
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,
+    // ignore is specified in .repomixignore
     "customPatterns": []
   },
   "security": {

--- a/src/config/configLoad.ts
+++ b/src/config/configLoad.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs/promises';
 import path from 'node:path';
+import stripJsonComments from 'strip-json-comments';
 import { z } from 'zod';
 import { RepomixError, rethrowValidationErrorIfZodError } from '../shared/errorHandle.js';
 import { logger } from '../shared/logger.js';
@@ -13,7 +14,6 @@ import {
   repomixConfigMergedSchema,
 } from './configSchema.js';
 import { getGlobalDirectory } from './globalDirectory.js';
-import stripJsonComments from 'strip-json-comments';
 
 const defaultConfigPath = 'repomix.config.json';
 

--- a/src/config/configLoad.ts
+++ b/src/config/configLoad.ts
@@ -13,6 +13,7 @@ import {
   repomixConfigMergedSchema,
 } from './configSchema.js';
 import { getGlobalDirectory } from './globalDirectory.js';
+import stripJsonComments from 'strip-json-comments';
 
 const defaultConfigPath = 'repomix.config.json';
 
@@ -67,7 +68,7 @@ export const loadFileConfig = async (rootDir: string, argConfigPath: string | nu
 const loadAndValidateConfig = async (filePath: string): Promise<RepomixConfigFile> => {
   try {
     const fileContent = await fs.readFile(filePath, 'utf-8');
-    const config = JSON.parse(fileContent);
+    const config = JSON.parse(stripJsonComments(fileContent));
     return repomixConfigFileSchema.parse(config);
   } catch (error) {
     rethrowValidationErrorIfZodError(error, 'Invalid config schema');

--- a/tests/config/configLoad.test.ts
+++ b/tests/config/configLoad.test.ts
@@ -83,6 +83,28 @@ describe('configLoad', () => {
 
       await expect(loadFileConfig(process.cwd(), 'test-config.json')).rejects.toThrow('Invalid JSON');
     });
+
+    test('should parse config file with comments', async () => {
+      const configWithComments = `{
+        // Output configuration
+        "output": {
+          "filePath": "test-output.txt"
+        },
+        /* Ignore configuration */
+        "ignore": {
+          "useGitignore": true // Use .gitignore file
+        }
+      }`;
+
+      vi.mocked(fs.readFile).mockResolvedValue(configWithComments);
+      vi.mocked(fs.stat).mockResolvedValue({ isFile: () => true } as Stats);
+
+      const result = await loadFileConfig(process.cwd(), 'test-config.json');
+      expect(result).toEqual({
+        output: { filePath: 'test-output.txt' },
+        ignore: { useGitignore: true },
+      });
+    });
   });
 
   describe('mergeConfigs', () => {


### PR DESCRIPTION
Integrated [strip-json-comments](https://github.com/sindresorhus/strip-json-comments) to clean JSON configuration files by removing comments before parsing.


## Checklist

- [x] Run `npm run test`:

```
stdout | tests/cli/actions/initAction.test.ts > initAction > createConfigFile > should create a new local config file when one does not exist
configPath /test/dir/repomix.config.json

 ✓ tests/cli/actions/migrationAction.test.ts (5)
 ✓ tests/core/file/permissionCheck.test.ts (13)
 ✓ tests/core/packager.test.ts (5)
 ✓ tests/cli/actions/initAction.test.ts (11)
 ✓ tests/config/configSchema.test.ts (14)
 ✓ tests/cli/cliRun.test.ts (9)
 ✓ tests/core/file/fileProcess.test.ts (8)
 ✓ tests/core/tokenCount/tokenCount.test.ts (12)
     ⠙ should correctly pack simple xml style
 ✓ tests/cli/cliPrint.test.ts (8)
 ✓ tests/cli/cliRun.test.ts (9)
 ✓ tests/config/configLoad.test.ts (7)
 ✓ tests/config/configSchema.test.ts (14)
 ✓ tests/config/globalDirectory.test.ts (7)
 ✓ tests/core/packager.test.ts (5)
 ✓ tests/integration-tests/packager.test.ts (2)
 ✓ tests/shared/logger.test.ts (12)
 ✓ tests/cli/actions/defaultAction.test.ts (7)
 ✓ tests/cli/actions/initAction.test.ts (11)
 ✓ tests/cli/actions/migrationAction.test.ts (5)
 ✓ tests/cli/actions/remoteAction.test.ts (6)
 ✓ tests/cli/actions/versionAction.test.ts (1)
 ✓ tests/core/file/fileCollect.test.ts (3)
 ✓ tests/core/file/fileManipulate.test.ts (40)
 ✓ tests/core/file/filePathSort.test.ts (7)
 ✓ tests/core/file/fileProcess.test.ts (8)
 ✓ tests/core/file/fileSearch.test.ts (12)
 ✓ tests/core/file/gitCommand.test.ts (6)
 ✓ tests/core/file/packageJsonParse.test.ts (2)
 ✓ tests/core/file/permissionCheck.test.ts (13)
 ✓ tests/core/output/outputGenerate.test.ts (1)
 ✓ tests/core/security/securityCheck.test.ts (2)
 ✓ tests/core/tokenCount/tokenCount.test.ts (12)
 ✓ tests/core/output/outputStyles/markdownStyle.test.ts (17)
 ✓ tests/core/output/outputStyles/plainStyle.test.ts (1)
 ✓ tests/core/output/outputStyles/xmlStyle.test.ts (1)

 Test Files  27 passed (27)
      Tests  219 passed (219)
   Start at  18:59:34
   Duration  1.10s (transform 391ms, setup 0ms, collect 1.73s, tests 519ms, environment 4ms, prepare 1.08s)
```

- [x] Run `npm run lint`:

```
> repomix@0.2.6 lint
> npm run lint-biome && npm run lint-ts && npm run lint-secretlint


> repomix@0.2.6 lint-biome
> biome check --write

Checked 77 files in 19ms. No fixes applied.

> repomix@0.2.6 lint-ts
> tsc --noEmit


> repomix@0.2.6 lint-secretlint
> secretlint "**/*" --secretlintignore .gitignore
```
