### PR TITLE
feat(cli): Add browser version announcement to completion message

### DIFF
--- a/src/cli/cliPrint.ts
+++ b/src/cli/cliPrint.ts
@@ -85,4 +85,7 @@ export const printTopFiles = (
 export const printCompletion = () => {
   logger.log(pc.green('🎉 All Done!'));
   logger.log(pc.white('Your repository has been successfully packed.'));
+
+  logger.log('');
+  logger.log(`💡 Repomix is now available in your browser! Try it at ${pc.underline('https://repomix.com')}`);
 };

--- a/tests/cli/cliPrint.test.ts
+++ b/tests/cli/cliPrint.test.ts
@@ -14,6 +14,7 @@ vi.mock('picocolors', () => ({
     yellow: (str: string) => `YELLOW:${str}`,
     red: (str: string) => `RED:${str}`,
     cyan: (str: string) => `CYAN:${str}`,
+    underline: (str: string) => `UNDERLINE:${str}`,
   },
 }));
 


### PR DESCRIPTION
<!-- Please include a summary of the changes -->

Add browser version announcement (https://repomix.com) to tool completion message.

Currently, the announcement appears every time.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
