### PR TITLE
XML Escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@
 [![codecov](https://codecov.io/github/yamadashy/repomix/graph/badge.svg)](https://codecov.io/github/yamadashy/repomix)
 
 📦 Repomix is a powerful tool that packs your entire repository into a single, AI-friendly file.  
-It is perfect for when you need to feed your codebase to Large Language Models (LLMs) or other AI tools like Claude, ChatGPT, and Gemini.
+It is perfect for when you need to feed your codebase to Large Language Models (LLMs) or other AI tools like Claude,
+ChatGPT, and Gemini.
 
 ## 🎉 New: Repomix Website & Discord Community!
 
@@ -46,12 +47,13 @@ It is perfect for when you need to feed your codebase to Large Language Models (
 - **Simple to Use**: You need just one command to pack your entire repository.
 - **Customizable**: Easily configure what to include or exclude.
 - **Git-Aware**: Automatically respects your .gitignore files.
-- **Security-Focused**: Incorporates [Secretlint](https://github.com/secretlint/secretlint) for robust security checks to detect and prevent inclusion of sensitive information.
-
-
+- **Security-Focused**: Incorporates [Secretlint](https://github.com/secretlint/secretlint) for robust security checks
+  to detect and prevent inclusion of sensitive information.
 
 ## 🚀 Quick Start
+
 ### Using the CLI Tool `>_`
+
 You can try Repomix instantly in your project directory without installation:
 
 ```bash
@@ -74,7 +76,8 @@ brew install repomix
 repomix
 ```
 
-That's it! Repomix will generate a `repomix-output.txt` file in your current directory, containing your entire repository in an AI-friendly format.
+That's it! Repomix will generate a `repomix-output.txt` file in your current directory, containing your entire
+repository in an AI-friendly format.
 
 You can then send this file to an AI assistant with a prompt like:
 
@@ -85,24 +88,31 @@ I want to refactor the code, so please review it first.
 
 ![Repomix File Usage 1](website/client/src/public/images/docs/repomix-file-usage-1.png)
 
-When you propose specific changes, the AI might be able to generate code accordingly. With features like Claude's Artifacts, you could potentially output multiple files, allowing for the generation of multiple interdependent pieces of code.
+When you propose specific changes, the AI might be able to generate code accordingly. With features like Claude's
+Artifacts, you could potentially output multiple files, allowing for the generation of multiple interdependent pieces of
+code.
 
 ![Repomix File Usage 2](website/client/src/public/images/docs/repomix-file-usage-2.png)
 
 Happy coding! 🚀
 
 ### Using The Website 🌐
-Want to try it quickly? Visit the official website at [repomix.com](https://repomix.com). Simply enter your repository name, fill in any optional details, and click the **Pack** button to see your generated output.
+
+Want to try it quickly? Visit the official website at [repomix.com](https://repomix.com). Simply enter your repository
+name, fill in any optional details, and click the **Pack** button to see your generated output.
 
 #### Available Options
+
 The website offers several convenient features:
+
 - Customizable output format (Plain Text, XML, or Markdown)
 - Instant token count estimation
 - Much more!
 
 ### Alternative Tools 🛠️
 
-If you're using Python, you might want to check out `Gitingest`, which is better suited for Python ecosystem and data science workflows:
+If you're using Python, you might want to check out `Gitingest`, which is better suited for Python ecosystem and data
+science workflows:
 https://github.com/cyclotruc/gitingest
 
 ## 📊 Usage
@@ -119,7 +129,8 @@ To pack a specific directory:
 repomix path/to/directory
 ```
 
-To pack specific files or directories using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax):
+To pack specific files or directories
+using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax):
 
 ```bash
 repomix --include "src/**/*.ts,**/*.md"
@@ -132,6 +143,7 @@ repomix --ignore "**/*.log,tmp/"
 ```
 
 To pack a remote repository:
+
 ```bash
 repomix --remote https://github.com/yamadashy/repomix
 
@@ -165,6 +177,7 @@ docker run -v .:/app -it --rm ghcr.io/yamadashy/repomix
 ```
 
 To pack a specific directory:
+
 ```bash
 docker run -v .:/app -it --rm ghcr.io/yamadashy/repomix path/to/directory
 ```
@@ -176,9 +189,12 @@ docker run -v ./output:/app -it --rm ghcr.io/yamadashy/repomix --remote https://
 ```
 
 ### Prompt Examples
-Once you have generated the packed file with Repomix, you can use it with AI tools like Claude, ChatGPT, and Gemini. Here are some example prompts to get you started:
+
+Once you have generated the packed file with Repomix, you can use it with AI tools like Claude, ChatGPT, and Gemini.
+Here are some example prompts to get you started:
 
 #### Code Review and Refactoring
+
 For a comprehensive code review and refactoring suggestions:
 
 ```
@@ -186,6 +202,7 @@ This file contains my entire codebase. Please review the overall structure and s
 ```
 
 #### Documentation Generation
+
 To generate project documentation:
 
 ```
@@ -193,6 +210,7 @@ Based on the codebase in this file, please generate a detailed README.md that in
 ```
 
 #### Test Case Generation
+
 For generating test cases:
 
 ```
@@ -200,6 +218,7 @@ Analyze the code in this file and suggest a comprehensive set of unit tests for 
 ```
 
 #### Code Quality Assessment
+
 Evaluate code quality and adherence to best practices:
 
 ```
@@ -207,6 +226,7 @@ Review the codebase for adherence to coding best practices and industry standard
 ```
 
 #### Library Overview
+
 Get a high-level understanding of the library
 
 ```
@@ -216,18 +236,22 @@ This file contains the entire codebase of library. Please provide a comprehensiv
 Feel free to modify these prompts based on your specific needs and the capabilities of the AI tool you're using.
 
 ### Community Discussion
+
 Check out our [community discussion](https://github.com/yamadashy/repomix/discussions/154) where users share:
+
 - Which AI tools they're using with Repomix
 - Effective prompts they've discovered
 - How Repomix has helped them
 - Tips and tricks for getting the most out of AI code analysis
 
-Feel free to join the discussion and share your own experiences! Your insights could help others make better use of Repomix.
+Feel free to join the discussion and share your own experiences! Your insights could help others make better use of
+Repomix.
 
 ### Output File Format
 
 Repomix generates a single file with clear separators between different parts of your codebase.  
-To enhance AI comprehension, the output file begins with an AI-oriented explanation, making it easier for AI models to understand the context and structure of the packed repository.
+To enhance AI comprehension, the output file begins with an AI-oriented explanation, making it easier for AI models to
+understand the context and structure of the packed repository.
 
 #### Plain Text Format (default)
 
@@ -276,6 +300,7 @@ Instruction
 #### XML Format
 
 To generate output in XML format, use the `--style xml` option:
+
 ```bash
 repomix --style xml
 ```
@@ -286,21 +311,21 @@ The XML format structures the content in a hierarchical manner:
 This file is a merged representation of the entire codebase, combining all repository files into a single document.
 
 <file_summary>
-(Metadata and usage AI instructions)
+  (Metadata and usage AI instructions)
 </file_summary>
 
 <directory_structure>
 src/
-  cli/
-    cliOutput.ts
-    index.ts
+cli/
+cliOutput.ts
+index.ts
 
 (...remaining directories)
 </directory_structure>
 
 <files>
 <file path="src/index.js">
-// File contents here
+  // File contents here
 </file>
 
 (...remaining files)
@@ -314,13 +339,16 @@ src/
 For those interested in the potential of XML tags in AI contexts:  
 https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/use-xml-tags
 
-> When your prompts involve multiple components like context, instructions, and examples, XML tags can be a game-changer. They help Claude parse your prompts more accurately, leading to higher-quality outputs.
+> When your prompts involve multiple components like context, instructions, and examples, XML tags can be a
+> game-changer. They help Claude parse your prompts more accurately, leading to higher-quality outputs.
 
-This means that the XML output from Repomix is not just a different format, but potentially a more effective way to feed your codebase into AI systems for analysis, code review, or other tasks.
+This means that the XML output from Repomix is not just a different format, but potentially a more effective way to feed
+your codebase into AI systems for analysis, code review, or other tasks.
 
 #### Markdown Format
 
 To generate output in Markdown format, use the `--style markdown` option:
+
 ```bash
 repomix --style markdown
 ```
@@ -331,20 +359,24 @@ The Markdown format structures the content in a hierarchical manner:
 This file is a merged representation of the entire codebase, combining all repository files into a single document.
 
 # File Summary
+
 (Metadata and usage AI instructions)
 
 # Repository Structure
+
 ```
 src/
   cli/
     cliOutput.ts
     index.ts
 ```
+
 (...remaining directories)
 
 # Repository Files
 
 ## File: src/index.js
+
 ```
 // File contents here
 ```
@@ -352,6 +384,7 @@ src/
 (...remaining files)
 
 # Instruction
+
 (Custom instructions from `output.instructionFilePath`)
 ````
 
@@ -379,6 +412,7 @@ This format provides a clean, readable structure that is both human-friendly and
 - `--verbose`: Enable verbose logging
 
 Examples:
+
 ```bash
 repomix -o custom-output.txt
 repomix -i "*.log,tmp" -v
@@ -402,10 +436,10 @@ yarn global upgrade repomix
 
 Using `npx repomix` is generally more convenient as it always uses the latest version.
 
-
 ### Remote Repository Processing
 
-Repomix supports processing remote Git repositories without the need for manual cloning. This feature allows you to quickly analyze any public Git repository with a single command.
+Repomix supports processing remote Git repositories without the need for manual cloning. This feature allows you to
+quickly analyze any public Git repository with a single command.
 
 To process a remote repository, use the `--remote` option followed by the repository URL:
 
@@ -426,6 +460,7 @@ repomix --remote https://github.com/yamadashy/repomix --remote-branch main
 ```
 
 Or use a specific commit hash:
+
 ```bash
 repomix --remote https://github.com/yamadashy/repomix --remote-branch 935b695
 ```
@@ -433,32 +468,34 @@ repomix --remote https://github.com/yamadashy/repomix --remote-branch 935b695
 ## ⚙️ Configuration
 
 Create a `repomix.config.json` file in your project root for custom configurations.
+
 ```bash
 repomix --init
 ```
 
 Here's an explanation of the configuration options:
 
-| Option | Description | Default |
-|--------|-------------|---------|
-|`output.filePath`| The name of the output file | `"repomix-output.txt"` |
-|`output.style`| The style of the output (`plain`, `xml`, `markdown`) |`"plain"`|
-|`output.headerText`| Custom text to include in the file header |`null`|
-|`output.instructionFilePath`| Path to a file containing detailed custom instructions |`null`|
-|`output.fileSummary`| Whether to include a summary section at the beginning of the output |`true`|
-|`output.directoryStructure`| Whether to include the directory structure in the output |`true`|
-|`output.removeComments`| Whether to remove comments from supported file types | `false` |
-|`output.removeEmptyLines`| Whether to remove empty lines from the output | `false` |
-|`output.showLineNumbers`| Whether to add line numbers to each line in the output |`false`|
-|`output.copyToClipboard`| Whether to copy the output to system clipboard in addition to saving the file |`false`|
-|`output.topFilesLength`| Number of top files to display in the summary. If set to 0, no summary will be displayed |`5`|
-|`output.includeEmptyDirectories`| Whether to include empty directories in the repository structure |`false`|
-|`include`| Patterns of files to include (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) |`[]`|
-|`ignore.useGitignore`| Whether to use patterns from the project's `.gitignore` file |`true`|
-|`ignore.useDefaultPatterns`| Whether to use default ignore patterns |`true`|
-|`ignore.customPatterns`| Additional patterns to ignore (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) |`[]`|
-|`security.enableSecurityCheck`| Whether to perform security checks on files |`true`|
-|`tokenCount.encoding`| Token count encoding for AI model context limits (e.g., `o200k_base`, `cl100k_base`) |`"o200k_base"`|
+| Option                           | Description                                                                                                                  | Default                |
+|----------------------------------|------------------------------------------------------------------------------------------------------------------------------|------------------------|
+| `output.filePath`                | The name of the output file                                                                                                  | `"repomix-output.txt"` |
+| `output.style`                   | The style of the output (`plain`, `xml`, `markdown`)                                                                         | `"plain"`              |
+| `output.parsableStyle`           | Whether to escape the output based on the chosen style schema. Note that this can increase token count.                      | `false`                |
+| `output.headerText`              | Custom text to include in the file header                                                                                    | `null`                 |
+| `output.instructionFilePath`     | Path to a file containing detailed custom instructions                                                                       | `null`                 |
+| `output.fileSummary`             | Whether to include a summary section at the beginning of the output                                                          | `true`                 |
+| `output.directoryStructure`      | Whether to include the directory structure in the output                                                                     | `true`                 |
+| `output.removeComments`          | Whether to remove comments from supported file types                                                                         | `false`                |
+| `output.removeEmptyLines`        | Whether to remove empty lines from the output                                                                                | `false`                |
+| `output.showLineNumbers`         | Whether to add line numbers to each line in the output                                                                       | `false`                |
+| `output.copyToClipboard`         | Whether to copy the output to system clipboard in addition to saving the file                                                | `false`                |
+| `output.topFilesLength`          | Number of top files to display in the summary. If set to 0, no summary will be displayed                                     | `5`                    |
+| `output.includeEmptyDirectories` | Whether to include empty directories in the repository structure                                                             | `false`                |
+| `include`                        | Patterns of files to include (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax))  | `[]`                   |
+| `ignore.useGitignore`            | Whether to use patterns from the project's `.gitignore` file                                                                 | `true`                 |
+| `ignore.useDefaultPatterns`      | Whether to use default ignore patterns                                                                                       | `true`                 |
+| `ignore.customPatterns`          | Additional patterns to ignore (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
+| `security.enableSecurityCheck`   | Whether to perform security checks on files                                                                                  | `true`                 |
+| `tokenCount.encoding`            | Token count encoding for AI model context limits (e.g., `o200k_base`, `cl100k_base`)                                         | `"o200k_base"`         |
 
 Example configuration:
 
@@ -467,6 +504,7 @@ Example configuration:
   "output": {
     "filePath": "repomix-output.xml",
     "style": "xml",
+    "parsableStyle": true,
     "headerText": "Custom header information for the packed file.",
     "fileSummary": true,
     "directoryStructure": true,
@@ -477,12 +515,17 @@ Example configuration:
     "topFilesLength": 5,
     "includeEmptyDirectories": false
   },
-  "include": ["**/*"],
+  "include": [
+    "**/*"
+  ],
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,
     // Patterns can also be specified in .repomixignore
-    "customPatterns": ["additional-folder", "**/*.log"]
+    "customPatterns": [
+      "additional-folder",
+      "**/*.log"
+    ]
   },
   "security": {
     "enableSecurityCheck": true
@@ -494,6 +537,7 @@ Example configuration:
 ```
 
 ### Global Configuration
+
 To create a global configuration file:
 
 ```bash
@@ -501,40 +545,60 @@ repomix --init --global
 ```
 
 The global configuration file will be created in:
+
 - Windows: `%LOCALAPPDATA%\Repomix\repomix.config.json`
 - macOS/Linux: `$XDG_CONFIG_HOME/repomix/repomix.config.json` or `~/.config/repomix/repomix.config.json`
 
 Note: Local configuration (if present) takes precedence over global configuration.
 
 ### Include and Ignore
+
 #### Include Patterns
-Repomix now supports specifying files to include using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax). This allows for more flexible and powerful file selection:
+
+Repomix now supports specifying files to include
+using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax). This allows for more
+flexible and powerful file selection:
 
 - Use `**/*.js` to include all JavaScript files in any directory
 - Use `src/**/*` to include all files within the `src` directory and its subdirectories
-- Combine multiple patterns like `["src/**/*.js", "**/*.md"]` to include JavaScript files in `src` and all Markdown files
+- Combine multiple patterns like `["src/**/*.js", "**/*.md"]` to include JavaScript files in `src` and all Markdown
+  files
 
 #### Ignore Patterns
-Repomix offers multiple methods to set ignore patterns for excluding specific files or directories during the packing process:
 
-- **.gitignore**: By default, patterns listed in your project's `.gitignore` file are used. This behavior can be controlled with the `ignore.useGitignore` setting.
-- **Default patterns**: Repomix includes a default list of commonly excluded files and directories (e.g., node_modules, .git, binary files). This feature can be controlled with the `ignore.useDefaultPatterns` setting. Please see [defaultIgnore.ts](src/config/defaultIgnore.ts) for more details.
-- **.repomixignore**: You can create a `.repomixignore` file in your project root to define Repomix-specific ignore patterns. This file follows the same format as `.gitignore`.
-- **Custom patterns**: Additional ignore patterns can be specified using the `ignore.customPatterns` option in the configuration file. You can overwrite this setting with the `-i, --ignore` command line option.
+Repomix offers multiple methods to set ignore patterns for excluding specific files or directories during the packing
+process:
+
+- **.gitignore**: By default, patterns listed in your project's `.gitignore` file are used. This behavior can be
+  controlled with the `ignore.useGitignore` setting.
+- **Default patterns**: Repomix includes a default list of commonly excluded files and directories (e.g., node_modules,
+  .git, binary files). This feature can be controlled with the `ignore.useDefaultPatterns` setting. Please
+  see [defaultIgnore.ts](src/config/defaultIgnore.ts) for more details.
+- **.repomixignore**: You can create a `.repomixignore` file in your project root to define Repomix-specific ignore
+  patterns. This file follows the same format as `.gitignore`.
+- **Custom patterns**: Additional ignore patterns can be specified using the `ignore.customPatterns` option in the
+  configuration file. You can overwrite this setting with the `-i, --ignore` command line option.
 
 Priority Order (from highest to lowest):
+
 1. Custom patterns `ignore.customPatterns`
 2. `.repomixignore`
 3. `.gitignore` (if `ignore.useGitignore` is true)
 4. Default patterns (if `ignore.useDefaultPatterns` is true)
 
-This approach allows for flexible file exclusion configuration based on your project's needs. It helps optimize the size of the generated pack file by ensuring the exclusion of security-sensitive files and large binary files, while preventing the leakage of confidential information.
+This approach allows for flexible file exclusion configuration based on your project's needs. It helps optimize the size
+of the generated pack file by ensuring the exclusion of security-sensitive files and large binary files, while
+preventing the leakage of confidential information.
 
-Note: Binary files are not included in the packed output by default, but their paths are listed in the "Repository Structure" section of the output file. This provides a complete overview of the repository structure while keeping the packed file efficient and text-based.
+Note: Binary files are not included in the packed output by default, but their paths are listed in the "Repository
+Structure" section of the output file. This provides a complete overview of the repository structure while keeping the
+packed file efficient and text-based.
 
 ### Custom Instruction
 
-The `output.instructionFilePath` option allows you to specify a separate file containing detailed instructions or context about your project. This allows AI systems to understand the specific context and requirements of your project, potentially leading to more relevant and tailored analysis or suggestions.
+The `output.instructionFilePath` option allows you to specify a separate file containing detailed instructions or
+context about your project. This allows AI systems to understand the specific context and requirements of your project,
+potentially leading to more relevant and tailored analysis or suggestions.
 
 Here's an example of how you might use this feature:
 
@@ -542,12 +606,14 @@ Here's an example of how you might use this feature:
 
 ```markdown
 # Coding Guidelines
+
 - Follow the Airbnb JavaScript Style Guide
 - Suggest splitting files into smaller, focused units when appropriate
 - Add comments for non-obvious logic. Keep all text in English
 - All new features should have corresponding unit tests
 
 # Generate Comprehensive Output
+
 - Include all content without abbreviation, unless specified otherwise
 - Optimize for handling large codebases while maintaining output quality
 ```
@@ -565,28 +631,35 @@ Here's an example of how you might use this feature:
 
 When Repomix generates the output, it will include the contents of `repomix-instruction.md` in a dedicated section.
 
-Note: The instruction content is appended at the end of the output file. This placement can be particularly effective for AI systems. For those interested in understanding why this might be beneficial, Anthropic provides some insights in their documentation:  
+Note: The instruction content is appended at the end of the output file. This placement can be particularly effective
+for AI systems. For those interested in understanding why this might be beneficial, Anthropic provides some insights in
+their documentation:  
 https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/long-context-tips
 
-> Put long-form data at the top: Place your long documents and inputs (~20K+ tokens) near the top of your prompt, above your query, instructions, and examples. This can significantly improve Claude's performance across all models.
+> Put long-form data at the top: Place your long documents and inputs (~20K+ tokens) near the top of your prompt, above
+> your query, instructions, and examples. This can significantly improve Claude's performance across all models.
 > Queries at the end can improve response quality by up to 30% in tests, especially with complex, multi-document inputs.
 
 ### Comment Removal
 
-When `output.removeComments` is set to `true`, Repomix will attempt to remove comments from supported file types. This feature can help reduce the size of the output file and focus on the essential code content.
+When `output.removeComments` is set to `true`, Repomix will attempt to remove comments from supported file types. This
+feature can help reduce the size of the output file and focus on the essential code content.
 
 Supported languages include:  
-HTML, CSS, JavaScript, TypeScript, Vue, Svelte, Python, PHP, Ruby, C, C#, Java, Go, Rust, Swift, Kotlin, Dart, Shell, and YAML.
+HTML, CSS, JavaScript, TypeScript, Vue, Svelte, Python, PHP, Ruby, C, C#, Java, Go, Rust, Swift, Kotlin, Dart, Shell,
+and YAML.
 
-Note: The comment removal process is conservative to avoid accidentally removing code. In complex cases, some comments might be retained.
-
-
+Note: The comment removal process is conservative to avoid accidentally removing code. In complex cases, some comments
+might be retained.
 
 ## 🔍 Security Check
 
-Repomix includes a security check feature that uses [Secretlint](https://github.com/secretlint/secretlint) to detect potentially sensitive information in your files. This feature helps you identify possible security risks before sharing your packed repository.
+Repomix includes a security check feature that uses [Secretlint](https://github.com/secretlint/secretlint) to detect
+potentially sensitive information in your files. This feature helps you identify possible security risks before sharing
+your packed repository.
 
-The security check results will be displayed in the CLI output after the packing process is complete. If any suspicious files are detected, you'll see a list of these files along with a warning message.
+The security check results will be displayed in the CLI output after the packing process is complete. If any suspicious
+files are detected, you'll see a list of these files along with a warning message.
 
 Example output:
 
@@ -600,7 +673,8 @@ Example output:
 Please review these files for potentially sensitive information.
 ```
 
-By default, Repomix's security check feature is enabled. You can disable it by setting `security.enableSecurityCheck` to `false` in your configuration file:
+By default, Repomix's security check feature is enabled. You can disable it by setting `security.enableSecurityCheck` to
+`false` in your configuration file:
 
 ```json
 {
@@ -617,9 +691,8 @@ repomix --no-security-check
 ```
 
 > [!NOTE]
-> Disabling security checks may expose sensitive information. Use this option with caution and only when necessary, such as when working with test files or documentation that contains example credentials.
-
-
+> Disabling security checks may expose sensitive information. Use this option with caution and only when necessary, such
+> as when working with test files or documentation that contains example credentials.
 
 ## 🤝 Contribution
 

--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ This format provides a clean, readable structure that is both human-friendly and
 - `-i, --ignore <patterns>`: Additional ignore patterns (comma-separated)
 - `-c, --config <path>`: Path to a custom config file
 - `--style <style>`: Specify the output style (`plain`, `xml`, `markdown`)
+- `--parsable-style`: Enable parsable output based on the chosen style schema. Note that this can increase token count.
 - `--no-file-summary`: Disable file summary section output
 - `--no-directory-structure`: Disable directory structure section output
 - `--remove-comments`: Remove comments from supported file types

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "cli-spinners": "^2.9.2",
         "clipboardy": "^4.0.0",
         "commander": "^13.0.0",
+        "fast-xml-parser": "^4.5.1",
         "globby": "^14.0.2",
         "handlebars": "^4.7.8",
         "iconv-lite": "^0.6.3",
@@ -2134,6 +2135,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.1.tgz",
+      "integrity": "sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -3656,6 +3679,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "license": "MIT"
     },
     "node_modules/structured-source": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "cli-spinners": "^2.9.2",
     "clipboardy": "^4.0.0",
     "commander": "^13.0.0",
+    "fast-xml-parser": "^4.5.1",
     "globby": "^14.0.2",
     "handlebars": "^4.7.8",
     "iconv-lite": "^0.6.3",

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -112,6 +112,9 @@ const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
   if (options.style) {
     cliConfig.output = { ...cliConfig.output, style: options.style.toLowerCase() as RepomixOutputStyle };
   }
+  if (options.parsableStyle !== undefined) {
+    cliConfig.output = { ...cliConfig.output, parsableStyle: options.parsableStyle };
+  }
   if (options.securityCheck !== undefined) {
     cliConfig.security = { enableSecurityCheck: options.securityCheck };
   }

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -21,6 +21,7 @@ export interface CliOptions extends OptionValues {
   topFilesLen?: number;
   outputShowLineNumbers?: boolean;
   style?: RepomixOutputStyle;
+  parsableStyle?: boolean;
   init?: boolean;
   global?: boolean;
   remote?: string;
@@ -47,6 +48,7 @@ export const run = async () => {
       .option('--top-files-len <number>', 'specify the number of top files to display', Number.parseInt)
       .option('--output-show-line-numbers', 'add line numbers to each line in the output')
       .option('--style <type>', 'specify the output style (plain, xml, markdown)')
+      .option('--parsableStyle', 'by escaping and formatting, ensure the output is parsable as a document of its type')
       .option('--no-file-summary', 'disable file summary section output')
       .option('--no-directory-structure', 'disable directory structure section output')
       .option('--remove-comments', 'remove comments')

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -48,7 +48,7 @@ export const run = async () => {
       .option('--top-files-len <number>', 'specify the number of top files to display', Number.parseInt)
       .option('--output-show-line-numbers', 'add line numbers to each line in the output')
       .option('--style <type>', 'specify the output style (plain, xml, markdown)')
-      .option('--parsableStyle', 'by escaping and formatting, ensure the output is parsable as a document of its type')
+      .option('--parsable-style', 'by escaping and formatting, ensure the output is parsable as a document of its type')
       .option('--no-file-summary', 'disable file summary section output')
       .option('--no-directory-structure', 'disable directory structure section output')
       .option('--remove-comments', 'remove comments')

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -18,6 +18,7 @@ export const repomixConfigBaseSchema = z.object({
     .object({
       filePath: z.string().optional(),
       style: repomixOutputStyleSchema.optional(),
+      parsableStyle: z.boolean().optional(),
       headerText: z.string().optional(),
       instructionFilePath: z.string().optional(),
       fileSummary: z.boolean().optional(),

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -56,6 +56,7 @@ export const repomixConfigDefaultSchema = z.object({
     .object({
       filePath: z.string().default(defaultFilePathMap.plain),
       style: repomixOutputStyleSchema.default('plain'),
+      parsableStyle: z.boolean().default(false),
       headerText: z.string().optional(),
       instructionFilePath: z.string().optional(),
       fileSummary: z.boolean().default(true),

--- a/src/core/output/outputGenerate.ts
+++ b/src/core/output/outputGenerate.ts
@@ -1,13 +1,13 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { XMLBuilder } from 'fast-xml-parser';
+import {XMLBuilder} from 'fast-xml-parser';
 import Handlebars from 'handlebars';
-import type { RepomixConfigMerged } from '../../config/configSchema.js';
-import { RepomixError } from '../../shared/errorHandle.js';
-import { searchFiles } from '../file/fileSearch.js';
-import { generateTreeString } from '../file/fileTreeGenerate.js';
-import type { ProcessedFile } from '../file/fileTypes.js';
-import type { OutputGeneratorContext } from './outputGeneratorTypes.js';
+import type {RepomixConfigMerged} from '../../config/configSchema.js';
+import {RepomixError} from '../../shared/errorHandle.js';
+import {searchFiles} from '../file/fileSearch.js';
+import {generateTreeString} from '../file/fileTreeGenerate.js';
+import type {ProcessedFile} from '../file/fileTypes.js';
+import type {OutputGeneratorContext} from './outputGeneratorTypes.js';
 import {
   generateHeader,
   generateSummaryFileFormat,
@@ -15,9 +15,9 @@ import {
   generateSummaryPurpose,
   generateSummaryUsageGuidelines,
 } from './outputStyleDecorate.js';
-import { getMarkdownTemplate } from './outputStyles/markdownStyle.js';
-import { getPlainTemplate } from './outputStyles/plainStyle.js';
-import { getXmlTemplate } from './outputStyles/xmlStyle.js';
+import {getMarkdownTemplate} from './outputStyles/markdownStyle.js';
+import {getPlainTemplate} from './outputStyles/plainStyle.js';
+import {getXmlTemplate} from './outputStyles/xmlStyle.js';
 
 interface RenderContext {
   readonly generationHeader: string;
@@ -34,6 +34,14 @@ interface RenderContext {
   readonly escapeFileContent: boolean;
   readonly markdownCodeBlockDelimiter: string;
 }
+
+const calculateMarkdownDelimiter = (files: ReadonlyArray<ProcessedFile>): string => {
+  const maxBackticks = files
+    .flatMap(file => file.content.match(/`*/g) ?? [])
+    .reduce((max, match) => Math.max(max, match.length), 0);
+  return '`'.repeat(Math.max(3, maxBackticks + 1));
+};
+
 
 const createRenderContext = (outputGeneratorContext: OutputGeneratorContext): RenderContext => {
   return {
@@ -52,43 +60,29 @@ const createRenderContext = (outputGeneratorContext: OutputGeneratorContext): Re
     fileSummaryEnabled: outputGeneratorContext.config.output.fileSummary,
     directoryStructureEnabled: outputGeneratorContext.config.output.directoryStructure,
     escapeFileContent: outputGeneratorContext.config.output.parsableStyle,
-    markdownCodeBlockDelimiter: '`'.repeat(
-      Math.max(
-        3,
-        1 +
-          outputGeneratorContext.processedFiles
-            .map(
-              (file) =>
-                file.content
-                  .match(/`*/g)
-                  ?.map((s) => s.length)
-                  .reduce((acc, l) => (l > acc ? l : acc), 0) ?? 0,
-            )
-            .reduce((acc, l) => (l > acc ? l : acc), 0),
-      ),
-    ),
+    markdownCodeBlockDelimiter: calculateMarkdownDelimiter(outputGeneratorContext.processedFiles),
   };
 };
 
 const generateParsableXmlOutput = async (renderContext: RenderContext): Promise<string> => {
-  const xmlBuilder = new XMLBuilder({ ignoreAttributes: false });
+  const xmlBuilder = new XMLBuilder({ignoreAttributes: false});
   const xmlDocument = {
     repomix: {
       '#text': renderContext.generationHeader,
       file_summary: renderContext.fileSummaryEnabled
         ? {
-            '#text': 'This section contains a summary of this file.',
-            purpose: renderContext.summaryPurpose,
-            file_format: `${renderContext.summaryFileFormat}
+          '#text': 'This section contains a summary of this file.',
+          purpose: renderContext.summaryPurpose,
+          file_format: `${renderContext.summaryFileFormat}
 4. Repository files, each consisting of:
   - File path as an attribute
   - Full contents of the file`,
-            usage_guidelines: renderContext.summaryUsageGuidelines,
-            notes: renderContext.summaryNotes,
-            additional_info: {
-              user_provided_header: renderContext.headerText,
-            },
-          }
+          usage_guidelines: renderContext.summaryUsageGuidelines,
+          notes: renderContext.summaryNotes,
+          additional_info: {
+            user_provided_header: renderContext.headerText,
+          },
+        }
         : undefined,
       directory_structure: renderContext.directoryStructureEnabled ? renderContext.treeString : undefined,
       files: {
@@ -101,7 +95,11 @@ const generateParsableXmlOutput = async (renderContext: RenderContext): Promise<
       instruction: renderContext.instruction ? renderContext.instruction : undefined,
     },
   };
-  return xmlBuilder.build(xmlDocument);
+  try {
+    return xmlBuilder.build(xmlDocument);
+  } catch (error) {
+    throw new RepomixError(`Failed to generate XML output: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
 };
 
 const generateHandlebarOutput = async (config: RepomixConfigMerged, renderContext: RenderContext): Promise<string> => {

--- a/src/core/output/outputGenerate.ts
+++ b/src/core/output/outputGenerate.ts
@@ -1,12 +1,12 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import Handlebars from 'handlebars';
-import type { RepomixConfigMerged } from '../../config/configSchema.js';
-import { RepomixError } from '../../shared/errorHandle.js';
-import { searchFiles } from '../file/fileSearch.js';
-import { generateTreeString } from '../file/fileTreeGenerate.js';
-import type { ProcessedFile } from '../file/fileTypes.js';
-import type { OutputGeneratorContext } from './outputGeneratorTypes.js';
+import type {RepomixConfigMerged} from '../../config/configSchema.js';
+import {RepomixError} from '../../shared/errorHandle.js';
+import {searchFiles} from '../file/fileSearch.js';
+import {generateTreeString} from '../file/fileTreeGenerate.js';
+import type {ProcessedFile} from '../file/fileTypes.js';
+import type {OutputGeneratorContext} from './outputGeneratorTypes.js';
 import {
   generateHeader,
   generateSummaryFileFormat,
@@ -14,11 +14,26 @@ import {
   generateSummaryPurpose,
   generateSummaryUsageGuidelines,
 } from './outputStyleDecorate.js';
-import { getMarkdownTemplate } from './outputStyles/markdownStyle.js';
-import { getPlainTemplate } from './outputStyles/plainStyle.js';
-import { getXmlTemplate } from './outputStyles/xmlStyle.js';
+import {getMarkdownTemplate} from './outputStyles/markdownStyle.js';
+import {getPlainTemplate} from './outputStyles/plainStyle.js';
+import {getXmlTemplate} from './outputStyles/xmlStyle.js';
+import {XMLBuilder} from "fast-xml-parser";
 
-const createRenderContext = (outputGeneratorContext: OutputGeneratorContext) => {
+interface RenderContext {
+  readonly generationHeader: string,
+  readonly summaryPurpose: string,
+  readonly summaryFileFormat: string,
+  readonly summaryUsageGuidelines: string,
+  readonly summaryNotes: string,
+  readonly headerText: string | undefined,
+  readonly instruction: string,
+  readonly treeString: string,
+  readonly processedFiles: ReadonlyArray<ProcessedFile>,
+  readonly fileSummaryEnabled: boolean,
+  readonly directoryStructureEnabled: boolean,
+}
+
+const createRenderContext = (outputGeneratorContext: OutputGeneratorContext): RenderContext => {
   return {
     generationHeader: generateHeader(outputGeneratorContext.generationDate),
     summaryPurpose: generateSummaryPurpose(),
@@ -37,15 +52,50 @@ const createRenderContext = (outputGeneratorContext: OutputGeneratorContext) => 
   };
 };
 
-export const generateOutput = async (
-  rootDir: string,
+const generateParsableXmlOutput = async (
   config: RepomixConfigMerged,
-  processedFiles: ProcessedFile[],
-  allFilePaths: string[],
+  renderContext: RenderContext,
 ): Promise<string> => {
-  const outputGeneratorContext = await buildOutputGeneratorContext(rootDir, config, allFilePaths, processedFiles);
-  const renderContext = createRenderContext(outputGeneratorContext);
+  const xmlBuilder = new XMLBuilder({ignoreAttributes: false})
+  const xmlDocument = {
+    repomix: {
+      '#text': renderContext.generationHeader,
+      file_summary: renderContext.fileSummaryEnabled ? {
+        '#text': "This section contains a summary of this file.",
+        purpose: renderContext.summaryPurpose,
+        file_format: `${renderContext.summaryFileFormat}
+4. Repository files, each consisting of:
+  - File path as an attribute
+  - Full contents of the file`,
+        usage_guidelines: renderContext.summaryUsageGuidelines,
+        notes: renderContext.summaryNotes,
+        additional_info: {
+          user_provided_header: renderContext.headerText,
+        }
+      } : undefined,
+      directory_structure: renderContext.directoryStructureEnabled ?
+        renderContext.treeString : undefined,
+      files: {
+        '#text': "This section contains the contents of the repository's files.",
+        file: renderContext.processedFiles.map((file) => ({
+          '#text': file.content, '@_path': file.path
+        })),
+      },
+      instruction: renderContext.instruction ? renderContext.instruction : undefined,
+    }
+  }
+  return xmlBuilder.build(xmlDocument)
+}
 
+const generateParsableMarkdownOutput = async (): Promise<string> => {
+  // TODO
+  throw "TODO"
+}
+
+const generateHandlebarOutput = async (
+  config: RepomixConfigMerged,
+  renderContext: RenderContext,
+): Promise<string> => {
   let template: string;
   switch (config.output.style) {
     case 'xml':
@@ -60,6 +110,29 @@ export const generateOutput = async (
 
   const compiledTemplate = Handlebars.compile(template);
   return `${compiledTemplate(renderContext).trim()}\n`;
+}
+
+export const generateOutput = async (
+  rootDir: string,
+  config: RepomixConfigMerged,
+  processedFiles: ProcessedFile[],
+  allFilePaths: string[],
+): Promise<string> => {
+  const outputGeneratorContext = await buildOutputGeneratorContext(rootDir, config, allFilePaths, processedFiles);
+  const renderContext = createRenderContext(outputGeneratorContext);
+
+  if (!config.output.parsableStyle || config.output.style == "plain") {
+    return generateHandlebarOutput(config, renderContext)
+  } else {
+    switch (config.output.style) {
+      case 'xml':
+        return generateParsableXmlOutput(config, renderContext)
+      case 'markdown':
+        return generateParsableMarkdownOutput()
+      default:
+        return generateHandlebarOutput(config, renderContext)
+    }
+  }
 };
 
 export const buildOutputGeneratorContext = async (

--- a/src/core/output/outputGenerate.ts
+++ b/src/core/output/outputGenerate.ts
@@ -1,13 +1,13 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import {XMLBuilder} from 'fast-xml-parser';
+import { XMLBuilder } from 'fast-xml-parser';
 import Handlebars from 'handlebars';
-import type {RepomixConfigMerged} from '../../config/configSchema.js';
-import {RepomixError} from '../../shared/errorHandle.js';
-import {searchFiles} from '../file/fileSearch.js';
-import {generateTreeString} from '../file/fileTreeGenerate.js';
-import type {ProcessedFile} from '../file/fileTypes.js';
-import type {OutputGeneratorContext} from './outputGeneratorTypes.js';
+import type { RepomixConfigMerged } from '../../config/configSchema.js';
+import { RepomixError } from '../../shared/errorHandle.js';
+import { searchFiles } from '../file/fileSearch.js';
+import { generateTreeString } from '../file/fileTreeGenerate.js';
+import type { ProcessedFile } from '../file/fileTypes.js';
+import type { OutputGeneratorContext } from './outputGeneratorTypes.js';
 import {
   generateHeader,
   generateSummaryFileFormat,
@@ -15,9 +15,9 @@ import {
   generateSummaryPurpose,
   generateSummaryUsageGuidelines,
 } from './outputStyleDecorate.js';
-import {getMarkdownTemplate} from './outputStyles/markdownStyle.js';
-import {getPlainTemplate} from './outputStyles/plainStyle.js';
-import {getXmlTemplate} from './outputStyles/xmlStyle.js';
+import { getMarkdownTemplate } from './outputStyles/markdownStyle.js';
+import { getPlainTemplate } from './outputStyles/plainStyle.js';
+import { getXmlTemplate } from './outputStyles/xmlStyle.js';
 
 interface RenderContext {
   readonly generationHeader: string;
@@ -37,11 +37,10 @@ interface RenderContext {
 
 const calculateMarkdownDelimiter = (files: ReadonlyArray<ProcessedFile>): string => {
   const maxBackticks = files
-    .flatMap(file => file.content.match(/`*/g) ?? [])
+    .flatMap((file) => file.content.match(/`*/g) ?? [])
     .reduce((max, match) => Math.max(max, match.length), 0);
   return '`'.repeat(Math.max(3, maxBackticks + 1));
 };
-
 
 const createRenderContext = (outputGeneratorContext: OutputGeneratorContext): RenderContext => {
   return {
@@ -65,24 +64,24 @@ const createRenderContext = (outputGeneratorContext: OutputGeneratorContext): Re
 };
 
 const generateParsableXmlOutput = async (renderContext: RenderContext): Promise<string> => {
-  const xmlBuilder = new XMLBuilder({ignoreAttributes: false});
+  const xmlBuilder = new XMLBuilder({ ignoreAttributes: false });
   const xmlDocument = {
     repomix: {
       '#text': renderContext.generationHeader,
       file_summary: renderContext.fileSummaryEnabled
         ? {
-          '#text': 'This section contains a summary of this file.',
-          purpose: renderContext.summaryPurpose,
-          file_format: `${renderContext.summaryFileFormat}
+            '#text': 'This section contains a summary of this file.',
+            purpose: renderContext.summaryPurpose,
+            file_format: `${renderContext.summaryFileFormat}
 4. Repository files, each consisting of:
   - File path as an attribute
   - Full contents of the file`,
-          usage_guidelines: renderContext.summaryUsageGuidelines,
-          notes: renderContext.summaryNotes,
-          additional_info: {
-            user_provided_header: renderContext.headerText,
-          },
-        }
+            usage_guidelines: renderContext.summaryUsageGuidelines,
+            notes: renderContext.summaryNotes,
+            additional_info: {
+              user_provided_header: renderContext.headerText,
+            },
+          }
         : undefined,
       directory_structure: renderContext.directoryStructureEnabled ? renderContext.treeString : undefined,
       files: {
@@ -98,7 +97,9 @@ const generateParsableXmlOutput = async (renderContext: RenderContext): Promise<
   try {
     return xmlBuilder.build(xmlDocument);
   } catch (error) {
-    throw new RepomixError(`Failed to generate XML output: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    throw new RepomixError(
+      `Failed to generate XML output: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    );
   }
 };
 

--- a/src/core/output/outputStyles/markdownStyle.ts
+++ b/src/core/output/outputStyles/markdownStyle.ts
@@ -40,9 +40,9 @@ export const getMarkdownTemplate = () => {
 
 {{#each processedFiles}}
 ## File: {{{this.path}}}
-\`\`\`{{{getFileExtension this.path}}}
+{{{../markdownCodeBlockDelimiter}}}{{{getFileExtension this.path}}}
 {{{this.content}}}
-\`\`\`
+{{{../markdownCodeBlockDelimiter}}}
 
 {{/each}}
 

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -21,6 +21,7 @@ describe('defaultAction', () => {
       output: {
         filePath: 'output.txt',
         style: 'plain',
+        parsableStyle: false,
         fileSummary: true,
         directoryStructure: true,
         topFilesLength: 5,

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -130,6 +130,44 @@ describe('defaultAction', () => {
     await expect(runDefaultAction('.', process.cwd(), options)).rejects.toThrow('Test error');
   });
 
+  describe('parsableStyle flag', () => {
+    it('should handle --parsable-style flag', async () => {
+      const options: CliOptions = {
+        parsableStyle: true,
+      };
+
+      await runDefaultAction('.', process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
+        expect.objectContaining({
+          output: {
+            parsableStyle: true,
+          },
+        }),
+      );
+    });
+
+    it('should handle explicit --no-parsable-style flag', async () => {
+      const options: CliOptions = {
+        parsableStyle: false,
+      };
+
+      await runDefaultAction('.', process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
+        expect.objectContaining({
+          output: {
+            parsableStyle: false,
+          },
+        }),
+      );
+    });
+  });
+
   describe('security check flag', () => {
     it('should handle --no-security-check flag', async () => {
       const options: CliOptions = {

--- a/tests/cli/cliRun.test.ts
+++ b/tests/cli/cliRun.test.ts
@@ -158,6 +158,32 @@ describe('cliRun', () => {
     });
   });
 
+  describe('parsable style flag', () => {
+    test('should disable parsable style by default', async () => {
+      await executeAction('.', process.cwd(), {});
+
+      expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
+        '.',
+        process.cwd(),
+        expect.not.objectContaining({
+          parsableStyle: false,
+        }),
+      );
+    });
+
+    test('should handle --parsable-style flag', async () => {
+      await executeAction('.', process.cwd(), { parsableStyle: true });
+
+      expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
+        '.',
+        process.cwd(),
+        expect.objectContaining({
+          parsableStyle: true,
+        }),
+      );
+    });
+  });
+
   describe('security check flag', () => {
     test('should enable security check by default', async () => {
       await executeAction('.', process.cwd(), {});

--- a/tests/cli/cliRun.test.ts
+++ b/tests/cli/cliRun.test.ts
@@ -47,6 +47,7 @@ describe('cliRun', () => {
         output: {
           filePath: 'repomix-output.txt',
           style: 'plain',
+          parsableStyle: false,
           fileSummary: true,
           directoryStructure: true,
           topFilesLength: 5,
@@ -84,6 +85,7 @@ describe('cliRun', () => {
         output: {
           filePath: 'repomix-output.txt',
           style: 'plain',
+          parsableStyle: false,
           fileSummary: true,
           directoryStructure: true,
           topFilesLength: 5,

--- a/tests/config/configSchema.test.ts
+++ b/tests/config/configSchema.test.ts
@@ -64,6 +64,7 @@ describe('configSchema', () => {
         output: {
           filePath: 'output.txt',
           style: 'plain',
+          parsableStyle: false,
           fileSummary: true,
           directoryStructure: true,
           removeComments: false,
@@ -147,6 +148,7 @@ describe('configSchema', () => {
         output: {
           filePath: 'merged-output.txt',
           style: 'plain',
+          parsableStyle: false,
           fileSummary: true,
           directoryStructure: true,
           removeComments: true,

--- a/tests/core/output/outputGenerate.test.ts
+++ b/tests/core/output/outputGenerate.test.ts
@@ -59,4 +59,30 @@ describe('outputGenerate', () => {
       { '#text': mockProcessedFiles[1].content, '@_path': mockProcessedFiles[1].path },
     ]);
   });
+
+  test('generateOutput should write correct content to file (parsable markdown style)', async () => {
+    const mockConfig = createMockConfig({
+      output: {
+        filePath: 'output.txt',
+        style: 'markdown',
+        parsableStyle: true,
+        topFilesLength: 2,
+        showLineNumbers: false,
+        removeComments: false,
+        removeEmptyLines: false,
+      },
+    });
+    const mockProcessedFiles: ProcessedFile[] = [
+      { path: 'file1.txt', content: 'content1' },
+      { path: 'dir/file2.txt', content: '```\ncontent2\n```' },
+    ];
+
+    const output = await generateOutput(process.cwd(), mockConfig, mockProcessedFiles, []);
+
+    expect(output).toContain('# File Summary');
+    expect(output).toContain('## File: file1.txt');
+    expect(output).toContain('````\ncontent1\n````');
+    expect(output).toContain('## File: dir/file2.txt');
+    expect(output).toContain('````\n```\ncontent2\n```\n````');
+  });
 });

--- a/tests/core/output/outputGenerate.test.ts
+++ b/tests/core/output/outputGenerate.test.ts
@@ -1,11 +1,12 @@
 import process from 'node:process';
-import { describe, expect, test } from 'vitest';
-import type { ProcessedFile } from '../../../src/core/file/fileTypes.js';
-import { generateOutput } from '../../../src/core/output/outputGenerate.js';
-import { createMockConfig } from '../../testing/testUtils.js';
+import {describe, expect, test} from 'vitest';
+import type {ProcessedFile} from '../../../src/core/file/fileTypes.js';
+import {generateOutput} from '../../../src/core/output/outputGenerate.js';
+import {createMockConfig} from '../../testing/testUtils.js';
+import {XMLParser} from "fast-xml-parser";
 
 describe('outputGenerate', () => {
-  test('generateOutput should write correct content to file', async () => {
+  test('generateOutput should write correct content to file (plain style)', async () => {
     const mockConfig = createMockConfig({
       output: {
         filePath: 'output.txt',
@@ -17,8 +18,8 @@ describe('outputGenerate', () => {
       },
     });
     const mockProcessedFiles: ProcessedFile[] = [
-      { path: 'file1.txt', content: 'content1' },
-      { path: 'dir/file2.txt', content: 'content2' },
+      {path: 'file1.txt', content: 'content1'},
+      {path: 'dir/file2.txt', content: 'content2'},
     ];
 
     const output = await generateOutput(process.cwd(), mockConfig, mockProcessedFiles, []);
@@ -28,5 +29,34 @@ describe('outputGenerate', () => {
     expect(output).toContain('content1');
     expect(output).toContain('File: dir/file2.txt');
     expect(output).toContain('content2');
+  });
+
+  test('generateOutput should write correct content to file (parsable xml style)', async () => {
+    const mockConfig = createMockConfig({
+      output: {
+        filePath: 'output.txt',
+        style: 'xml',
+        parsableStyle: true,
+        topFilesLength: 2,
+        showLineNumbers: false,
+        removeComments: false,
+        removeEmptyLines: false,
+      },
+    });
+    const mockProcessedFiles: ProcessedFile[] = [
+      {path: 'file1.txt', content: '<div>foo</div>'},
+      {path: 'dir/file2.txt', content: 'if (a && b)'},
+    ];
+
+    const output = await generateOutput(process.cwd(), mockConfig, mockProcessedFiles, []);
+
+    const parser = new XMLParser({ignoreAttributes: false});
+    let parsedOutput = parser.parse(output);
+
+    expect(parsedOutput.repomix.file_summary).not.toBeUndefined();
+    expect(parsedOutput.repomix.files.file).toEqual([
+      {"#text": mockProcessedFiles[0].content, "@_path": mockProcessedFiles[0].path},
+      {"#text": mockProcessedFiles[1].content, "@_path": mockProcessedFiles[1].path},
+    ]);
   });
 });

--- a/tests/core/output/outputGenerate.test.ts
+++ b/tests/core/output/outputGenerate.test.ts
@@ -1,9 +1,9 @@
 import process from 'node:process';
-import {describe, expect, test} from 'vitest';
-import type {ProcessedFile} from '../../../src/core/file/fileTypes.js';
-import {generateOutput} from '../../../src/core/output/outputGenerate.js';
-import {createMockConfig} from '../../testing/testUtils.js';
-import {XMLParser} from "fast-xml-parser";
+import { XMLParser } from 'fast-xml-parser';
+import { describe, expect, test } from 'vitest';
+import type { ProcessedFile } from '../../../src/core/file/fileTypes.js';
+import { generateOutput } from '../../../src/core/output/outputGenerate.js';
+import { createMockConfig } from '../../testing/testUtils.js';
 
 describe('outputGenerate', () => {
   test('generateOutput should write correct content to file (plain style)', async () => {
@@ -18,8 +18,8 @@ describe('outputGenerate', () => {
       },
     });
     const mockProcessedFiles: ProcessedFile[] = [
-      {path: 'file1.txt', content: 'content1'},
-      {path: 'dir/file2.txt', content: 'content2'},
+      { path: 'file1.txt', content: 'content1' },
+      { path: 'dir/file2.txt', content: 'content2' },
     ];
 
     const output = await generateOutput(process.cwd(), mockConfig, mockProcessedFiles, []);
@@ -44,19 +44,19 @@ describe('outputGenerate', () => {
       },
     });
     const mockProcessedFiles: ProcessedFile[] = [
-      {path: 'file1.txt', content: '<div>foo</div>'},
-      {path: 'dir/file2.txt', content: 'if (a && b)'},
+      { path: 'file1.txt', content: '<div>foo</div>' },
+      { path: 'dir/file2.txt', content: 'if (a && b)' },
     ];
 
     const output = await generateOutput(process.cwd(), mockConfig, mockProcessedFiles, []);
 
-    const parser = new XMLParser({ignoreAttributes: false});
-    let parsedOutput = parser.parse(output);
+    const parser = new XMLParser({ ignoreAttributes: false });
+    const parsedOutput = parser.parse(output);
 
     expect(parsedOutput.repomix.file_summary).not.toBeUndefined();
     expect(parsedOutput.repomix.files.file).toEqual([
-      {"#text": mockProcessedFiles[0].content, "@_path": mockProcessedFiles[0].path},
-      {"#text": mockProcessedFiles[1].content, "@_path": mockProcessedFiles[1].path},
+      { '#text': mockProcessedFiles[0].content, '@_path': mockProcessedFiles[0].path },
+      { '#text': mockProcessedFiles[1].content, '@_path': mockProcessedFiles[1].path },
     ]);
   });
 });

--- a/website/server/src/remoteRepo.ts
+++ b/website/server/src/remoteRepo.ts
@@ -7,6 +7,7 @@ import { RequestCache, generateCacheKey } from './utils/cache.js';
 import { AppError } from './utils/errorHandler.js';
 import { RateLimiter } from './utils/rateLimit.js';
 import { sanitizePattern, validateRequest } from './utils/validation.js';
+import type {DefaultActionRunnerResult} from "../../../src/cli/actions/defaultAction.js";
 
 // Create instances of cache and rate limiter
 const cache = new RequestCache<PackResult>(180); // 3 minutes cache
@@ -50,6 +51,7 @@ export async function processRemoteRepo(
   const cliOptions = {
     output: outputFilePath,
     style: validatedData.format,
+    parsableStyle: validatedData.options.outputParsable,
     removeComments: validatedData.options.removeComments,
     removeEmptyLines: validatedData.options.removeEmptyLines,
     outputShowLineNumbers: validatedData.options.showLineNumbers,
@@ -63,7 +65,7 @@ export async function processRemoteRepo(
 
   try {
     // Execute remote action
-    const result = await runRemoteAction(repoUrl, cliOptions);
+    const result: DefaultActionRunnerResult = await runRemoteAction(repoUrl, cliOptions);
     const { packResult } = result;
 
     // Read the generated file

--- a/website/server/src/remoteRepo.ts
+++ b/website/server/src/remoteRepo.ts
@@ -7,7 +7,6 @@ import { RequestCache, generateCacheKey } from './utils/cache.js';
 import { AppError } from './utils/errorHandler.js';
 import { RateLimiter } from './utils/rateLimit.js';
 import { sanitizePattern, validateRequest } from './utils/validation.js';
-import type {DefaultActionRunnerResult} from "../../../src/cli/actions/defaultAction.js";
 
 // Create instances of cache and rate limiter
 const cache = new RequestCache<PackResult>(180); // 3 minutes cache
@@ -65,7 +64,7 @@ export async function processRemoteRepo(
 
   try {
     // Execute remote action
-    const result: DefaultActionRunnerResult = await runRemoteAction(repoUrl, cliOptions);
+    const result = await runRemoteAction(repoUrl, cliOptions);
     const { packResult } = result;
 
     // Read the generated file

--- a/website/server/src/schemas/request.ts
+++ b/website/server/src/schemas/request.ts
@@ -23,6 +23,7 @@ export const packOptionsSchema = z
       .max(1000, 'Ignore patterns too long')
       .optional()
       .transform((val) => val?.trim()),
+    outputParsable: z.boolean().optional(),
   })
   .strict();
 

--- a/website/server/src/types.ts
+++ b/website/server/src/types.ts
@@ -6,6 +6,7 @@ export interface PackOptions {
   directoryStructure?: boolean;
   includePatterns?: string;
   ignorePatterns?: string;
+  outputParsable?: boolean;
 }
 
 interface TopFile {


### PR DESCRIPTION
See #282 

Adds a `parsableStyle` flag to ensure the output strictly follows the specification of the output style.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
