### PR TITLE
Support getting remote ref by parsing url

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,13 @@ repomix --remote https://github.com/yamadashy/repomix --remote-branch main
 
 # Or use a specific commit hash:
 repomix --remote https://github.com/yamadashy/repomix --remote-branch 935b695
+
+# Another convenient way is specifying the branch's URL
+repomix --remote https://github.com/yamadashy/repomix/tree/main
+
+# Commit's URL is also supported
+repomix --remote https://github.com/yamadashy/repomix/commit/836abcd7335137228ad77feb28655d85712680f1
+
 ```
 
 To initialize a new configuration file (`repomix.config.json`):
@@ -470,13 +477,21 @@ repomix --remote yamadashy/repomix
 You can specify the branch name, tag, or commit hash:
 
 ```bash
+# Using --remote-branch option
 repomix --remote https://github.com/yamadashy/repomix --remote-branch main
+
+# Using branch's URL
+repomix --remote https://github.com/yamadashy/repomix/tree/main
 ```
 
 Or use a specific commit hash:
 
 ```bash
+# Using --remote-branch option
 repomix --remote https://github.com/yamadashy/repomix --remote-branch 935b695
+
+# Using commit's URL
+repomix --remote https://github.com/yamadashy/repomix/commit/836abcd7335137228ad77feb28655d85712680f1
 ```
 
 ## ⚙️ Configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "clipboardy": "^4.0.0",
         "commander": "^13.1.0",
         "fast-xml-parser": "^4.5.1",
+        "git-url-parse": "^16.0.0",
         "globby": "^14.0.2",
         "handlebars": "^4.7.8",
         "iconv-lite": "^0.6.3",
@@ -35,6 +36,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
+        "@types/git-url-parse": "^9.0.3",
         "@types/node": "^22.13.0",
         "@types/strip-comments": "^2.0.4",
         "@vitest/coverage-v8": "^3.0.5",
@@ -1743,6 +1745,13 @@
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true
     },
+    "node_modules/@types/git-url-parse": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@types/git-url-parse/-/git-url-parse-9.0.3.tgz",
+      "integrity": "sha512-Wrb8zeghhpKbYuqAOg203g+9YSNlrZWNZYvwxJuDF4dTmerijqpnGbI79yCuPtHSXHPEwv1pAFUB4zsSqn82Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.13.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.0.tgz",
@@ -1758,6 +1767,12 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
+    },
+    "node_modules/@types/parse-path": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse-path/-/parse-path-7.0.3.tgz",
+      "integrity": "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==",
+      "license": "MIT"
     },
     "node_modules/@types/strip-comments": {
       "version": "2.0.4",
@@ -2522,6 +2537,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/git-up": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-8.0.0.tgz",
+      "integrity": "sha512-uBI8Zdt1OZlrYfGcSVroLJKgyNNXlgusYFzHk614lTasz35yg2PVpL1RMy0LOO2dcvF9msYW3pRfUSmafZNrjg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-ssh": "^1.4.0",
+        "parse-url": "^9.2.0"
+      }
+    },
+    "node_modules/git-url-parse": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-16.0.0.tgz",
+      "integrity": "sha512-Y8iAF0AmCaqXc6a5GYgPQW9ESbncNLOL+CeQAJRhmWUOmnPkKpBYeWYp4mFd3LA5j53CdGDdslzX12yEBVHQQg==",
+      "license": "MIT",
+      "dependencies": {
+        "git-up": "^8.0.0"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -2736,6 +2770,15 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-ssh": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.0.tgz",
+      "integrity": "sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocols": "^2.0.1"
       }
     },
     "node_modules/is-stream": {
@@ -3265,6 +3308,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-path": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.0.tgz",
+      "integrity": "sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==",
+      "license": "MIT",
+      "dependencies": {
+        "protocols": "^2.0.0"
+      }
+    },
+    "node_modules/parse-url": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-9.2.0.tgz",
+      "integrity": "sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-path": "^7.0.0",
+        "parse-path": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.13.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -3379,6 +3444,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/protocols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
+      "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "clipboardy": "^4.0.0",
     "commander": "^13.1.0",
     "fast-xml-parser": "^4.5.1",
+    "git-url-parse": "^16.0.0",
     "globby": "^14.0.2",
     "handlebars": "^4.7.8",
     "iconv-lite": "^0.6.3",
@@ -85,6 +86,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "@types/git-url-parse": "^9.0.3",
     "@types/node": "^22.13.0",
     "@types/strip-comments": "^2.0.4",
     "@vitest/coverage-v8": "^3.0.5",

--- a/src/cli/actions/remoteAction.ts
+++ b/src/cli/actions/remoteAction.ts
@@ -89,7 +89,7 @@ export const parseRemoteValue = (remoteValue: string): { repoUrl: string; remote
     if (parsedFields.ref) {
       return {
         repoUrl: repoUrl,
-        remoteBranch: parsedFields.ref,
+        remoteBranch: parsedFields.filepath ? `${parsedFields.ref}/${parsedFields.filepath}` : parsedFields.ref,
       };
     }
 

--- a/src/cli/actions/remoteAction.ts
+++ b/src/cli/actions/remoteAction.ts
@@ -138,13 +138,13 @@ export const cloneRepository = async (
     execGitShallowClone,
   },
 ): Promise<void> => {
-  logger.log(`Clone repository: ${url} to temporary directory.${pc.dim(`path: ${directory}`)} `);
+  logger.log(`Clone repository: ${url} to temporary directory.${pc.dim(`path: ${directory}`)}`);
   logger.log('');
 
   try {
     await deps.execGitShallowClone(url, directory, remoteBranch);
   } catch (error) {
-    throw new RepomixError(`Failed to clone repository: ${(error as Error).message} `);
+    throw new RepomixError(`Failed to clone repository: ${(error as Error).message}`);
   }
 };
 
@@ -162,9 +162,9 @@ export const copyOutputToCurrentDirectory = async (
   const targetPath = path.join(targetDir, outputFileName);
 
   try {
-    logger.trace(`Copying output file from: ${sourcePath} to: ${targetPath} `);
+    logger.trace(`Copying output file from: ${sourcePath} to: ${targetPath}`);
     await fs.copyFile(sourcePath, targetPath);
   } catch (error) {
-    throw new RepomixError(`Failed to copy output file: ${(error as Error).message} `);
+    throw new RepomixError(`Failed to copy output file: ${(error as Error).message}`);
   }
 };

--- a/src/cli/actions/remoteAction.ts
+++ b/src/cli/actions/remoteAction.ts
@@ -9,7 +9,7 @@ import { logger } from '../../shared/logger.js';
 import type { CliOptions } from '../cliRun.js';
 import Spinner from '../cliSpinner.js';
 import { type DefaultActionRunnerResult, runDefaultAction } from './defaultAction.js';
-interface CorrectedGitUrl extends GitUrl {
+interface IGitUrl extends GitUrl {
   commit: string | undefined;
 }
 export const runRemoteAction = async (
@@ -72,7 +72,7 @@ export const parseRemoteValue = (remoteValue: string): { repoUrl: string; remote
   }
 
   try {
-    const parsedFields = GitUrlParse(remoteValue);
+    const parsedFields = GitUrlParse(remoteValue) as IGitUrl;
 
     // This will make parsedFields.toString() automatically append '.git' to the returned url
     parsedFields.git_suffix = true;
@@ -93,10 +93,10 @@ export const parseRemoteValue = (remoteValue: string): { repoUrl: string; remote
       };
     }
 
-    if ((parsedFields as CorrectedGitUrl).commit) {
+    if (parsedFields.commit) {
       return {
         repoUrl: repoUrl,
-        remoteBranch: (parsedFields as CorrectedGitUrl).commit,
+        remoteBranch: parsedFields.commit,
       };
     }
 

--- a/src/cli/actions/remoteAction.ts
+++ b/src/cli/actions/remoteAction.ts
@@ -138,7 +138,7 @@ export const cloneRepository = async (
     execGitShallowClone,
   },
 ): Promise<void> => {
-  logger.log(`Clone repository: ${url} to temporary directory.${pc.dim(`path: ${directory}`)}`);
+  logger.log(`Clone repository: ${url} to temporary directory. ${pc.dim(`path: ${directory}`)}`);
   logger.log('');
 
   try {
@@ -149,7 +149,7 @@ export const cloneRepository = async (
 };
 
 export const cleanupTempDirectory = async (directory: string): Promise<void> => {
-  logger.trace(`Cleaning up temporary directory: ${directory} `);
+  logger.trace(`Cleaning up temporary directory: ${directory}`);
   await fs.rm(directory, { recursive: true, force: true });
 };
 

--- a/src/cli/actions/remoteAction.ts
+++ b/src/cli/actions/remoteAction.ts
@@ -26,13 +26,7 @@ export const runRemoteAction = async (
   }
 
   const parsedFields = parseRemoteValue(repoUrl);
-
-  if (options.remoteBranch === undefined) {
-    options.remoteBranch = parsedFields.remoteBranch;
-  }
-
   const spinner = new Spinner('Cloning repository...');
-
   const tempDirPath = await createTempDirectory();
   let result: DefaultActionRunnerResult;
 
@@ -40,7 +34,7 @@ export const runRemoteAction = async (
     spinner.start();
 
     // Clone the repository
-    await cloneRepository(parsedFields.repoUrl, tempDirPath, options.remoteBranch, {
+    await cloneRepository(parsedFields.repoUrl, tempDirPath, options.remoteBranch || parsedFields.remoteBranch, {
       execGitShallowClone: deps.execGitShallowClone,
     });
 

--- a/tests/cli/actions/remoteAction.test.ts
+++ b/tests/cli/actions/remoteAction.test.ts
@@ -102,6 +102,12 @@ describe('remoteAction functions', () => {
         repoUrl: 'https://some.gitlab.domain/some/path/username/repo.git',
         remoteBranch: 'branchname',
       });
+      expect(
+        parseRemoteValue('https://some.gitlab.domain/some/path/username/repo/-/tree/branchname/withslash'),
+      ).toEqual({
+        repoUrl: 'https://some.gitlab.domain/some/path/username/repo.git',
+        remoteBranch: 'branchname/withslash',
+      });
     });
 
     test('should get correct commit hash from url', () => {

--- a/tests/cli/actions/remoteAction.test.ts
+++ b/tests/cli/actions/remoteAction.test.ts
@@ -4,8 +4,8 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { DefaultActionRunnerResult } from '../../../src/cli/actions/defaultAction.js';
 import {
   copyOutputToCurrentDirectory,
-  formatRemoteValueToUrl,
   isValidRemoteValue,
+  parseRemoteValue,
   runRemoteAction,
 } from '../../../src/cli/actions/remoteAction.js';
 import { createMockConfig } from '../../testing/testUtils.js';
@@ -55,20 +55,20 @@ describe('remoteAction functions', () => {
 
   describe('formatGitUrl', () => {
     test('should convert GitHub shorthand to full URL', () => {
-      expect(formatRemoteValueToUrl('user/repo')).toBe('https://github.com/user/repo.git');
-      expect(formatRemoteValueToUrl('user-name/repo-name')).toBe('https://github.com/user-name/repo-name.git');
-      expect(formatRemoteValueToUrl('user_name/repo_name')).toBe('https://github.com/user_name/repo_name.git');
-      expect(formatRemoteValueToUrl('a.b/a-b_c')).toBe('https://github.com/a.b/a-b_c.git');
+      expect(parseRemoteValue('user/repo').repoUrl).toBe('https://github.com/user/repo.git');
+      expect(parseRemoteValue('user-name/repo-name').repoUrl).toBe('https://github.com/user-name/repo-name.git');
+      expect(parseRemoteValue('user_name/repo_name').repoUrl).toBe('https://github.com/user_name/repo_name.git');
+      expect(parseRemoteValue('a.b/a-b_c').repoUrl).toBe('https://github.com/a.b/a-b_c.git');
     });
 
     test('should handle HTTPS URLs', () => {
-      expect(formatRemoteValueToUrl('https://github.com/user/repo')).toBe('https://github.com/user/repo.git');
-      expect(formatRemoteValueToUrl('https://github.com/user/repo.git')).toBe('https://github.com/user/repo.git');
+      expect(parseRemoteValue('https://github.com/user/repo').repoUrl).toBe('https://github.com/user/repo.git');
+      expect(parseRemoteValue('https://github.com/user/repo.git').repoUrl).toBe('https://github.com/user/repo.git');
     });
 
     test('should not modify SSH URLs', () => {
       const sshUrl = 'git@github.com:user/repo.git';
-      expect(formatRemoteValueToUrl(sshUrl)).toBe(sshUrl);
+      expect(parseRemoteValue(sshUrl).repoUrl).toBe(sshUrl);
     });
   });
 


### PR DESCRIPTION
<!-- Please include a summary of the changes -->
This PR helps resolving https://github.com/yamadashy/repomix/issues/311, adding the ability to parse the cli option value --remote (remote repository url) to get branch/commit/tag.
**This PR does not modify any code of the website.**

For example:
```
npm run repomix -- --remote https://github.com/yamadashy/repomix/tree/0.1.x
```
Works exactly the same as:
```
npm run repomix -- --remote https://github.com/yamadashy/repomix --remote-branch 0.1.x
```

New dependency: 
-  "git-url-parse": "^16.0.0"
-  "@types/git-url-parse": "^9.0.3"

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
