### PR TITLE
Add support for Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+npm-debug.log
+.git
+.gitignore
+.env
+.env.*
+*.md
+.vscode
+coverage
+.nyc_output
+dist
+build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,62 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - "main"
+    paths-ignore:
+      - "**.md"
+      - LICENSE
+  pull_request:
+    branches:
+      - "*"
+    paths:
+      - "Dockerfile"
+  workflow_dispatch:
+  release:
+    types: [published, edited]
+
+jobs:
+  build-and-publish-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/yamadashy/repomix
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Publish Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          target: release
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,8 @@ on:
       - "*"
     paths:
       - "Dockerfile"
+      - ".dockerignore"
+      - ".github/workflows/docker.yml"
   workflow_dispatch:
   release:
     types: [published, edited]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,7 +54,6 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          target: release
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,19 @@ To run Repomix locally:
 npm run cli-run
 ```
 
+### Docker Usage
+You can also run Repomix using Docker. Here's how:
+
+First, build the Docker image:
+```bash
+docker build -t repomix .
+```
+
+Then, run the Docker container:
+```bash
+docker run -v ./:/app -it --rm repomix
+```
+
 ### Coding Style
 
 We use [Biome](https://biomejs.dev/) for linting and formatting. Please make sure your code follows the style guide by running:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,18 @@ RUN mkdir /repomix
 WORKDIR /repomix
 
 # Install dependencies and build repomix, then link the package to the global scope
+# To reduce the size of the layer, npm ci and npm link are executed in the same RUN command
 COPY . .
 RUN npm ci \
     && npm run build \
     && npm link \
     && npm ci --omit=dev \
-    && npm cache clean --force \
-    && repomix --help
+    && npm cache clean --force
 
 WORKDIR /app
+
+# Check the operation of repomix
+RUN repomix --version
+RUN repomix --help
 
 ENTRYPOINT ["repomix"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN mkdir /repomix
 WORKDIR /repomix
 
-# Install dependencies
-COPY package*.json ./
-RUN npm install
-
-# Build and link repomix
+# Install dependencies and build repomix, then link the package to the global scope
 COPY . .
-RUN npm install \
+RUN npm ci \
     && npm run build \
-    && npm link
+    && npm link \
+    && npm ci --omit=dev \
+    && npm cache clean --force
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN npm ci \
     && npm run build \
     && npm link \
     && npm ci --omit=dev \
-    && npm cache clean --force
+    && npm cache clean --force \
+    && repomix --help
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
+RUN mkdir /repomix
+WORKDIR /repomix
 
+# Install dependencies
 COPY package*.json ./
-
 RUN npm install
 
+# Build and link repomix
 COPY . .
+RUN npm install \
+    && npm run build \
+    && npm link
 
-RUN npm run build
+WORKDIR /app
 
-ENTRYPOINT ["npx", "repomix"]
+ENTRYPOINT ["repomix"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && npm install -g repomix
+    && npm install -g repomix --no-cache-dir \
+    && npm cache clean --force
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:22-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g repomix
+
+WORKDIR /app
+
+ENTRYPOINT ["repomix"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
 FROM node:22-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git ca-certificates \
-    && rm -rf /var/lib/apt/lists/* \
-    && npm install -g repomix --no-cache-dir \
-    && npm cache clean --force
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-ENTRYPOINT ["repomix"]
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+RUN npm run build
+
+ENTRYPOINT ["npx", "repomix"]

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ To initialize a new configuration file (`repomix.config.json`):
 repomix --init
 ```
 
+Once you have generated the packed file, you can use it with Generative AI tools like Claude, ChatGPT, and Gemini.
+
 ### Docker Usage
 You can also run Repomix using Docker 🐳  
 This is useful if you want to run Repomix in an isolated environment or prefer using containers.
@@ -106,8 +108,6 @@ docker run -v .:/app -it --rm ghcr.io/yamadashy/repomix
 # Process a remote repository and output to a `output` directory
 docker run -v ./output:/app -it --rm ghcr.io/yamadashy/repomix --remote https://github.com/yamadashy/repomix
 ```
-
-Once you have generated the packed file, you can use it with Generative AI tools like Claude, ChatGPT, and Gemini.
 
 ### Prompt Examples
 Once you have generated the packed file with Repomix, you can use it with AI tools like Claude, ChatGPT, and Gemini. Here are some example prompts to get you started:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ To initialize a new configuration file (`repomix.config.json`):
 repomix --init
 ```
 
+### 🐳 Docker
+
+Run Repomix using Docker
+
+```bash
+docker run -v ./output:/app -it --rm ghcr.io/yamadashy/repomix --remote https://github.com/yamadashy/repomix
+```
+
 Once you have generated the packed file, you can use it with Generative AI tools like Claude, ChatGPT, and Gemini.
 
 ### Prompt Examples

--- a/README.md
+++ b/README.md
@@ -95,11 +95,13 @@ To initialize a new configuration file (`repomix.config.json`):
 repomix --init
 ```
 
-### 🐳 Docker
-
-Run Repomix using Docker
+You can run it using Docker 🐳
 
 ```bash
+# Basic usage (current directory)
+docker run -v .:/app -it --rm ghcr.io/yamadashy/repomix
+
+# Process a remote repository and output to a `output` directory
 docker run -v ./output:/app -it --rm ghcr.io/yamadashy/repomix --remote https://github.com/yamadashy/repomix
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ To initialize a new configuration file (`repomix.config.json`):
 repomix --init
 ```
 
-You can run it using Docker 🐳
+### Docker Usage
+You can also run Repomix using Docker 🐳  
+This is useful if you want to run Repomix in an isolated environment or prefer using containers.
 
 ```bash
 # Basic usage (current directory)


### PR DESCRIPTION
- Add `Dockerfile` to facilitate running `repomix` using Docker.
- Update `README` with instructions on how to run the cli using Docker.
- Add github-actions workflow for Building, and Publishing the image to Github Container Registry (ghcr.io).
  - Image will be build on each PR.
  - Image will only be published when a branch is merged into `main`, and when a release is tagged.
  - The image can be tested once a branch is merged by using the `ghcr.io/yamadashy/repomix:main` tag
  - The workflow will create `semver` tags for the Docker image.

Fixes #221 

@yamadashy You may have to tweak `Package Settings` to make the image public. https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility

As a separate PR, we could make this repo a `Github Action` that people can run on their repos to automatically generate the output using `repomix`.