### PR TITLE
feat(output): remove repository URL from output files

### DIFF
--- a/src/core/output/outputGenerate.ts
+++ b/src/core/output/outputGenerate.ts
@@ -9,7 +9,6 @@ import type { ProcessedFile } from '../file/fileTypes.js';
 import type { OutputGeneratorContext } from './outputGeneratorTypes.js';
 import {
   generateHeader,
-  generateSummaryAdditionalInfo,
   generateSummaryFileFormat,
   generateSummaryNotes,
   generateSummaryPurpose,
@@ -29,7 +28,6 @@ const createRenderContext = (outputGeneratorContext: OutputGeneratorContext) => 
       outputGeneratorContext.instruction,
     ),
     summaryNotes: generateSummaryNotes(outputGeneratorContext.config),
-    summaryAdditionalInfo: generateSummaryAdditionalInfo(),
     headerText: outputGeneratorContext.config.output.headerText,
     instruction: outputGeneratorContext.instruction,
     treeString: outputGeneratorContext.treeString,

--- a/src/core/output/outputStyleDecorate.ts
+++ b/src/core/output/outputStyleDecorate.ts
@@ -48,9 +48,3 @@ ${config.output.removeComments ? '- Code comments have been removed.\n' : ''}
 ${config.output.showLineNumbers ? '- Line numbers have been added to the beginning of each line.\n' : ''}
 `.trim();
 };
-
-export const generateSummaryAdditionalInfo = (): string => {
-  return `
-For more information about Repomix, visit: https://github.com/yamadashy/repomix
-`.trim();
-};

--- a/src/core/output/outputStyles/markdownStyle.ts
+++ b/src/core/output/outputStyles/markdownStyle.ts
@@ -28,8 +28,6 @@ export const getMarkdownTemplate = () => {
 {{{headerText}}}
 {{/if}}
 
-{{{summaryAdditionalInfo}}}
-
 {{/if}}
 {{#if directoryStructureEnabled}}
 # Directory Structure

--- a/src/core/output/outputStyles/plainStyle.ts
+++ b/src/core/output/outputStyles/plainStyle.ts
@@ -40,8 +40,6 @@ User Provided Header:
 {{{headerText}}}
 {{/if}}
 
-{{{summaryAdditionalInfo}}}
-
 {{/if}}
 {{#if directoryStructureEnabled}}
 ${PLAIN_LONG_SEPARATOR}

--- a/src/core/output/outputStyles/xmlStyle.ts
+++ b/src/core/output/outputStyles/xmlStyle.ts
@@ -32,7 +32,6 @@ This section contains a summary of this file.
 </user_provided_header>
 {{/if}}
 
-{{{summaryAdditionalInfo}}}
 </additional_info>
 
 </file_summary>

--- a/tests/core/output/outputStyles/markdownStyle.test.ts
+++ b/tests/core/output/outputStyles/markdownStyle.test.ts
@@ -22,7 +22,6 @@ describe('markdownStyle', () => {
         summaryFileFormat: 'Test Format',
         summaryUsageGuidelines: 'Test Guidelines',
         summaryNotes: 'Test Notes',
-        summaryAdditionalInfo: 'Test Additional Info',
         treeString: 'src/\n  index.ts',
         processedFiles: [
           {
@@ -41,7 +40,6 @@ describe('markdownStyle', () => {
       expect(result).toContain('Test Format');
       expect(result).toContain('Test Guidelines');
       expect(result).toContain('Test Notes');
-      expect(result).toContain('Test Additional Info');
       expect(result).toContain('src/\n  index.ts');
       expect(result).toContain('## File: src/index.ts');
       expect(result).toContain('console.log("Hello");');

--- a/tests/integration-tests/fixtures/packager/outputs/simple-project-output.txt
+++ b/tests/integration-tests/fixtures/packager/outputs/simple-project-output.txt
@@ -47,8 +47,6 @@ User Provided Header:
 -----------------------
 This repository is simple-project
 
-For more information about Repomix, visit: https://github.com/yamadashy/repomix
-
 ================================================================
 Directory Structure
 ================================================================

--- a/tests/integration-tests/fixtures/packager/outputs/simple-project-output.xml
+++ b/tests/integration-tests/fixtures/packager/outputs/simple-project-output.xml
@@ -42,7 +42,6 @@ The content is organized as follows:
 This repository is simple-project
 </user_provided_header>
 
-For more information about Repomix, visit: https://github.com/yamadashy/repomix
 </additional_info>
 
 </file_summary>


### PR DESCRIPTION
<!-- Please include a summary of the changes -->

This PR removes the repository URL from all output formats (plain text, XML, and markdown). 


This change was made because:

- AI tools analyzing the codebase don't need information about Repomix itself
- Makes output files cleaner and more focused on the actual codebase content

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
