### PR TITLE
Allow for passing in multiple directories

### DIFF
--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -21,7 +21,7 @@ export interface DefaultActionRunnerResult {
 }
 
 export const runDefaultAction = async (
-  directory: string,
+  directories: string[],
   cwd: string,
   options: CliOptions,
 ): Promise<DefaultActionRunnerResult> => {
@@ -43,7 +43,7 @@ export const runDefaultAction = async (
 
   logger.trace('Merged config:', config);
 
-  const targetPath = path.resolve(directory);
+  const targetPaths = directories.map((directory) => path.resolve(directory));
 
   const spinner = new Spinner('Packing files...');
   spinner.start();
@@ -51,7 +51,7 @@ export const runDefaultAction = async (
   let packResult: PackResult;
 
   try {
-    packResult = await pack(targetPath, config, (message) => {
+    packResult = await pack(targetPaths, config, (message) => {
       spinner.update(message);
     });
   } catch (error) {
@@ -104,37 +104,64 @@ const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
     cliConfig.ignore = { ...cliConfig.ignore, useGitignore: options.gitignore };
   }
   if (options.defaultPatterns !== undefined) {
-    cliConfig.ignore = { ...cliConfig.ignore, useDefaultPatterns: options.defaultPatterns };
+    cliConfig.ignore = {
+      ...cliConfig.ignore,
+      useDefaultPatterns: options.defaultPatterns,
+    };
   }
   if (options.topFilesLen !== undefined) {
-    cliConfig.output = { ...cliConfig.output, topFilesLength: options.topFilesLen };
+    cliConfig.output = {
+      ...cliConfig.output,
+      topFilesLength: options.topFilesLen,
+    };
   }
   if (options.outputShowLineNumbers !== undefined) {
-    cliConfig.output = { ...cliConfig.output, showLineNumbers: options.outputShowLineNumbers };
+    cliConfig.output = {
+      ...cliConfig.output,
+      showLineNumbers: options.outputShowLineNumbers,
+    };
   }
   if (options.copy) {
     cliConfig.output = { ...cliConfig.output, copyToClipboard: options.copy };
   }
   if (options.style) {
-    cliConfig.output = { ...cliConfig.output, style: options.style.toLowerCase() as RepomixOutputStyle };
+    cliConfig.output = {
+      ...cliConfig.output,
+      style: options.style.toLowerCase() as RepomixOutputStyle,
+    };
   }
   if (options.parsableStyle !== undefined) {
-    cliConfig.output = { ...cliConfig.output, parsableStyle: options.parsableStyle };
+    cliConfig.output = {
+      ...cliConfig.output,
+      parsableStyle: options.parsableStyle,
+    };
   }
   if (options.securityCheck !== undefined) {
     cliConfig.security = { enableSecurityCheck: options.securityCheck };
   }
   if (options.fileSummary !== undefined) {
-    cliConfig.output = { ...cliConfig.output, fileSummary: options.fileSummary };
+    cliConfig.output = {
+      ...cliConfig.output,
+      fileSummary: options.fileSummary,
+    };
   }
   if (options.directoryStructure !== undefined) {
-    cliConfig.output = { ...cliConfig.output, directoryStructure: options.directoryStructure };
+    cliConfig.output = {
+      ...cliConfig.output,
+      directoryStructure: options.directoryStructure,
+    };
   }
   if (options.removeComments !== undefined) {
-    cliConfig.output = { ...cliConfig.output, removeComments: options.removeComments };
+    cliConfig.output = {
+      ...cliConfig.output,
+      removeComments: options.removeComments,
+    };
   }
   if (options.removeEmptyLines !== undefined) {
-    cliConfig.output = { ...cliConfig.output, removeEmptyLines: options.removeEmptyLines };
+    cliConfig.output = {
+      ...cliConfig.output,
+      removeEmptyLines: options.removeEmptyLines,
+    };
   }
   if (options.headerText !== undefined) {
     cliConfig.output = { ...cliConfig.output, headerText: options.headerText };
@@ -143,10 +170,16 @@ const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
     cliConfig.tokenCount = { encoding: options.tokenCountEncoding };
   }
   if (options.instructionFilePath) {
-    cliConfig.output = { ...cliConfig.output, instructionFilePath: options.instructionFilePath };
+    cliConfig.output = {
+      ...cliConfig.output,
+      instructionFilePath: options.instructionFilePath,
+    };
   }
   if (options.includeEmptyDirectories) {
-    cliConfig.output = { ...cliConfig.output, includeEmptyDirectories: options.includeEmptyDirectories };
+    cliConfig.output = {
+      ...cliConfig.output,
+      includeEmptyDirectories: options.includeEmptyDirectories,
+    };
   }
 
   try {

--- a/src/cli/actions/remoteAction.ts
+++ b/src/cli/actions/remoteAction.ts
@@ -42,7 +42,7 @@ export const runRemoteAction = async (
     logger.log('');
 
     // Run the default action on the cloned repository
-    result = await deps.runDefaultAction(tempDirPath, tempDirPath, options);
+    result = await deps.runDefaultAction([tempDirPath], tempDirPath, options);
     await copyOutputToCurrentDirectory(tempDirPath, process.cwd(), result.config.output.filePath);
   } catch (error) {
     spinner.fail('Error during repository cloning. cleanup...');

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -43,7 +43,7 @@ export const run = async () => {
   try {
     program
       .description('Repomix - Pack your repository into a single AI-friendly file')
-      .arguments('[directories...]')
+      .argument('[directories...]', 'list of directories to process', ['.'])
       .option('-v, --version', 'show version information')
       .option('-o, --output <file>', 'specify the output file name')
       .option('--include <patterns>', 'list of include patterns (comma-separated)')
@@ -73,7 +73,7 @@ export const run = async () => {
       .option('--no-security-check', 'disable security check')
       .option('--instruction-file-path <path>', 'path to a file containing detailed custom instructions')
       .option('--include-empty-directories', 'include empty directories in the output')
-      .action((directories = ['.'], options: CliOptions = {}) => executeAction(directories, process.cwd(), options));
+      .action((directories, options: CliOptions = {}) => executeAction(directories, process.cwd(), options));
 
     await program.parseAsync(process.argv);
   } catch (error) {
@@ -83,6 +83,10 @@ export const run = async () => {
 
 export const executeAction = async (directories: string[], cwd: string, options: CliOptions) => {
   logger.setVerbose(options.verbose || false);
+
+  logger.trace('directories:', directories);
+  logger.trace('cwd:', cwd);
+  logger.trace('options:', options);
 
   if (options.version) {
     await runVersionAction();

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -43,7 +43,7 @@ export const run = async () => {
   try {
     program
       .description('Repomix - Pack your repository into a single AI-friendly file')
-      .arguments('[directory]')
+      .arguments('[directories...]')
       .option('-v, --version', 'show version information')
       .option('-o, --output <file>', 'specify the output file name')
       .option('--include <patterns>', 'list of include patterns (comma-separated)')
@@ -73,7 +73,7 @@ export const run = async () => {
       .option('--no-security-check', 'disable security check')
       .option('--instruction-file-path <path>', 'path to a file containing detailed custom instructions')
       .option('--include-empty-directories', 'include empty directories in the output')
-      .action((directory = '.', options: CliOptions = {}) => executeAction(directory, process.cwd(), options));
+      .action((directories = ['.'], options: CliOptions = {}) => executeAction(directories, process.cwd(), options));
 
     await program.parseAsync(process.argv);
   } catch (error) {
@@ -81,7 +81,7 @@ export const run = async () => {
   }
 };
 
-export const executeAction = async (directory: string, cwd: string, options: CliOptions) => {
+export const executeAction = async (directories: string[], cwd: string, options: CliOptions) => {
   logger.setVerbose(options.verbose || false);
 
   if (options.version) {
@@ -102,5 +102,5 @@ export const executeAction = async (directory: string, cwd: string, options: Cli
     return;
   }
 
-  await runDefaultAction(directory, cwd, options);
+  await runDefaultAction(directories, cwd, options);
 };

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -63,7 +63,7 @@ describe('defaultAction', () => {
       verbose: true,
     };
 
-    await runDefaultAction('.', process.cwd(), options);
+    await runDefaultAction(['.'], process.cwd(), options);
 
     expect(configLoader.loadFileConfig).toHaveBeenCalled();
     expect(configLoader.mergeConfigs).toHaveBeenCalled();
@@ -75,7 +75,7 @@ describe('defaultAction', () => {
       include: '*.js,*.ts',
     };
 
-    await runDefaultAction('.', process.cwd(), options);
+    await runDefaultAction(['.'], process.cwd(), options);
 
     expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
       process.cwd(),
@@ -91,7 +91,7 @@ describe('defaultAction', () => {
       ignore: 'node_modules,*.log',
     };
 
-    await runDefaultAction('.', process.cwd(), options);
+    await runDefaultAction(['.'], process.cwd(), options);
 
     expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
       process.cwd(),
@@ -109,7 +109,7 @@ describe('defaultAction', () => {
       style: 'xml',
     };
 
-    await runDefaultAction('.', process.cwd(), options);
+    await runDefaultAction(['.'], process.cwd(), options);
 
     expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
       process.cwd(),
@@ -127,7 +127,7 @@ describe('defaultAction', () => {
 
     const options: CliOptions = {};
 
-    await expect(runDefaultAction('.', process.cwd(), options)).rejects.toThrow('Test error');
+    await expect(runDefaultAction(['.'], process.cwd(), options)).rejects.toThrow('Test error');
   });
 
   describe('parsableStyle flag', () => {
@@ -136,7 +136,7 @@ describe('defaultAction', () => {
         parsableStyle: true,
       };
 
-      await runDefaultAction('.', process.cwd(), options);
+      await runDefaultAction(['.'], process.cwd(), options);
 
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
@@ -154,7 +154,7 @@ describe('defaultAction', () => {
         parsableStyle: false,
       };
 
-      await runDefaultAction('.', process.cwd(), options);
+      await runDefaultAction(['.'], process.cwd(), options);
 
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
@@ -174,7 +174,7 @@ describe('defaultAction', () => {
         securityCheck: false,
       };
 
-      await runDefaultAction('.', process.cwd(), options);
+      await runDefaultAction(['.'], process.cwd(), options);
 
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
@@ -192,7 +192,7 @@ describe('defaultAction', () => {
         securityCheck: true,
       };
 
-      await runDefaultAction('.', process.cwd(), options);
+      await runDefaultAction(['.'], process.cwd(), options);
 
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
@@ -212,7 +212,7 @@ describe('defaultAction', () => {
         fileSummary: false,
       };
 
-      await runDefaultAction('.', process.cwd(), options);
+      await runDefaultAction(['.'], process.cwd(), options);
 
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
@@ -230,7 +230,7 @@ describe('defaultAction', () => {
         fileSummary: true,
       };
 
-      await runDefaultAction('.', process.cwd(), options);
+      await runDefaultAction(['.'], process.cwd(), options);
 
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
@@ -250,7 +250,7 @@ describe('defaultAction', () => {
         directoryStructure: false,
       };
 
-      await runDefaultAction('.', process.cwd(), options);
+      await runDefaultAction(['.'], process.cwd(), options);
 
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
@@ -268,7 +268,7 @@ describe('defaultAction', () => {
         directoryStructure: true,
       };
 
-      await runDefaultAction('.', process.cwd(), options);
+      await runDefaultAction(['.'], process.cwd(), options);
 
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
@@ -288,7 +288,7 @@ describe('defaultAction', () => {
         removeComments: true,
       };
 
-      await runDefaultAction('.', process.cwd(), options);
+      await runDefaultAction(['.'], process.cwd(), options);
 
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
@@ -306,7 +306,7 @@ describe('defaultAction', () => {
         removeComments: false,
       };
 
-      await runDefaultAction('.', process.cwd(), options);
+      await runDefaultAction(['.'], process.cwd(), options);
 
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
@@ -326,7 +326,7 @@ describe('defaultAction', () => {
         removeEmptyLines: true,
       };
 
-      await runDefaultAction('.', process.cwd(), options);
+      await runDefaultAction(['.'], process.cwd(), options);
 
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
@@ -344,7 +344,7 @@ describe('defaultAction', () => {
         removeEmptyLines: false,
       };
 
-      await runDefaultAction('.', process.cwd(), options);
+      await runDefaultAction(['.'], process.cwd(), options);
 
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
@@ -364,7 +364,7 @@ describe('defaultAction', () => {
         gitignore: false,
       };
 
-      await runDefaultAction('.', process.cwd(), options);
+      await runDefaultAction(['.'], process.cwd(), options);
 
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
@@ -384,7 +384,7 @@ describe('defaultAction', () => {
         defaultPatterns: false,
       };
 
-      await runDefaultAction('.', process.cwd(), options);
+      await runDefaultAction(['.'], process.cwd(), options);
 
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
@@ -404,7 +404,7 @@ describe('defaultAction', () => {
         headerText: 'Another header text',
       };
 
-      await runDefaultAction('.', process.cwd(), options);
+      await runDefaultAction(['.'], process.cwd(), options);
 
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
@@ -424,7 +424,7 @@ describe('defaultAction', () => {
         instructionFilePath: 'path/to/instruction.txt',
       };
 
-      await runDefaultAction('.', process.cwd(), options);
+      await runDefaultAction(['.'], process.cwd(), options);
 
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
@@ -444,7 +444,7 @@ describe('defaultAction', () => {
         includeEmptyDirectories: true,
       };
 
-      await runDefaultAction('.', process.cwd(), options);
+      await runDefaultAction(['.'], process.cwd(), options);
 
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),

--- a/tests/cli/cliRun.test.ts
+++ b/tests/cli/cliRun.test.ts
@@ -125,33 +125,35 @@ describe('cliRun', () => {
 
   describe('executeAction', () => {
     test('should execute default action when no special options provided', async () => {
-      await executeAction('.', process.cwd(), {});
+      await executeAction(['.'], process.cwd(), {});
 
-      expect(defaultAction.runDefaultAction).toHaveBeenCalledWith('.', process.cwd(), expect.any(Object));
+      expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(['.'], process.cwd(), expect.any(Object));
     });
 
     test('should enable verbose logging when verbose option is true', async () => {
-      await executeAction('.', process.cwd(), { verbose: true });
+      await executeAction(['.'], process.cwd(), { verbose: true });
 
       expect(logger.setVerbose).toHaveBeenCalledWith(true);
     });
 
     test('should execute version action when version option is true', async () => {
-      await executeAction('.', process.cwd(), { version: true });
+      await executeAction(['.'], process.cwd(), { version: true });
 
       expect(versionAction.runVersionAction).toHaveBeenCalled();
       expect(defaultAction.runDefaultAction).not.toHaveBeenCalled();
     });
 
     test('should execute init action when init option is true', async () => {
-      await executeAction('.', process.cwd(), { init: true });
+      await executeAction(['.'], process.cwd(), { init: true });
 
       expect(initAction.runInitAction).toHaveBeenCalledWith(process.cwd(), false);
       expect(defaultAction.runDefaultAction).not.toHaveBeenCalled();
     });
 
     test('should execute remote action when remote option is provided', async () => {
-      await executeAction('.', process.cwd(), { remote: 'yamadashy/repomix' });
+      await executeAction(['.'], process.cwd(), {
+        remote: 'yamadashy/repomix',
+      });
 
       expect(remoteAction.runRemoteAction).toHaveBeenCalledWith('yamadashy/repomix', expect.any(Object));
       expect(defaultAction.runDefaultAction).not.toHaveBeenCalled();
@@ -160,10 +162,10 @@ describe('cliRun', () => {
 
   describe('parsable style flag', () => {
     test('should disable parsable style by default', async () => {
-      await executeAction('.', process.cwd(), {});
+      await executeAction(['.'], process.cwd(), {});
 
       expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
-        '.',
+        ['.'],
         process.cwd(),
         expect.not.objectContaining({
           parsableStyle: false,
@@ -172,10 +174,10 @@ describe('cliRun', () => {
     });
 
     test('should handle --parsable-style flag', async () => {
-      await executeAction('.', process.cwd(), { parsableStyle: true });
+      await executeAction(['.'], process.cwd(), { parsableStyle: true });
 
       expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
-        '.',
+        ['.'],
         process.cwd(),
         expect.objectContaining({
           parsableStyle: true,
@@ -186,10 +188,10 @@ describe('cliRun', () => {
 
   describe('security check flag', () => {
     test('should enable security check by default', async () => {
-      await executeAction('.', process.cwd(), {});
+      await executeAction(['.'], process.cwd(), {});
 
       expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
-        '.',
+        ['.'],
         process.cwd(),
         expect.not.objectContaining({
           securityCheck: false,
@@ -198,10 +200,10 @@ describe('cliRun', () => {
     });
 
     test('should handle --no-security-check flag', async () => {
-      await executeAction('.', process.cwd(), { securityCheck: false });
+      await executeAction(['.'], process.cwd(), { securityCheck: false });
 
       expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
-        '.',
+        ['.'],
         process.cwd(),
         expect.objectContaining({
           securityCheck: false,
@@ -210,10 +212,10 @@ describe('cliRun', () => {
     });
 
     test('should handle explicit --security-check flag', async () => {
-      await executeAction('.', process.cwd(), { securityCheck: true });
+      await executeAction(['.'], process.cwd(), { securityCheck: true });
 
       expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
-        '.',
+        ['.'],
         process.cwd(),
         expect.objectContaining({
           securityCheck: true,
@@ -222,10 +224,10 @@ describe('cliRun', () => {
     });
 
     test('should handle explicit --no-gitignore flag', async () => {
-      await executeAction('.', process.cwd(), { gitignore: false });
+      await executeAction(['.'], process.cwd(), { gitignore: false });
 
       expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
-        '.',
+        ['.'],
         process.cwd(),
         expect.objectContaining({
           gitignore: false,
@@ -234,10 +236,10 @@ describe('cliRun', () => {
     });
 
     test('should handle explicit --no-default-patterns flag', async () => {
-      await executeAction('.', process.cwd(), { defaultPatterns: false });
+      await executeAction(['.'], process.cwd(), { defaultPatterns: false });
 
       expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
-        '.',
+        ['.'],
         process.cwd(),
         expect.objectContaining({
           defaultPatterns: false,
@@ -246,10 +248,12 @@ describe('cliRun', () => {
     });
 
     test('should handle explicit --header-text flag', async () => {
-      await executeAction('.', process.cwd(), { headerText: 'I am a good header text' });
+      await executeAction(['.'], process.cwd(), {
+        headerText: 'I am a good header text',
+      });
 
       expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
-        '.',
+        ['.'],
         process.cwd(),
         expect.objectContaining({
           headerText: 'I am a good header text',
@@ -258,10 +262,12 @@ describe('cliRun', () => {
     });
 
     test('should handle --instruction-file-path flag', async () => {
-      await executeAction('.', process.cwd(), { instructionFilePath: 'path/to/instruction.txt' });
+      await executeAction(['.'], process.cwd(), {
+        instructionFilePath: 'path/to/instruction.txt',
+      });
 
       expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
-        '.',
+        ['.'],
         process.cwd(),
         expect.objectContaining({
           instructionFilePath: 'path/to/instruction.txt',
@@ -270,10 +276,12 @@ describe('cliRun', () => {
     });
 
     test('should handle --include-empty-directories flag', async () => {
-      await executeAction('.', process.cwd(), { includeEmptyDirectories: true });
+      await executeAction(['.'], process.cwd(), {
+        includeEmptyDirectories: true,
+      });
 
       expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
-        '.',
+        ['.'],
         process.cwd(),
         expect.objectContaining({
           includeEmptyDirectories: true,

--- a/tests/core/output/outputGenerate.test.ts
+++ b/tests/core/output/outputGenerate.test.ts
@@ -22,7 +22,7 @@ describe('outputGenerate', () => {
       { path: 'dir/file2.txt', content: 'content2' },
     ];
 
-    const output = await generateOutput(process.cwd(), mockConfig, mockProcessedFiles, []);
+    const output = await generateOutput([process.cwd()], mockConfig, mockProcessedFiles, []);
 
     expect(output).toContain('File Summary');
     expect(output).toContain('File: file1.txt');
@@ -48,15 +48,21 @@ describe('outputGenerate', () => {
       { path: 'dir/file2.txt', content: 'if (a && b)' },
     ];
 
-    const output = await generateOutput(process.cwd(), mockConfig, mockProcessedFiles, []);
+    const output = await generateOutput([process.cwd()], mockConfig, mockProcessedFiles, []);
 
     const parser = new XMLParser({ ignoreAttributes: false });
     const parsedOutput = parser.parse(output);
 
     expect(parsedOutput.repomix.file_summary).not.toBeUndefined();
     expect(parsedOutput.repomix.files.file).toEqual([
-      { '#text': mockProcessedFiles[0].content, '@_path': mockProcessedFiles[0].path },
-      { '#text': mockProcessedFiles[1].content, '@_path': mockProcessedFiles[1].path },
+      {
+        '#text': mockProcessedFiles[0].content,
+        '@_path': mockProcessedFiles[0].path,
+      },
+      {
+        '#text': mockProcessedFiles[1].content,
+        '@_path': mockProcessedFiles[1].path,
+      },
     ]);
   });
 
@@ -77,7 +83,7 @@ describe('outputGenerate', () => {
       { path: 'dir/file2.txt', content: '```\ncontent2\n```' },
     ];
 
-    const output = await generateOutput(process.cwd(), mockConfig, mockProcessedFiles, []);
+    const output = await generateOutput([process.cwd()], mockConfig, mockProcessedFiles, []);
 
     expect(output).toContain('# File Summary');
     expect(output).toContain('## File: file1.txt');

--- a/tests/core/output/outputStyles/plainStyle.test.ts
+++ b/tests/core/output/outputStyles/plainStyle.test.ts
@@ -23,7 +23,7 @@ describe('plainStyle', () => {
       },
     });
 
-    const output = await generateOutput(process.cwd(), mockConfig, [], []);
+    const output = await generateOutput([process.cwd()], mockConfig, [], []);
 
     expect(output).toContain('File Summary');
     expect(output).toContain('Directory Structure');

--- a/tests/core/output/outputStyles/xmlStyle.test.ts
+++ b/tests/core/output/outputStyles/xmlStyle.test.ts
@@ -23,7 +23,7 @@ describe('xmlStyle', () => {
       },
     });
 
-    const output = await generateOutput(process.cwd(), mockConfig, [], []);
+    const output = await generateOutput([process.cwd()], mockConfig, [], []);
 
     expect(output).toContain('file_summary');
     expect(output).toContain('directory_structure');

--- a/tests/core/packager.test.ts
+++ b/tests/core/packager.test.ts
@@ -69,7 +69,7 @@ describe('packager', () => {
 
     const mockConfig = createMockConfig();
     const progressCallback = vi.fn();
-    const result = await pack('root', mockConfig, progressCallback, mockDeps);
+    const result = await pack(['root'], mockConfig, progressCallback, mockDeps);
 
     expect(mockDeps.searchFiles).toHaveBeenCalledWith('root', mockConfig);
     expect(mockDeps.collectFiles).toHaveBeenCalledWith(mockFilePaths, 'root', progressCallback);
@@ -81,7 +81,7 @@ describe('packager', () => {
 
     expect(mockDeps.validateFileSafety).toHaveBeenCalledWith(mockRawFiles, progressCallback, mockConfig);
     expect(mockDeps.processFiles).toHaveBeenCalledWith(mockSafeRawFiles, mockConfig, progressCallback);
-    expect(mockDeps.generateOutput).toHaveBeenCalledWith('root', mockConfig, mockProcessedFiles, mockFilePaths);
+    expect(mockDeps.generateOutput).toHaveBeenCalledWith(['root'], mockConfig, mockProcessedFiles, mockFilePaths);
     expect(mockDeps.writeOutputToDisk).toHaveBeenCalledWith(mockOutput, mockConfig);
     expect(mockDeps.copyToClipboardIfEnabled).toHaveBeenCalledWith(mockOutput, progressCallback, mockConfig);
     expect(mockDeps.calculateMetrics).toHaveBeenCalledWith(

--- a/tests/integration-tests/packager.test.ts
+++ b/tests/integration-tests/packager.test.ts
@@ -31,12 +31,19 @@ const mockCollectFileInitTaskRunner = () => {
 
 describe.runIf(!isWindows)('packager integration', () => {
   const testCases = [
-    { desc: 'simple plain style', input: 'simple-project', output: 'simple-project-output.txt', config: {} },
+    {
+      desc: 'simple plain style',
+      input: 'simple-project',
+      output: 'simple-project-output.txt',
+      config: {},
+    },
     {
       desc: 'simple xml style',
       input: 'simple-project',
       output: 'simple-project-output.xml',
-      config: { output: { style: 'xml', filePath: 'simple-project-output.xml' } },
+      config: {
+        output: { style: 'xml', filePath: 'simple-project-output.xml' },
+      },
     },
   ];
 
@@ -67,7 +74,7 @@ describe.runIf(!isWindows)('packager integration', () => {
       });
 
       // Run the pack function
-      await pack(inputDir, mergedConfig, () => {}, {
+      await pack([inputDir], mergedConfig, () => {}, {
         searchFiles,
         collectFiles: (filePaths, rootDir, progressCallback) => {
           return collectFiles(filePaths, rootDir, progressCallback, {


### PR DESCRIPTION
On large projects, I will have files that are contextually related but in separate sub directories that I would like to bundle together. However, due to token limits, I don't necessarily want to find the closest common parent directory and bundle the entire thing. What I really wanted was an option to be able to pass in multiple directories as arguments and have repomix bundle them all together automatically, something like

```
repomix path/to/foo path/to/bar ...
```

This PR adds support for having the `directory` argument be an arbitrary number of directories instead of a single string and collects all of that into one output. 


```
➜  repomix git:(rc/multiple-dir-paths) npm run repomix src/cli src/core
```

yields 

```
➜  repomix git:(rc/multiple-dir-paths) cat repomix-output.xml | rg -U "<directory_structure>([\s\S]*?)</directory_structure>" -r '$1'

actions/
  defaultAction.ts
  initAction.ts
  migrationAction.ts
  remoteAction.ts
  versionAction.ts
file/
  workers/
    fileCollectWorker.ts
    fileProcessWorker.ts
  fileCollect.ts
  fileManipulate.ts
  filePathSort.ts
  fileProcess.ts
  fileSearch.ts
  fileTreeGenerate.ts
  fileTypes.ts
  gitCommand.ts
  packageJsonParse.ts
  permissionCheck.ts
metrics/
  workers/
    fileMetricsWorker.ts
    outputMetricsWorker.ts
    types.ts
  calculateAllFileMetrics.ts
  calculateMetrics.ts
  calculateOutputMetrics.ts
output/
  outputStyles/
    markdownStyle.ts
    plainStyle.ts
    xmlStyle.ts
  outputGenerate.ts
  outputGeneratorTypes.ts
  outputStyleDecorate.ts
packager/
  copyToClipboardIfEnabled.ts
  writeOutputToDisk.ts
security/
  workers/
    securityCheckWorker.ts
  filterOutUntrustedFiles.ts
  securityCheck.ts
  validateFileSafety.ts
tokenCount/
  tokenCount.ts
cliPrint.ts
cliRun.ts
cliSpinner.ts
packager.ts
```


## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
