### PR TITLE
fix(cli): ignore output path using a relative path to the target

### DIFF
--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -159,7 +159,7 @@ export const getIgnorePatterns = async (rootDir: string, config: RepomixConfigMe
 
   // Add repomix output file
   if (config.output.filePath) {
-    const absoluteOutputPath = path.resolve(process.cwd(), config.output.filePath);
+    const absoluteOutputPath = path.resolve(config.cwd, config.output.filePath);
     const relativeToTargetPath = path.relative(rootDir, absoluteOutputPath);
 
     logger.trace('Adding output file to ignore patterns:', relativeToTargetPath);

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -159,8 +159,12 @@ export const getIgnorePatterns = async (rootDir: string, config: RepomixConfigMe
 
   // Add repomix output file
   if (config.output.filePath) {
-    logger.trace('Adding output file to ignore patterns:', config.output.filePath);
-    ignorePatterns.add(config.output.filePath);
+    const absoluteOutputPath = path.resolve(process.cwd(), config.output.filePath);
+    const relativeToTargetPath = path.relative(rootDir, absoluteOutputPath);
+
+    logger.trace('Adding output file to ignore patterns:', relativeToTargetPath);
+
+    ignorePatterns.add(relativeToTargetPath);
   }
 
   // Add custom ignore patterns


### PR DESCRIPTION
# Fix: Properly Ignore Output Path When a Target Is Given

Hi @yamadashy! 👋

I think we have an issue with ignoring the output file when a target is specified.

## Issue Description

```bash
npx repomix foo/bar --output foo/bar/custom-output.txt
```

-> The `custom-output.txt` file is not ignored. If we run the command multiple times, it leads to an increased output file size, etc.

## Why

I believe this happens because the output file added to the `ignorePatterns` is the path `foo/bar/custom-output.txt`. 

However, `globby` compares the `rootDir` with this path. 

When a target is specified, the `rootDir` becomes `/current-working-directory/foo`. As a result, `globby` tries to ignore `/foo/bar/custom-output.txt` inside `/cwd/foo`, which it cannot find.

The ignored file needs to be relative to the target, in this case `/bar/custom-output.txt`.

### Summary

We need to use a relative path to the target to ignore the output file.

## Remark
For the same reason, `.gitignore` and `.repomixignore` are not used if a target is specified. I'm not sure if this is intentional—maybe? If not, we would need to traverse up the tree from the target directory to retrieve the `.gitignore` and `.repomixignore` files.

If needed, I’d be happy to write the code to implement this change. Just let me know! 😊

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

---

