### PR TITLE
feat(cli): Add CLI flags for controlling output sections and content processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,10 @@ This format provides a clean, readable structure that is both human-friendly and
 - `-i, --ignore <patterns>`: Additional ignore patterns (comma-separated)
 - `-c, --config <path>`: Path to a custom config file
 - `--style <style>`: Specify the output style (`plain`, `xml`, `markdown`)
+- `--no-file-summary`: Disable file summary section output
+- `--no-directory-structure`: Disable directory structure section output
+- `--remove-comments`: Remove comments from supported file types
+- `--remove-empty-lines`: Remove empty lines from the output
 - `--top-files-len <number>`: Number of top files to display in the summary
 - `--output-show-line-numbers`: Show line numbers in the output
 - `--copy`: Additionally copy generated output to system clipboard

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -115,6 +115,18 @@ const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
   if (options.securityCheck !== undefined) {
     cliConfig.security = { enableSecurityCheck: options.securityCheck };
   }
+  if (options.fileSummary !== undefined) {
+    cliConfig.output = { ...cliConfig.output, fileSummary: options.fileSummary };
+  }
+  if (options.directoryStructure !== undefined) {
+    cliConfig.output = { ...cliConfig.output, directoryStructure: options.directoryStructure };
+  }
+  if (options.removeComments !== undefined) {
+    cliConfig.output = { ...cliConfig.output, removeComments: options.removeComments };
+  }
+  if (options.removeEmptyLines !== undefined) {
+    cliConfig.output = { ...cliConfig.output, removeEmptyLines: options.removeEmptyLines };
+  }
 
   try {
     return repomixConfigCliSchema.parse(cliConfig);

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -26,6 +26,10 @@ export interface CliOptions extends OptionValues {
   remote?: string;
   remoteBranch?: string;
   securityCheck?: boolean;
+  fileSummary?: boolean;
+  directoryStructure?: boolean;
+  removeComments?: boolean; // 追加
+  removeEmptyLines?: boolean; // 追加
 }
 
 export const run = async () => {
@@ -42,6 +46,10 @@ export const run = async () => {
       .option('--top-files-len <number>', 'specify the number of top files to display', Number.parseInt)
       .option('--output-show-line-numbers', 'add line numbers to each line in the output')
       .option('--style <type>', 'specify the output style (plain, xml, markdown)')
+      .option('--no-file-summary', 'disable file summary section output')
+      .option('--no-directory-structure', 'disable directory structure section output')
+      .option('--remove-comments', 'remove comments')
+      .option('--remove-empty-lines', 'remove empty lines')
       .option('--verbose', 'enable verbose logging for detailed output')
       .option('--init', 'initialize a new repomix.config.json file')
       .option('--global', 'use global configuration (only applicable with --init)')

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -163,4 +163,156 @@ describe('defaultAction', () => {
       );
     });
   });
+
+  describe('fileSummary flag', () => {
+    it('should handle --no-file-summary flag', async () => {
+      const options: CliOptions = {
+        fileSummary: false,
+      };
+
+      await runDefaultAction('.', process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
+        expect.objectContaining({
+          output: {
+            fileSummary: false,
+          },
+        }),
+      );
+    });
+
+    it('should handle explicit --file-summary flag', async () => {
+      const options: CliOptions = {
+        fileSummary: true,
+      };
+
+      await runDefaultAction('.', process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
+        expect.objectContaining({
+          output: {
+            fileSummary: true,
+          },
+        }),
+      );
+    });
+  });
+
+  describe('directoryStructure flag', () => {
+    it('should handle --no-directory-structure flag', async () => {
+      const options: CliOptions = {
+        directoryStructure: false,
+      };
+
+      await runDefaultAction('.', process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
+        expect.objectContaining({
+          output: {
+            directoryStructure: false,
+          },
+        }),
+      );
+    });
+
+    it('should handle explicit --directory-structure flag', async () => {
+      const options: CliOptions = {
+        directoryStructure: true,
+      };
+
+      await runDefaultAction('.', process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
+        expect.objectContaining({
+          output: {
+            directoryStructure: true,
+          },
+        }),
+      );
+    });
+  });
+
+  describe('removeComments flag', () => {
+    it('should handle --remove-comments flag', async () => {
+      const options: CliOptions = {
+        removeComments: true,
+      };
+
+      await runDefaultAction('.', process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
+        expect.objectContaining({
+          output: {
+            removeComments: true,
+          },
+        }),
+      );
+    });
+
+    it('should handle explicit --no-remove-comments flag', async () => {
+      const options: CliOptions = {
+        removeComments: false,
+      };
+
+      await runDefaultAction('.', process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
+        expect.objectContaining({
+          output: {
+            removeComments: false,
+          },
+        }),
+      );
+    });
+  });
+
+  describe('removeEmptyLines flag', () => {
+    it('should handle --remove-empty-lines flag', async () => {
+      const options: CliOptions = {
+        removeEmptyLines: true,
+      };
+
+      await runDefaultAction('.', process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
+        expect.objectContaining({
+          output: {
+            removeEmptyLines: true,
+          },
+        }),
+      );
+    });
+
+    it('should handle explicit --no-remove-empty-lines flag', async () => {
+      const options: CliOptions = {
+        removeEmptyLines: false,
+      };
+
+      await runDefaultAction('.', process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
+        expect.objectContaining({
+          output: {
+            removeEmptyLines: false,
+          },
+        }),
+      );
+    });
+  });
 });


### PR DESCRIPTION
This pull request adds new CLI flags to provide users with more control over the structure and content of Repomix output. These flags allow users to:

-   Disable the file summary section.
-   Disable the directory structure section.
-   Enable comment removal from supported file types.
-   Enable removal of empty lines.

ref
https://github.com/yamadashy/repomix/issues/206#issuecomment-2566463455

<!-- Please include a summary of the changes -->

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
