### PR TITLE
Handle large files gracefully

### DIFF
--- a/src/core/file/fileCollect.ts
+++ b/src/core/file/fileCollect.ts
@@ -34,7 +34,7 @@ export const collectFiles = async (filePaths: string[], rootDir: string): Promis
 const readRawFile = async (filePath: string): Promise<string | null> => {
   try {
     const stats = await fs.stat(filePath);
-    
+
     if (stats.size > MAX_FILE_SIZE) {
       const sizeMB = (stats.size / 1024 / 1024).toFixed(1);
       logger.log('⚠️ Large File Warning:');

--- a/src/core/file/fileCollect.ts
+++ b/src/core/file/fileCollect.ts
@@ -37,8 +37,9 @@ const readRawFile = async (filePath: string): Promise<string | null> => {
 
     if (stats.size > MAX_FILE_SIZE) {
       const sizeMB = (stats.size / 1024 / 1024).toFixed(1);
+      logger.log('');
       logger.log('⚠️ Large File Warning:');
-      logger.log('────────────────────────────────────────────────');
+      logger.log('──────────────────────');
       logger.log(`File exceeds size limit: ${sizeMB}MB > ${MAX_FILE_SIZE / 1024 / 1024}MB (${filePath})`);
       logger.note('Add this file to .repomixignore if you want to exclude it permanently');
       logger.log('');

--- a/src/core/file/fileCollect.ts
+++ b/src/core/file/fileCollect.ts
@@ -10,7 +10,7 @@ import type { RawFile } from './fileTypes.js';
 
 // Maximum file size to process (50MB)
 // This prevents out-of-memory errors when processing very large files
-const MAX_FILE_SIZE = 50 * 1024 * 1024;
+export const MAX_FILE_SIZE = 50 * 1024 * 1024;
 
 export const collectFiles = async (filePaths: string[], rootDir: string): Promise<RawFile[]> => {
   const rawFiles = await pMap(

--- a/src/core/file/fileCollect.ts
+++ b/src/core/file/fileCollect.ts
@@ -8,6 +8,10 @@ import { logger } from '../../shared/logger.js';
 import { getProcessConcurrency } from '../../shared/processConcurrency.js';
 import type { RawFile } from './fileTypes.js';
 
+// Maximum file size to process (50MB)
+// This prevents out-of-memory errors when processing very large files
+const MAX_FILE_SIZE = 50 * 1024 * 1024;
+
 export const collectFiles = async (filePaths: string[], rootDir: string): Promise<RawFile[]> => {
   const rawFiles = await pMap(
     filePaths,
@@ -28,14 +32,26 @@ export const collectFiles = async (filePaths: string[], rootDir: string): Promis
 };
 
 const readRawFile = async (filePath: string): Promise<string | null> => {
-  if (isBinary(filePath)) {
-    logger.debug(`Skipping binary file: ${filePath}`);
-    return null;
-  }
-
-  logger.trace(`Reading file: ${filePath}`);
-
   try {
+    const stats = await fs.stat(filePath);
+    
+    if (stats.size > MAX_FILE_SIZE) {
+      const sizeMB = (stats.size / 1024 / 1024).toFixed(1);
+      logger.log('⚠️ Large File Warning:');
+      logger.log('────────────────────────────────────────────────');
+      logger.log(`File exceeds size limit: ${sizeMB}MB > ${MAX_FILE_SIZE / 1024 / 1024}MB (${filePath})`);
+      logger.note('Add this file to .repomixignore if you want to exclude it permanently');
+      logger.log('');
+      return null;
+    }
+
+    if (isBinary(filePath)) {
+      logger.debug(`Skipping binary file: ${filePath}`);
+      return null;
+    }
+
+    logger.trace(`Reading file: ${filePath}`);
+
     const buffer = await fs.readFile(filePath);
 
     if (isBinary(null, buffer)) {

--- a/tests/core/file/fileCollect.test.ts
+++ b/tests/core/file/fileCollect.test.ts
@@ -88,7 +88,7 @@ describe('fileCollect', () => {
 
     expect(result).toEqual([{ path: 'normal.txt', content: 'decoded content' }]);
     expect(logger.log).toHaveBeenCalledWith('⚠️ Large File Warning:');
-    expect(logger.log).toHaveBeenCalledWith('────────────────────────────────────────────────');
+    expect(logger.log).toHaveBeenCalledWith('──────────────────────');
     expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('File exceeds size limit:'));
     expect(logger.log).toHaveBeenCalledWith(expect.stringContaining(largePath));
     expect(logger.note).toHaveBeenCalledWith('Add this file to .repomixignore if you want to exclude it permanently');

--- a/tests/core/file/fileCollect.test.ts
+++ b/tests/core/file/fileCollect.test.ts
@@ -17,7 +17,7 @@ vi.mock('../../../src/shared/logger');
 describe('fileCollect', () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    
+
     // Setup basic file size mock to fix stat
     vi.mocked(fs.stat).mockResolvedValue({
       size: 1024,
@@ -51,7 +51,7 @@ describe('fileCollect', () => {
     const mockRootDir = '/root';
 
     vi.mocked(isBinary)
-      .mockReturnValueOnce(true)  // for binary.bin
+      .mockReturnValueOnce(true) // for binary.bin
       .mockReturnValueOnce(false); // for text.txt
     vi.mocked(fs.readFile).mockResolvedValue(Buffer.from('file content'));
     vi.mocked(jschardet.detect).mockReturnValue({ encoding: 'utf-8', confidence: 0.99 });
@@ -68,11 +68,13 @@ describe('fileCollect', () => {
     const mockRootDir = '/root';
 
     vi.mocked(fs.stat)
-      .mockResolvedValueOnce({  // for large.txt
+      .mockResolvedValueOnce({
+        // for large.txt
         size: 60 * 1024 * 1024,
         isFile: () => true,
       } as Stats)
-      .mockResolvedValueOnce({  // for normal.txt
+      .mockResolvedValueOnce({
+        // for normal.txt
         size: 1024,
         isFile: () => true,
       } as Stats);

--- a/tests/core/file/fileCollect.test.ts
+++ b/tests/core/file/fileCollect.test.ts
@@ -87,9 +87,9 @@ describe('fileCollect', () => {
     const result = await collectFiles(mockFilePaths, mockRootDir);
 
     expect(result).toEqual([{ path: 'normal.txt', content: 'decoded content' }]);
-
     expect(logger.log).toHaveBeenCalledWith('⚠️ Large File Warning:');
-    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining(`File exceeds size limit:`));
+    expect(logger.log).toHaveBeenCalledWith('────────────────────────────────────────────────');
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('File exceeds size limit:'));
     expect(logger.log).toHaveBeenCalledWith(expect.stringContaining(largePath));
     expect(logger.note).toHaveBeenCalledWith('Add this file to .repomixignore if you want to exclude it permanently');
 


### PR DESCRIPTION
Fixes critical out-of-memory errors when processing repositories containing large files

### The Problem
When accidentally adding a large file to a repository (such as a 480MB txt file), Repomix would try to load it into memory and crash with a Node.js heap out-of-memory error:

```
❯ repomix

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
[1]    63614 abort      repomix
```

This provides a poor user experience as:
1. The error is not user-friendly or actionable
2. The program crashes instead of gracefully handling the situation
3. Users don't know which file caused the problem

### The Solution
Added a size limit check (50MB) before loading files into memory, with clear user guidance:

```
📦 Repomix v0.2.21

⚠️ Large File Warning:
────────────────────────────────────────────────
File exceeds size limit: 486.8MB > 50MB (/path/to/large/file)
Add this file to .repomixignore if you want to exclude it permanently

✔ Packing completed successfully!
```

### Changes
- Added 50MB file size limit to prevent memory issues
- Added user-friendly warning message that:
  - Shows the file size and limit
  - Points to the specific file causing the issue
  - Suggests adding it to .repomixignore

### Why
Large files are often added by accident (logfiles, lock files, etc.). Instead of crashing, Repomix should help users identify and handle these files appropriately. The 50MB limit was chosen because:
1. It's well above typical source code file sizes
2. It matches GitHub's recommended file size limit
3. It ensures stable memory usage even on systems with limited RAM