### PR TITLE
Fix/support parentheses in paths

### DIFF
--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -77,9 +77,8 @@ export const searchFiles = async (rootDir: string, config: RepomixConfigMerged):
     throw new Error(`Cannot access directory ${rootDir}: ${permissionCheck.error?.message}`);
   }
 
-  const includePatterns = config.include.length > 0 
-    ? config.include.map(pattern => escapeGlobPattern(pattern))
-    : ['**/*'];
+  const includePatterns =
+    config.include.length > 0 ? config.include.map((pattern) => escapeGlobPattern(pattern)) : ['**/*'];
 
   try {
     const [ignorePatterns, ignoreFilePatterns] = await Promise.all([

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -61,7 +61,7 @@ const isGitWorktreeRef = async (gitPath: string): Promise<boolean> => {
  * Escapes special characters in glob patterns to handle paths with parentheses.
  * Example: "src/(categories)" -> "src/\\(categories\\)"
  */
-const escapeGlobPattern = (pattern: string): string => {
+export const escapeGlobPattern = (pattern: string): string => {
   return pattern.replace(/[()[\]{}]/g, '\\$&');
 };
 

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -57,6 +57,14 @@ const isGitWorktreeRef = async (gitPath: string): Promise<boolean> => {
   }
 };
 
+/**
+ * Escapes special characters in glob patterns to handle paths with parentheses.
+ * Example: "src/(categories)" -> "src/\\(categories\\)"
+ */
+const escapeGlobPattern = (pattern: string): string => {
+  return pattern.replace(/[()[\]{}]/g, '\\$&');
+};
+
 // Get all file paths considering the config
 export const searchFiles = async (rootDir: string, config: RepomixConfigMerged): Promise<FileSearchResult> => {
   // First check directory permissions
@@ -69,7 +77,9 @@ export const searchFiles = async (rootDir: string, config: RepomixConfigMerged):
     throw new Error(`Cannot access directory ${rootDir}: ${permissionCheck.error?.message}`);
   }
 
-  const includePatterns = config.include.length > 0 ? config.include : ['**/*'];
+  const includePatterns = config.include.length > 0 
+    ? config.include.map(pattern => escapeGlobPattern(pattern))
+    : ['**/*'];
 
   try {
     const [ignorePatterns, ignoreFilePatterns] = await Promise.all([

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -62,7 +62,10 @@ const isGitWorktreeRef = async (gitPath: string): Promise<boolean> => {
  * Example: "src/(categories)" -> "src/\\(categories\\)"
  */
 export const escapeGlobPattern = (pattern: string): string => {
-  return pattern.replace(/[()[\]{}]/g, '\\$&');
+  // First escape backslashes
+  const escapedBackslashes = pattern.replace(/\\/g, '\\\\');
+  // Then escape special characters
+  return escapedBackslashes.replace(/[()[\]{}]/g, '\\$&');
 };
 
 // Get all file paths considering the config

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -374,4 +374,19 @@ node_modules
       expect(escapeGlobPattern(pattern)).toBe('src/\\(auth\\)/\\(settings\\)/**/*.ts');
     });
   });
+
+  test('should escape backslashes in pattern', () => {
+    const pattern = 'src\\temp\\(categories)';
+    expect(escapeGlobPattern(pattern)).toBe('src\\\\temp\\\\\\(categories\\)');
+  });
+
+  test('should handle patterns with already escaped special characters', () => {
+    const pattern = 'src\\\\(categories)';
+    expect(escapeGlobPattern(pattern)).toBe('src\\\\\\\\\\(categories\\)');
+  });
+
+  test('should handle patterns with mixed backslashes and special characters', () => {
+    const pattern = 'src\\temp\\[id]\\{slug}';
+    expect(escapeGlobPattern(pattern)).toBe('src\\\\temp\\\\\\[id\\]\\\\\\{slug\\}');
+  });
 });

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -6,6 +6,7 @@ import { globby } from 'globby';
 import { minimatch } from 'minimatch';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import {
+  escapeGlobPattern,
   getIgnoreFilePatterns,
   getIgnorePatterns,
   parseIgnoreContent,
@@ -340,6 +341,37 @@ node_modules
 
       // Verify the files were returned correctly
       expect(result.filePaths).toEqual(['file1.js', 'file2.js']);
+    });
+  });
+
+  describe('escapeGlobPattern', () => {
+    test('should escape parentheses in pattern', () => {
+      const pattern = 'src/(categories)/**/*.ts';
+      expect(escapeGlobPattern(pattern)).toBe('src/\\(categories\\)/**/*.ts');
+    });
+
+    test('should escape multiple types of brackets', () => {
+      const pattern = 'src/(auth)/[id]/{slug}/**/*.ts';
+      expect(escapeGlobPattern(pattern)).toBe('src/\\(auth\\)/\\[id\\]/\\{slug\\}/**/*.ts');
+    });
+
+    test('should handle nested brackets', () => {
+      const pattern = 'src/(auth)/([id])/**/*.ts';
+      expect(escapeGlobPattern(pattern)).toBe('src/\\(auth\\)/\\(\\[id\\]\\)/**/*.ts');
+    });
+
+    test('should handle empty string', () => {
+      expect(escapeGlobPattern('')).toBe('');
+    });
+
+    test('should not modify patterns without special characters', () => {
+      const pattern = 'src/components/**/*.ts';
+      expect(escapeGlobPattern(pattern)).toBe(pattern);
+    });
+
+    test('should handle multiple occurrences of the same bracket type', () => {
+      const pattern = 'src/(auth)/(settings)/**/*.ts';
+      expect(escapeGlobPattern(pattern)).toBe('src/\\(auth\\)/\\(settings\\)/**/*.ts');
     });
   });
 });


### PR DESCRIPTION
This PR adds support for paths containing special characters, specifically parentheses, in the `include` patterns. Previously, paths with characters like `()` were not correctly matched by the glob pattern matcher.

## **Example Use Case**  
When working with frameworks like **Next.js**, developers often use route groups. The following include pattern will now work as expected:

{
  "include": ["src/(categories)/**/*"]
}

## **Changes**

- **`escapeGlobPattern` function:**  
  - Added a utility to properly escape special characters within include patterns.

- **`searchFiles` modification:**  
  - Updated to apply the escaping logic to all include patterns before processing.

- **Special characters handled:**  
  - `()` (parentheses)  
  - `[]` (square brackets)  
  - `{}` (curly brackets)  

## **Checklist**  
- [x] Run `npm run test` and ensure all tests pass  
- [x] Run `npm run lint` and resolve any linting issues  
