### PR TITLE
feat(ignore): Add Rust default ignores

### DIFF
--- a/src/config/defaultIgnore.ts
+++ b/src/config/defaultIgnore.ts
@@ -132,4 +132,8 @@ export const defaultIgnoreList = [
   '**/.ipynb_checkpoints/**',
   '**/Pipfile.lock',
   '**/poetry.lock',
+
+  // Essential Rust-related entries
+  '**/Cargo.lock',
+  '**/Cargo.toml.orig',
 ];

--- a/src/config/defaultIgnore.ts
+++ b/src/config/defaultIgnore.ts
@@ -136,4 +136,6 @@ export const defaultIgnoreList = [
   // Essential Rust-related entries
   '**/Cargo.lock',
   '**/Cargo.toml.orig',
+  '**/target/**',
+  '**/*.rs.bk',
 ];


### PR DESCRIPTION
This PR adds Rust-specific patterns to the default ignore list.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
