### PR TITLE
ci(cache): Use setup-node npm cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version-file: .tool-versions
+        cache: npm
     - run: npm ci
     - run: npm run lint-biome && git diff --exit-code
 
@@ -29,6 +30,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version-file: .tool-versions
+        cache: npm
     - run: npm ci
     - run: npm run lint-ts
 
@@ -41,6 +43,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version-file: .tool-versions
+        cache: npm
     - run: npm ci
     - run: npm run lint-secretlint
 
@@ -53,6 +56,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version-file: .tool-versions
+        cache: npm
     - name: Validate Renovate config
       run: npx --yes --package renovate -- renovate-config-validator --strict
 
@@ -69,11 +73,12 @@ jobs:
     name: Check npm audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: .tool-versions
-      - run: npm audit
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: .tool-versions
+        cache: npm
+    - run: npm audit
 
   check-typos:
     name: Check typos


### PR DESCRIPTION
Enable npm caching for faster CI

<!-- Please include a summary of the changes -->

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
