### PR TITLE
readme: Mention the f2c alternative written in Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ If you're using Python, you might want to check out `Gitingest`, which is better
 science workflows:
 https://github.com/cyclotruc/gitingest
 
+The [f2c](https://github.com/LeanerCloud/f2c) tool is a more lightweight alternative written in Go that only supports the clipboard, without generating files. For Go projects it supports recursively looking into the current Go package using the Go AST to copy only a function's dependencies to the clipboard.
+
 ## 📊 Usage
 
 To pack your entire repository:


### PR DESCRIPTION
I just heard about repomix, a while ago I built a very similar tool in Go for my own use cases (funnily started working on it 10 days before the repomix first commit), mainly focusing on the clipboard operation, which is particularly useful for interactive use.

I recently also updated it to make it aware of Go projects using the Go AST package, copying recursively all the function and type definition dependencies of a given Go function to the clipboard.

<!-- Please include a summary of the changes -->

## Checklist

No, since this is just a readme change.

- [ ] Run `npm run test`
- [ ] Run `npm run lint`
