### PR TITLE
feat(process): Prevent main thread blocking in file processing

### DIFF
--- a/src/cli/actions/remoteAction.ts
+++ b/src/cli/actions/remoteAction.ts
@@ -75,7 +75,7 @@ export const cloneRepository = async (
   directory: string,
   branch?: string,
   deps = {
-    execGitShallowClone: execGitShallowClone,
+    execGitShallowClone,
   },
 ): Promise<void> => {
   logger.log(`Clone repository: ${url} to temporary directory. ${pc.dim(`path: ${directory}`)}`);

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -48,7 +48,7 @@ export const pack = async (
 
   // Process files (remove comments, etc.)
   progressCallback('Processing files...');
-  const processedFiles = await deps.processFiles(safeRawFiles, config);
+  const processedFiles = await deps.processFiles(safeRawFiles, config, progressCallback);
 
   progressCallback('Generating output...');
   const output = await deps.generateOutput(rootDir, config, processedFiles, safeFilePaths);

--- a/src/core/security/runSecurityCheckIfEnabled.ts
+++ b/src/core/security/runSecurityCheckIfEnabled.ts
@@ -7,11 +7,13 @@ export const runSecurityCheckIfEnabled = async (
   rawFiles: RawFile[],
   config: RepomixConfigMerged,
   progressCallback: RepomixProgressCallback,
-  checkSecurity = runSecurityCheck,
+  deps = {
+    runSecurityCheck,
+  },
 ): Promise<SuspiciousFileResult[]> => {
   if (config.security.enableSecurityCheck) {
     progressCallback('Running security check...');
-    return await checkSecurity(rawFiles, progressCallback);
+    return await deps.runSecurityCheck(rawFiles, progressCallback);
   }
   return [];
 };

--- a/tests/core/file/fileProcess.test.ts
+++ b/tests/core/file/fileProcess.test.ts
@@ -25,7 +25,7 @@ describe('fileProcess', () => {
         removeEmptyLines: (content: string) => content.replace(/^\s*[\r\n]/gm, ''),
       });
 
-      const result = await processFiles(mockRawFiles, config);
+      const result = await processFiles(mockRawFiles, config, () => {});
 
       expect(result).toEqual([
         { path: 'file1.js', content: 'const a = 1;' },

--- a/tests/core/packager.test.ts
+++ b/tests/core/packager.test.ts
@@ -80,7 +80,7 @@ describe('packager', () => {
     expect(mockDeps.calculateMetrics).toHaveBeenCalled();
 
     expect(mockDeps.validateFileSafety).toHaveBeenCalledWith(mockRawFiles, progressCallback, mockConfig);
-    expect(mockDeps.processFiles).toHaveBeenCalledWith(mockSafeRawFiles, mockConfig);
+    expect(mockDeps.processFiles).toHaveBeenCalledWith(mockSafeRawFiles, mockConfig, progressCallback);
     expect(mockDeps.generateOutput).toHaveBeenCalledWith('root', mockConfig, mockProcessedFiles, mockFilePaths);
     expect(mockDeps.writeOutputToDisk).toHaveBeenCalledWith(mockOutput, mockConfig);
     expect(mockDeps.copyToClipboardIfEnabled).toHaveBeenCalledWith(mockOutput, progressCallback, mockConfig);

--- a/tests/core/security/runSecurityCheckIfEnabled.test.ts
+++ b/tests/core/security/runSecurityCheckIfEnabled.test.ts
@@ -17,7 +17,9 @@ describe('runSecurityCheckIfEnabled', () => {
     const progressCallback: RepomixProgressCallback = vi.fn();
     const checkSecurity = vi.fn().mockResolvedValue([{ filePath: 'file1.txt' }] as SuspiciousFileResult[]);
 
-    const result = await runSecurityCheckIfEnabled(rawFiles, config, progressCallback, checkSecurity);
+    const result = await runSecurityCheckIfEnabled(rawFiles, config, progressCallback, {
+      runSecurityCheck: checkSecurity,
+    });
 
     expect(progressCallback).toHaveBeenCalledWith('Running security check...');
     expect(checkSecurity).toHaveBeenCalledWith(rawFiles, progressCallback);
@@ -35,7 +37,9 @@ describe('runSecurityCheckIfEnabled', () => {
     const progressCallback: RepomixProgressCallback = vi.fn();
     const checkSecurity = vi.fn();
 
-    const result = await runSecurityCheckIfEnabled(rawFiles, config, progressCallback, checkSecurity);
+    const result = await runSecurityCheckIfEnabled(rawFiles, config, progressCallback, {
+      runSecurityCheck: checkSecurity,
+    });
 
     expect(progressCallback).not.toHaveBeenCalled();
     expect(checkSecurity).not.toHaveBeenCalled();


### PR DESCRIPTION
<!-- Please include a summary of the changes -->

Related: #208

This PR addresses the issue where the main thread hangs when processing large codebases with removeComments and removeEmptyLines enabled.


## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
