### PR TITLE
refactor(website): Separate search translations for each language into separate files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,19 +47,6 @@ jobs:
     - run: npm ci
     - run: npm run lint-secretlint
 
-  lint-renovate-config:
-    name: Lint Renovate config
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version-file: .tool-versions
-        cache: npm
-    - name: Validate Renovate config
-      run: npx --yes --package renovate -- renovate-config-validator --strict
-
   lint-action:
     name: Lint GitHub Actions
     runs-on: ubuntu-latest

--- a/website/client/.vitepress/config/configEs.ts
+++ b/website/client/.vitepress/config/configEs.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitepress';
+import { type DefaultTheme, defineConfig } from 'vitepress';
 
 export const configEs = defineConfig({
   lang: 'es',
@@ -42,3 +42,25 @@ export const configEs = defineConfig({
     },
   },
 });
+
+export const configEsSearch: DefaultTheme.LocalSearchOptions['locales'] = {
+  es: {
+    translations: {
+      button: {
+        buttonText: 'Buscar',
+        buttonAriaLabel: 'Buscar',
+      },
+      modal: {
+        noResultsText: 'Sin resultados',
+        resetButtonTitle: 'Restablecer búsqueda',
+        backButtonTitle: 'Volver',
+        displayDetails: 'Mostrar detalles',
+        footer: {
+          selectText: 'Seleccionar',
+          navigateText: 'Navegar',
+          closeText: 'Cerrar',
+        },
+      },
+    },
+  },
+};

--- a/website/client/.vitepress/config/configJa.ts
+++ b/website/client/.vitepress/config/configJa.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitepress';
+import { type DefaultTheme, defineConfig } from 'vitepress';
 
 export const configJa = defineConfig({
   lang: 'ja',
@@ -41,3 +41,25 @@ export const configJa = defineConfig({
     },
   },
 });
+
+export const configJaSearch: DefaultTheme.LocalSearchOptions['locales'] = {
+  ja: {
+    translations: {
+      button: {
+        buttonText: '検索',
+        buttonAriaLabel: '検索',
+      },
+      modal: {
+        noResultsText: '検索結果がありません',
+        resetButtonTitle: '検索をリセット',
+        backButtonTitle: '前に戻る',
+        displayDetails: '詳細を表示',
+        footer: {
+          selectText: '選択',
+          navigateText: '移動',
+          closeText: '閉じる',
+        },
+      },
+    },
+  },
+};

--- a/website/client/.vitepress/config/configKo.ts
+++ b/website/client/.vitepress/config/configKo.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitepress';
+import { type DefaultTheme, defineConfig } from 'vitepress';
 
 export const configKo = defineConfig({
   lang: 'ko-KR',
@@ -41,3 +41,25 @@ export const configKo = defineConfig({
     },
   },
 });
+
+export const configKoSearch: DefaultTheme.LocalSearchOptions['locales'] = {
+  ko: {
+    translations: {
+      button: {
+        buttonText: '검색',
+        buttonAriaLabel: '검색',
+      },
+      modal: {
+        noResultsText: '결과 없음',
+        resetButtonTitle: '검색 재설정',
+        backButtonTitle: '뒤로',
+        displayDetails: '세부 정보 표시',
+        footer: {
+          selectText: '선택',
+          navigateText: '이동',
+          closeText: '닫기',
+        },
+      },
+    },
+  },
+};

--- a/website/client/.vitepress/config/configPtBr.ts
+++ b/website/client/.vitepress/config/configPtBr.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitepress';
+import { type DefaultTheme, defineConfig } from 'vitepress';
 
 export const configPtBr = defineConfig({
   lang: 'pt-br',
@@ -42,3 +42,25 @@ export const configPtBr = defineConfig({
     },
   },
 });
+
+export const configPtBrSearch: DefaultTheme.LocalSearchOptions['locales'] = {
+  'pt-br': {
+    translations: {
+      button: {
+        buttonText: 'Pesquisar',
+        buttonAriaLabel: 'Pesquisar',
+      },
+      modal: {
+        noResultsText: 'Sem resultados',
+        resetButtonTitle: 'Redefinir pesquisa',
+        backButtonTitle: 'Voltar',
+        displayDetails: 'Mostrar detalhes',
+        footer: {
+          selectText: 'Selecionar',
+          navigateText: 'Navegar',
+          closeText: 'Fechar',
+        },
+      },
+    },
+  },
+};

--- a/website/client/.vitepress/config/configShard.ts
+++ b/website/client/.vitepress/config/configShard.ts
@@ -1,4 +1,9 @@
 import { defineConfig } from 'vitepress';
+import { configEsSearch } from './configEs';
+import { configJaSearch } from './configJa';
+import { configKoSearch } from './configKo';
+import { configPtBrSearch } from './configPtBr';
+import { configZhCnSearch } from './configZhCn';
 
 const googleAnalyticsTag = 'G-7PTT4PLC69';
 
@@ -27,54 +32,11 @@ export const configShard = defineConfig({
       provider: 'local',
       options: {
         locales: {
-          root: {
-            translations: {
-              button: {
-                buttonText: 'Search',
-                buttonAriaLabel: 'Search',
-              },
-              modal: {
-                noResultsText: 'No results',
-                resetButtonTitle: 'Reset search',
-                footer: {
-                  selectText: 'to select',
-                  navigateText: 'to navigate',
-                },
-              },
-            },
-          },
-          ja: {
-            translations: {
-              button: {
-                buttonText: '検索',
-                buttonAriaLabel: '検索',
-              },
-              modal: {
-                noResultsText: '検索結果がありません',
-                resetButtonTitle: '検索をリセット',
-                footer: {
-                  selectText: '選択',
-                  navigateText: '移動',
-                },
-              },
-            },
-          },
-          'zh-cn': {
-            translations: {
-              button: {
-                buttonText: '搜索',
-                buttonAriaLabel: '搜索',
-              },
-              modal: {
-                noResultsText: '未找到结果',
-                resetButtonTitle: '重置搜索',
-                footer: {
-                  selectText: '选择',
-                  navigateText: '导航',
-                },
-              },
-            },
-          },
+          ...configJaSearch,
+          ...configZhCnSearch,
+          ...configKoSearch,
+          ...configPtBrSearch,
+          ...configEsSearch,
         },
       },
     },

--- a/website/client/.vitepress/config/configZhCn.ts
+++ b/website/client/.vitepress/config/configZhCn.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitepress';
+import { type DefaultTheme, defineConfig } from 'vitepress';
 
 export const configZhCn = defineConfig({
   lang: 'zh-cn',
@@ -41,3 +41,25 @@ export const configZhCn = defineConfig({
     },
   },
 });
+
+export const configZhCnSearch: DefaultTheme.LocalSearchOptions['locales'] = {
+  'zh-cn': {
+    translations: {
+      button: {
+        buttonText: '搜索',
+        buttonAriaLabel: '搜索',
+      },
+      modal: {
+        noResultsText: '无结果',
+        resetButtonTitle: '重置搜索',
+        backButtonTitle: '返回',
+        displayDetails: '显示详情',
+        footer: {
+          selectText: '选择',
+          navigateText: '导航',
+          closeText: '关闭',
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION


<!-- Please include a summary of the changes -->

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
