### PR TITLE
feat(remote): download and extract zip file if the remote is a GitHub URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "iconv-lite": "^0.6.3",
         "istextorbinary": "^9.5.0",
         "jschardet": "^3.1.4",
+        "jszip": "^3.10.1",
         "log-update": "^6.1.0",
         "minimatch": "^10.0.1",
         "picocolors": "^1.1.1",
@@ -2215,6 +2216,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2687,6 +2694,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -2696,6 +2709,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -2822,6 +2841,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2959,6 +2984,27 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lines-and-columns": {
@@ -3277,6 +3323,12 @@
       "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
       "dev": true
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse-json": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.1.tgz",
@@ -3445,6 +3497,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/protocols": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
@@ -3531,6 +3589,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/require-from-string": {
@@ -3723,6 +3796,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3762,6 +3841,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3914,6 +3999,15 @@
       "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -4395,6 +4489,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "iconv-lite": "^0.6.3",
     "istextorbinary": "^9.5.0",
     "jschardet": "^3.1.4",
+    "jszip": "^3.10.1",
     "log-update": "^6.1.0",
     "minimatch": "^10.0.1",
     "picocolors": "^1.1.1",

--- a/src/core/file/githubZipDownload.ts
+++ b/src/core/file/githubZipDownload.ts
@@ -1,0 +1,123 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import JSZip from 'jszip';
+import { RepomixError } from '../../shared/errorHandle.js';
+import { logger } from '../../shared/logger.js';
+
+export interface GitHubUrlInfo {
+  owner: string;
+  repo: string;
+  branch?: string;
+}
+
+export const VALID_NAME_PATTERN = '[a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9])?';
+export const validShorthandRegex = new RegExp(`^${VALID_NAME_PATTERN}/${VALID_NAME_PATTERN}$`);
+
+/**
+ * Check if value is GitHub shorthand format (e.g. owner/repo)
+ */
+export const isGitHubShorthand = (value: string): boolean => {
+  return validShorthandRegex.test(value);
+};
+
+/**
+ * Check if URL is a GitHub repository URL or shorthand
+ */
+export const isGitHubUrlOrShorthand = (value: string): boolean => {
+  return value.includes('github.com') || isGitHubShorthand(value);
+};
+
+/**
+ * Parse GitHub URL or shorthand to extract owner, repo and branch information
+ */
+export const parseGitHubUrl = (url: string): GitHubUrlInfo => {
+  // Handle shorthand format first
+  if (isGitHubShorthand(url)) {
+    const [owner, repo] = url.split('/');
+    return { owner, repo };
+  }
+
+  // Extract owner and repo from full URL
+  const repoMatch = url.match(/github\.com\/([^\/]+)\/([^\/\.]+)/);
+  if (!repoMatch) {
+    throw new RepomixError('Invalid GitHub repository URL');
+  }
+  const [, owner, repo] = repoMatch;
+
+  // Extract branch from URL if present
+  // First find the position of /tree/
+  const treeIndex = url.indexOf('/tree/');
+  if (treeIndex !== -1) {
+    // Extract everything after /tree/
+    const branch = url.slice(treeIndex + 6); // 6 is length of '/tree/'
+    return { owner, repo, branch };
+  }
+
+  return { owner, repo };
+};
+/**
+ * Build GitHub zip download URL
+ */
+export const buildZipUrl = (owner: string, repo: string, branch?: string): string => {
+  let zipUrl = `https://github.com/${owner}/${repo}/archive/`;
+  if (branch) {
+    zipUrl += `refs/heads/${branch}.zip`;
+  } else {
+    zipUrl += 'HEAD.zip';
+  }
+  return zipUrl;
+};
+
+/**
+ * Download and extract GitHub repository zip
+ */
+export const downloadGitHubZip = async (
+  url: string,
+  directory: string,
+  remoteBranch?: string,
+  deps = {
+    fetch: globalThis.fetch,
+    JSZip,
+  },
+): Promise<void> => {
+  const { owner, repo, branch } = parseGitHubUrl(url);
+  const effectiveBranch = remoteBranch || branch;
+  const zipUrl = buildZipUrl(owner, repo, effectiveBranch);
+
+  logger.trace(`Downloading zip from: ${zipUrl}`);
+
+  try {
+    // Download zip
+    const response = await deps.fetch(zipUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to download: ${response.statusText}`);
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    // Extract zip
+    const zip = await deps.JSZip.loadAsync(buffer);
+    const rootDirName = Object.keys(zip.files)[0]; // First entry is root directory
+
+    // Extract files
+    for (const [filename, file] of Object.entries(zip.files)) {
+      if (file.dir) continue;
+
+      // Remove root directory from path
+      const relativePath = filename.replace(rootDirName, '');
+      const targetPath = path.join(directory, relativePath);
+
+      // Ensure directory exists
+      await fs.mkdir(path.dirname(targetPath), { recursive: true });
+
+      // Extract file
+      const content = await file.async('nodebuffer');
+      await fs.writeFile(targetPath, content);
+    }
+
+    logger.trace('Zip extraction completed');
+  } catch (error) {
+    throw new RepomixError(`Failed to download or extract repository: ${(error as Error).message}`);
+  }
+};

--- a/tests/core/file/githubZipDownload.test.ts
+++ b/tests/core/file/githubZipDownload.test.ts
@@ -1,0 +1,374 @@
+import * as fs from 'node:fs/promises';
+import path from 'node:path';
+import type JSZip from 'jszip';
+import { type Mock, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  type GitHubUrlInfo,
+  buildZipUrl,
+  downloadGitHubZip,
+  isGitHubShorthand,
+  isGitHubUrlOrShorthand,
+  parseGitHubUrl,
+} from '../../../src/core/file/githubZipDownload.js';
+import { RepomixError } from '../../../src/shared/errorHandle.js';
+
+vi.mock('node:fs/promises');
+vi.mock('../../../src/shared/logger');
+
+describe('githubZipDownload', () => {
+  describe('isGitHubShorthand', () => {
+    test('should return true for valid shorthand formats', () => {
+      const validFormats = [
+        'user/repo',
+        'org-name/repo-name',
+        'user_name/repo_name',
+        'a.b/repo',
+        'MyUser123/MyRepo-123',
+        'user.name/repo.name',
+      ];
+
+      for (const format of validFormats) {
+        expect(isGitHubShorthand(format)).toBe(true);
+      }
+    });
+
+    test('should return false for invalid shorthand formats', () => {
+      const invalidFormats = [
+        'user', // Missing repo
+        '/repo', // Missing user
+        'user/', // Missing repo
+        '-user/repo', // User starts with hyphen
+        'user/-repo', // Repo starts with hyphen
+        'user./repo', // User ends with dot
+        'user/repo.', // Repo ends with dot
+        'user/repo#branch', // Contains invalid character
+        'user/repo/extra', // Extra path segment
+        'us!er/repo', // Contains invalid character
+        'user/re*po', // Contains invalid character
+        'user//repo', // Double slash
+        '.user/repo', // Starts with dot
+        'user/.repo', // Repo starts with dot
+        'https://github.com/user/repo', // Full URL
+        'git@github.com:user/repo.git', // SSH URL
+      ];
+
+      for (const format of invalidFormats) {
+        expect(isGitHubShorthand(format)).toBe(false);
+      }
+    });
+  });
+
+  describe('isGitHubUrlOrShorthand', () => {
+    test('should return true for GitHub URLs', () => {
+      const validUrls = [
+        'https://github.com/user/repo',
+        'http://github.com/user/repo',
+        'git@github.com:user/repo.git',
+        'git://github.com/user/repo.git',
+        'https://github.com/user/repo/tree/main',
+        'https://github.com/user/repo.git',
+      ];
+
+      for (const url of validUrls) {
+        expect(isGitHubUrlOrShorthand(url)).toBe(true);
+      }
+    });
+
+    test('should return true for GitHub shorthand', () => {
+      const validShorthands = ['user/repo', 'org-name/repo-name', 'user_name/repo_name', 'user.name/repo.name'];
+
+      for (const shorthand of validShorthands) {
+        expect(isGitHubUrlOrShorthand(shorthand)).toBe(true);
+      }
+    });
+
+    test('should return false for non-GitHub URLs and invalid formats', () => {
+      const invalidUrls = [
+        'https://gitlab.com/user/repo',
+        'https://bitbucket.org/user/repo',
+        'user',
+        '/repo',
+        'invalid-url',
+        'git@gitlab.com:user/repo.git',
+      ];
+
+      for (const url of invalidUrls) {
+        expect(isGitHubUrlOrShorthand(url)).toBe(false);
+      }
+    });
+  });
+
+  describe('parseGitHubUrl', () => {
+    test('should parse GitHub shorthand format', () => {
+      const inputs: [string, GitHubUrlInfo][] = [
+        ['user/repo', { owner: 'user', repo: 'repo' }],
+        ['org-name/repo-name', { owner: 'org-name', repo: 'repo-name' }],
+        ['user_name/repo_name', { owner: 'user_name', repo: 'repo_name' }],
+        ['user.name/repo.name', { owner: 'user.name', repo: 'repo.name' }],
+      ];
+
+      for (const [input, expected] of inputs) {
+        expect(parseGitHubUrl(input)).toEqual(expected);
+      }
+    });
+
+    test('should parse GitHub URLs', () => {
+      const inputs: [string, GitHubUrlInfo][] = [
+        ['https://github.com/user/repo', { owner: 'user', repo: 'repo' }],
+        ['http://github.com/user/repo', { owner: 'user', repo: 'repo' }],
+        ['https://github.com/user/repo.git', { owner: 'user', repo: 'repo' }],
+      ];
+
+      for (const [input, expected] of inputs) {
+        expect(parseGitHubUrl(input)).toEqual(expected);
+      }
+    });
+
+    test('should parse complex branch names', () => {
+      const cases = [
+        ['https://github.com/user/repo/tree/main', 'main'],
+        ['https://github.com/user/repo/tree/feature/branch', 'feature/branch'],
+        ['https://github.com/user/repo/tree/fix/issue-123/test', 'fix/issue-123/test'],
+        ['https://github.com/user/repo/tree/release/v1.0.0', 'release/v1.0.0'],
+        ['https://github.com/user/repo/tree/feat/add-support/for/deep/paths', 'feat/add-support/for/deep/paths'],
+      ];
+
+      for (const [input, expectedBranch] of cases) {
+        const result = parseGitHubUrl(input);
+        expect(result.branch).toBe(expectedBranch);
+      }
+    });
+
+    test('should throw for invalid URLs or formats', () => {
+      const invalidInputs = [
+        'https://gitlab.com/user/repo',
+        'user',
+        '/repo',
+        'user/',
+        'invalid-url',
+        'https://github.com/invalid',
+      ];
+
+      for (const input of invalidInputs) {
+        expect(() => parseGitHubUrl(input)).toThrow(RepomixError);
+      }
+    });
+  });
+
+  describe('buildZipUrl', () => {
+    test('should build URL for default branch (HEAD)', () => {
+      const urls: [string, string, string | undefined, string][] = [
+        ['user', 'repo', undefined, 'https://github.com/user/repo/archive/HEAD.zip'],
+        ['org-name', 'repo-name', undefined, 'https://github.com/org-name/repo-name/archive/HEAD.zip'],
+        ['user.name', 'repo.name', undefined, 'https://github.com/user.name/repo.name/archive/HEAD.zip'],
+      ];
+
+      for (const [owner, repo, branch, expected] of urls) {
+        expect(buildZipUrl(owner, repo, branch)).toBe(expected);
+      }
+    });
+
+    test('should build URL for specific branch', () => {
+      const urls = [
+        ['user', 'repo', 'main', 'https://github.com/user/repo/archive/refs/heads/main.zip'],
+        ['user', 'repo', 'develop', 'https://github.com/user/repo/archive/refs/heads/develop.zip'],
+        ['user', 'repo', 'feature/branch', 'https://github.com/user/repo/archive/refs/heads/feature/branch.zip'],
+        ['user', 'repo', 'v1.0.0', 'https://github.com/user/repo/archive/refs/heads/v1.0.0.zip'],
+      ];
+
+      for (const [owner, repo, branch, expected] of urls) {
+        expect(buildZipUrl(owner, repo, branch)).toBe(expected);
+      }
+    });
+  });
+
+  describe('downloadGitHubZip', () => {
+    const mockDirectory = '/test/dir';
+    type MockZipFile = {
+      dir: boolean;
+      async?: Mock;
+    };
+    const mockZipContent: Record<string, MockZipFile> = {
+      'repo-main/': { dir: true },
+      'repo-main/README.md': { dir: false, async: vi.fn() },
+      'repo-main/src/': { dir: true },
+      'repo-main/src/index.ts': { dir: false, async: vi.fn() },
+    };
+
+    beforeEach(() => {
+      vi.resetAllMocks();
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+    });
+
+    test('should download and extract zip successfully', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
+      });
+      const mockJSZip = {
+        loadAsync: vi.fn().mockResolvedValue({
+          files: mockZipContent,
+        }),
+        files: {},
+        file: vi.fn(),
+        folder: vi.fn(),
+        forEach: vi.fn(),
+        filter: vi.fn(),
+        remove: vi.fn(),
+        generateAsync: vi.fn(),
+        generateNodeStream: vi.fn(),
+        generateInternalStream: vi.fn(),
+        loadFile: vi.fn(),
+        support: {},
+      } as unknown as typeof JSZip;
+
+      // Mock file content async calls
+      const nonDirFiles = Object.values(mockZipContent).filter(
+        (file): file is MockZipFile & { async: Mock } => !file.dir && file.async !== undefined,
+      );
+      for (const file of nonDirFiles) {
+        file.async.mockResolvedValue(Buffer.from('test content'));
+      }
+
+      await downloadGitHubZip('yamadashy/repomix', mockDirectory, undefined, {
+        fetch: mockFetch,
+        JSZip: mockJSZip,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith('https://github.com/yamadashy/repomix/archive/HEAD.zip');
+      expect(mockJSZip.loadAsync).toHaveBeenCalled();
+      expect(fs.mkdir).toHaveBeenCalled();
+      expect(fs.writeFile).toHaveBeenCalled();
+    });
+
+    test('should handle HTTP error responses', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        statusText: 'Not Found',
+      });
+
+      await expect(
+        downloadGitHubZip('yamadashy/repomix', mockDirectory, undefined, {
+          fetch: mockFetch,
+          JSZip: {} as typeof JSZip,
+        }),
+      ).rejects.toThrow(RepomixError);
+    });
+
+    test('should handle network errors', async () => {
+      const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+      await expect(
+        downloadGitHubZip('yamadashy/repomix', mockDirectory, undefined, {
+          fetch: mockFetch,
+          JSZip: {} as typeof JSZip,
+        }),
+      ).rejects.toThrow(RepomixError);
+    });
+
+    test('should handle zip extraction errors', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
+      });
+      const mockJSZip = {
+        loadAsync: vi.fn().mockRejectedValue(new Error('Invalid zip file')),
+        files: {},
+        file: vi.fn(),
+        folder: vi.fn(),
+        forEach: vi.fn(),
+        filter: vi.fn(),
+        remove: vi.fn(),
+        generateAsync: vi.fn(),
+        generateNodeStream: vi.fn(),
+        generateInternalStream: vi.fn(),
+        loadFile: vi.fn(),
+        support: {},
+      } as unknown as typeof JSZip;
+
+      await expect(
+        downloadGitHubZip('yamadashy/repomix', mockDirectory, undefined, {
+          fetch: mockFetch,
+          JSZip: mockJSZip,
+        }),
+      ).rejects.toThrow(RepomixError);
+    });
+
+    test('should handle file system errors', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
+      });
+      const mockJSZip = {
+        loadAsync: vi.fn().mockResolvedValue({
+          files: mockZipContent,
+        }),
+        files: {},
+        file: vi.fn(),
+        folder: vi.fn(),
+        forEach: vi.fn(),
+        filter: vi.fn(),
+        remove: vi.fn(),
+        generateAsync: vi.fn(),
+        generateNodeStream: vi.fn(),
+        generateInternalStream: vi.fn(),
+        loadFile: vi.fn(),
+        support: {},
+      } as unknown as typeof JSZip;
+
+      const nonDirFiles = Object.values(mockZipContent).filter(
+        (file): file is MockZipFile & { async: Mock } => !file.dir && file.async !== undefined,
+      );
+      for (const file of nonDirFiles) {
+        file.async.mockResolvedValue(Buffer.from('test content'));
+      }
+
+      vi.mocked(fs.mkdir).mockRejectedValue(new Error('Permission denied'));
+
+      await expect(
+        downloadGitHubZip('yamadashy/repomix', mockDirectory, undefined, {
+          fetch: mockFetch,
+          JSZip: mockJSZip,
+        }),
+      ).rejects.toThrow(RepomixError);
+    });
+
+    test('should use specified branch for download', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
+      });
+      const mockJSZip = {
+        loadAsync: vi.fn().mockResolvedValue({
+          files: mockZipContent,
+        }),
+        files: {},
+        file: vi.fn(),
+        folder: vi.fn(),
+        forEach: vi.fn(),
+        filter: vi.fn(),
+        remove: vi.fn(),
+        generateAsync: vi.fn(),
+        generateNodeStream: vi.fn(),
+        generateInternalStream: vi.fn(),
+        loadFile: vi.fn(),
+        support: {},
+      } as unknown as typeof JSZip;
+
+      const nonDirFiles = Object.values(mockZipContent).filter(
+        (file): file is MockZipFile & { async: Mock } => !file.dir && file.async !== undefined,
+      );
+      for (const file of nonDirFiles) {
+        file.async.mockResolvedValue(Buffer.from('test content'));
+      }
+
+      await downloadGitHubZip('yamadashy/repomix', mockDirectory, 'develop', {
+        fetch: mockFetch,
+        JSZip: mockJSZip,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith('https://github.com/yamadashy/repomix/archive/refs/heads/develop.zip');
+    });
+  });
+});


### PR DESCRIPTION
This is an experimental PR.
Since GitHub allows downloading in zip format, it may be faster, so I will try it.
Also, this may make the remote function of repomix easier to use in the browser, even if only partially.

<!-- Please include a summary of the changes -->

## Checklist

- [ ] Run `npm run test`
- [ ] Run `npm run lint`
