### PR TITLE
Git Worktree Support

### DIFF
--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -50,8 +50,8 @@ const isGitWorktreeRef = async (gitPath: string): Promise<boolean> => {
       return false;
     }
 
-    const content = await fs.readFile(gitPath, "utf8");
-    return content.startsWith("gitdir:");
+    const content = await fs.readFile(gitPath, 'utf8');
+    return content.startsWith('gitdir:');
   } catch {
     return false;
   }
@@ -82,17 +82,17 @@ export const searchFiles = async (rootDir: string, config: RepomixConfigMerged):
     logger.trace('Ignore file patterns:', ignoreFilePatterns);
 
     // Check if .git is a worktree reference
-    const gitPath = path.join(rootDir, ".git");
+    const gitPath = path.join(rootDir, '.git');
     const isWorktree = await isGitWorktreeRef(gitPath);
 
     // Modify ignore patterns for git worktree
     const adjustedIgnorePatterns = [...ignorePatterns];
     if (isWorktree) {
       // Remove '.git/**' pattern and add '.git' to ignore the reference file
-      const gitIndex = adjustedIgnorePatterns.indexOf(".git/**");
+      const gitIndex = adjustedIgnorePatterns.indexOf('.git/**');
       if (gitIndex !== -1) {
         adjustedIgnorePatterns.splice(gitIndex, 1);
-        adjustedIgnorePatterns.push(".git");
+        adjustedIgnorePatterns.push('.git');
       }
     }
 
@@ -127,11 +127,7 @@ export const searchFiles = async (rootDir: string, config: RepomixConfigMerged):
         followSymbolicLinks: false,
       });
 
-      emptyDirPaths = await findEmptyDirectories(
-        rootDir,
-        directories,
-        adjustedIgnorePatterns
-      );
+      emptyDirPaths = await findEmptyDirectories(rootDir, directories, adjustedIgnorePatterns);
     }
 
     logger.trace(`Filtered ${filePaths.length} files`);

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -1,3 +1,4 @@
+import type { Stats } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
@@ -280,7 +281,7 @@ node_modules
       // Mock fs.stat and fs.readFile for .git file
       vi.mocked(fs.stat).mockResolvedValue({
         isFile: () => true,
-      } as fs.Stats);
+      } as Stats);
       vi.mocked(fs.readFile).mockResolvedValue(gitWorktreeContent);
 
       // Mock globby to return some test files
@@ -313,7 +314,7 @@ node_modules
       // Mock .git as a directory
       vi.mocked(fs.stat).mockResolvedValue({
         isFile: () => false,
-      } as fs.Stats);
+      } as Stats);
 
       // Mock globby to return some test files
       vi.mocked(globby).mockResolvedValue(['file1.js', 'file2.js']);

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -272,5 +272,73 @@ node_modules
       expect(result.filePaths).toContain('root/subdir/ignored.js');
       expect(result.emptyDirPaths).toEqual([]);
     });
+
+    test('should handle git worktree correctly', async () => {
+      // Mock .git file content for worktree
+      const gitWorktreeContent = 'gitdir: /path/to/main/repo/.git/worktrees/feature-branch';
+
+      // Mock fs.stat and fs.readFile for .git file
+      vi.mocked(fs.stat).mockResolvedValue({
+        isFile: () => true,
+      } as fs.Stats);
+      vi.mocked(fs.readFile).mockResolvedValue(gitWorktreeContent);
+
+      // Mock globby to return some test files
+      vi.mocked(globby).mockResolvedValue(['file1.js', 'file2.js']);
+
+      const mockConfig = createMockConfig({
+        ignore: {
+          useGitignore: true,
+          useDefaultPatterns: true,
+          customPatterns: [],
+        },
+      });
+
+      const result = await searchFiles('/test/dir', mockConfig);
+
+      // Check that globby was called with correct ignore patterns
+      const globbyCall = vi.mocked(globby).mock.calls[0];
+      const ignorePatterns = globbyCall[1]?.ignore as string[];
+
+      // Verify .git file (not directory) is in ignore patterns
+      expect(ignorePatterns).toContain('.git');
+      // Verify .git/** is not in ignore patterns
+      expect(ignorePatterns).not.toContain('.git/**');
+
+      // Verify the files were returned correctly
+      expect(result.filePaths).toEqual(['file1.js', 'file2.js']);
+    });
+
+    test('should handle regular git repository correctly', async () => {
+      // Mock .git as a directory
+      vi.mocked(fs.stat).mockResolvedValue({
+        isFile: () => false,
+      } as fs.Stats);
+
+      // Mock globby to return some test files
+      vi.mocked(globby).mockResolvedValue(['file1.js', 'file2.js']);
+
+      const mockConfig = createMockConfig({
+        ignore: {
+          useGitignore: true,
+          useDefaultPatterns: true,
+          customPatterns: [],
+        },
+      });
+
+      const result = await searchFiles('/test/dir', mockConfig);
+
+      // Check that globby was called with correct ignore patterns
+      const globbyCall = vi.mocked(globby).mock.calls[0];
+      const ignorePatterns = globbyCall[1]?.ignore as string[];
+
+      // Verify .git/** is in ignore patterns for regular git repos
+      expect(ignorePatterns).toContain('.git/**');
+      // Verify just .git is not in ignore patterns
+      expect(ignorePatterns).not.toContain('.git');
+
+      // Verify the files were returned correctly
+      expect(result.filePaths).toEqual(['file1.js', 'file2.js']);
+    });
   });
 });


### PR DESCRIPTION
Fixes an issue where Repomix fails when processing repositories created using `git worktree`. The error occurred because in worktree repositories, `.git` is a file containing a reference to the main repository, rather than a directory:

```
❯ repomix

📦 Repomix v0.2.17

Error filtering files: ENOTDIR: not a directory, stat '/Users/shvets/repos/testrepo_worktree/.git/**'
✖ Error during packing
Unexpected error: Failed to filter files in directory /Users/shvets/repos/testrepo_worktree. Reason: ENOTDIR: not a directory, stat '/Users/shvets/repos/testrepo_worktree/.git/**'
For more help, please visit: https://github.com/yamadashy/repomix/issues
```

### Changes
- Added detection of git worktree reference files
- Modified ignore patterns to handle `.git` file instead of `.git/**` directory for worktrees
- Added tests to verify worktree handling

### Why
When using `git worktree`, developers can create multiple working trees from a single repository. This is a common workflow for working on multiple branches simultaneously. The current version of Repomix fails in these cases with an ENOTDIR error because it tries to process `.git` as a directory.
