### PR TITLE
Fix import error that was causing CI to fail

### DIFF
--- a/tests/core/metrics/aggregateMetrics.test.ts
+++ b/tests/core/metrics/aggregateMetrics.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import type { FileMetrics } from '../../../lib/core/metrics/calculateIndividualFileMetrics.js';
 import type { ProcessedFile } from '../../../src/core/file/fileTypes.js';
 import { aggregateMetrics } from '../../../src/core/metrics/aggregateMetrics.js';
+import type { FileMetrics } from '../../../src/core/metrics/calculateIndividualFileMetrics.js';
 import type { TokenCounter } from '../../../src/core/tokenCount/tokenCount.js';
 
 describe('aggregateMetrics', () => {


### PR DESCRIPTION
Sorry for the mistake in my PR #217. Not really sure how I ended up importing from the distribution directory without anything failing in my branch, but it was certainly breaking CI in main.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
