### PR TITLE
feat: Add support for JSON5 in configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,9 +569,28 @@ Here's an explanation of the configuration options:
 
 | Option                           | Description                                                                                                                  | Default                |
 |----------------------------------|------------------------------------------------------------------------------------------------------------------------------|------------------------|
-// ...existing code...
+| `output.filePath`                | The name of the output file                                                                                                  | `"repomix-output.txt"` |
+| `output.style`                   | The style of the output (`plain`, `xml`, `markdown`)                                                                         | `"plain"`              |
+| `output.parsableStyle`           | Whether to escape the output based on the chosen style schema. Note that this can increase token count.                      | `false`                |
+| `output.compress`                | Whether to perform intelligent code extraction to reduce token count                                                         | `false`                |
+| `output.headerText`              | Custom text to include in the file header                                                                                    | `null`                 |
+| `output.instructionFilePath`     | Path to a file containing detailed custom instructions                                                                       | `null`                 |
+| `output.fileSummary`             | Whether to include a summary section at the beginning of the output                                                          | `true`                 |
+| `output.directoryStructure`      | Whether to include the directory structure in the output                                                                     | `true`                 |
+| `output.removeComments`          | Whether to remove comments from supported file types                                                                         | `false`                |
+| `output.removeEmptyLines`        | Whether to remove empty lines from the output                                                                                | `false`                |
+| `output.showLineNumbers`         | Whether to add line numbers to each line in the output                                                                       | `false`                |
+| `output.copyToClipboard`         | Whether to copy the output to system clipboard in addition to saving the file                                                | `false`                |
+| `output.topFilesLength`          | Number of top files to display in the summary. If set to 0, no summary will be displayed                                     | `5`                    |
+| `output.includeEmptyDirectories` | Whether to include empty directories in the repository structure                                                             | `false`                |
+| `include`                        | Patterns of files to include (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax))  | `[]`                   |
+| `ignore.useGitignore`            | Whether to use patterns from the project's `.gitignore` file                                                                 | `true`                 |
+| `ignore.useDefaultPatterns`      | Whether to use default ignore patterns                                                                                       | `true`                 |
+| `ignore.customPatterns`          | Additional patterns to ignore (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
+| `security.enableSecurityCheck`   | Whether to perform security checks on files                                                                                  | `true`                 |
+| `tokenCount.encoding`            | Token count encoding for AI model context limits (e.g., `o200k_base`, `cl100k_base`)                                         | `"o200k_base"`         |
 
-The configuration file supports JSON5 syntax, which allows:
+The configuration file supports [JSON5](https://json5.org/) syntax, which allows:
 - Comments (both single-line and multi-line)
 - Trailing commas in objects and arrays
 - Unquoted property names
@@ -581,39 +600,38 @@ Example configuration:
 
 ```json5
 {
-  // Output configuration
-  output: {
-    filePath: "repomix-output.xml",
-    style: "xml",
-    parsableStyle: true,
-    compress: false,
-    headerText: "Custom header information for the packed file.",
-    fileSummary: true,
-    directoryStructure: true,
-    removeComments: false,
-    removeEmptyLines: false,
-    showLineNumbers: false,
-    copyToClipboard: true,
-    topFilesLength: 5, // Number of top files to show
-    includeEmptyDirectories: false,
+  "output": {
+    "filePath": "repomix-output.xml",
+    "style": "xml",
+    "parsableStyle": true,
+    "compress": false,
+    "headerText": "Custom header information for the packed file.",
+    "fileSummary": true,
+    "directoryStructure": true,
+    "removeComments": false,
+    "removeEmptyLines": false,
+    "showLineNumbers": false,
+    "copyToClipboard": true,
+    "topFilesLength": 5,
+    "includeEmptyDirectories": false,
   },
-  include: [
-    "**/*",
+  "include": [
+    "**/*"
   ],
-  ignore: {
-    useGitignore: true,
-    useDefaultPatterns: true,
+  "ignore": {
+    "useGitignore": true,
+    "useDefaultPatterns": true,
     // Patterns can also be specified in .repomixignore
-    customPatterns: [
+    "customPatterns": [
       "additional-folder",
-      "**/*.log",
+      "**/*.log"
     ],
   },
-  security: {
-    enableSecurityCheck: true,
+  "security": {
+    "enableSecurityCheck": true
   },
-  tokenCount: {
-    encoding: "o200k_base",
+  "tokenCount": {
+    "encoding": "o200k_base"
   },
 }
 ```

--- a/README.md
+++ b/README.md
@@ -569,64 +569,52 @@ Here's an explanation of the configuration options:
 
 | Option                           | Description                                                                                                                  | Default                |
 |----------------------------------|------------------------------------------------------------------------------------------------------------------------------|------------------------|
-| `output.filePath`                | The name of the output file                                                                                                  | `"repomix-output.txt"` |
-| `output.style`                   | The style of the output (`plain`, `xml`, `markdown`)                                                                         | `"plain"`              |
-| `output.parsableStyle`           | Whether to escape the output based on the chosen style schema. Note that this can increase token count.                      | `false`                |
-| `output.compress`                | Whether to perform intelligent code extraction to reduce token count                                                         | `false`                |
-| `output.headerText`              | Custom text to include in the file header                                                                                    | `null`                 |
-| `output.instructionFilePath`     | Path to a file containing detailed custom instructions                                                                       | `null`                 |
-| `output.fileSummary`             | Whether to include a summary section at the beginning of the output                                                          | `true`                 |
-| `output.directoryStructure`      | Whether to include the directory structure in the output                                                                     | `true`                 |
-| `output.removeComments`          | Whether to remove comments from supported file types                                                                         | `false`                |
-| `output.removeEmptyLines`        | Whether to remove empty lines from the output                                                                                | `false`                |
-| `output.showLineNumbers`         | Whether to add line numbers to each line in the output                                                                       | `false`                |
-| `output.copyToClipboard`         | Whether to copy the output to system clipboard in addition to saving the file                                                | `false`                |
-| `output.topFilesLength`          | Number of top files to display in the summary. If set to 0, no summary will be displayed                                     | `5`                    |
-| `output.includeEmptyDirectories` | Whether to include empty directories in the repository structure                                                             | `false`                |
-| `include`                        | Patterns of files to include (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax))  | `[]`                   |
-| `ignore.useGitignore`            | Whether to use patterns from the project's `.gitignore` file                                                                 | `true`                 |
-| `ignore.useDefaultPatterns`      | Whether to use default ignore patterns                                                                                       | `true`                 |
-| `ignore.customPatterns`          | Additional patterns to ignore (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
-| `security.enableSecurityCheck`   | Whether to perform security checks on files                                                                                  | `true`                 |
-| `tokenCount.encoding`            | Token count encoding for AI model context limits (e.g., `o200k_base`, `cl100k_base`)                                         | `"o200k_base"`         |
+// ...existing code...
+
+The configuration file supports JSON5 syntax, which allows:
+- Comments (both single-line and multi-line)
+- Trailing commas in objects and arrays
+- Unquoted property names
+- More relaxed string syntax
 
 Example configuration:
 
 ```json5
 {
-  "output": {
-    "filePath": "repomix-output.xml",
-    "style": "xml",
-    "parsableStyle": true,
-    "compress": false,
-    "headerText": "Custom header information for the packed file.",
-    "fileSummary": true,
-    "directoryStructure": true,
-    "removeComments": false,
-    "removeEmptyLines": false,
-    "showLineNumbers": false,
-    "copyToClipboard": true,
-    "topFilesLength": 5,
-    "includeEmptyDirectories": false
+  // Output configuration
+  output: {
+    filePath: "repomix-output.xml",
+    style: "xml",
+    parsableStyle: true,
+    compress: false,
+    headerText: "Custom header information for the packed file.",
+    fileSummary: true,
+    directoryStructure: true,
+    removeComments: false,
+    removeEmptyLines: false,
+    showLineNumbers: false,
+    copyToClipboard: true,
+    topFilesLength: 5, // Number of top files to show
+    includeEmptyDirectories: false,
   },
-  "include": [
-    "**/*"
+  include: [
+    "**/*",
   ],
-  "ignore": {
-    "useGitignore": true,
-    "useDefaultPatterns": true,
+  ignore: {
+    useGitignore: true,
+    useDefaultPatterns: true,
     // Patterns can also be specified in .repomixignore
-    "customPatterns": [
+    customPatterns: [
       "additional-folder",
-      "**/*.log"
-    ]
+      "**/*.log",
+    ],
   },
-  "security": {
-    "enableSecurityCheck": true
+  security: {
+    enableSecurityCheck: true,
   },
-  "tokenCount": {
-    "encoding": "o200k_base"
-  }
+  tokenCount: {
+    encoding: "o200k_base",
+  },
 }
 ```
 

--- a/biome.json
+++ b/biome.json
@@ -48,7 +48,11 @@
   },
   "json": {
     "parser": {
-      "allowComments": true
+      "allowComments": true,
+      "allowTrailingCommas": true
+    },
+    "formatter": {
+      "enabled": false
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "iconv-lite": "^0.6.3",
         "istextorbinary": "^9.5.0",
         "jschardet": "^3.1.4",
+        "json5": "^2.2.3",
         "log-update": "^6.1.0",
         "minimatch": "^10.0.1",
         "picocolors": "^1.1.1",
@@ -2954,7 +2955,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "iconv-lite": "^0.6.3",
     "istextorbinary": "^9.5.0",
     "jschardet": "^3.1.4",
+    "json5": "^2.2.3",
     "log-update": "^6.1.0",
     "minimatch": "^10.0.1",
     "picocolors": "^1.1.1",

--- a/repomix.config.json
+++ b/repomix.config.json
@@ -11,19 +11,19 @@
     "removeEmptyLines": false,
     "topFilesLength": 5,
     "showLineNumbers": false,
-    "includeEmptyDirectories": true
+    "includeEmptyDirectories": true,
   },
   "include": [],
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,
     // ignore is specified in .repomixignore
-    "customPatterns": []
+    "customPatterns": [],
   },
   "security": {
-    "enableSecurityCheck": true
+    "enableSecurityCheck": true,
   },
   "tokenCount": {
-    "encoding": "o200k_base"
+    "encoding": "o200k_base",
   }
 }

--- a/src/config/configLoad.ts
+++ b/src/config/configLoad.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs/promises';
 import path from 'node:path';
 import pc from 'picocolors';
-import stripJsonComments from 'strip-json-comments';
+import JSON5 from 'json5';
 import { RepomixError, rethrowValidationErrorIfZodError } from '../shared/errorHandle.js';
 import { logger } from '../shared/logger.js';
 import {
@@ -70,12 +70,12 @@ export const loadFileConfig = async (rootDir: string, argConfigPath: string | nu
 const loadAndValidateConfig = async (filePath: string): Promise<RepomixConfigFile> => {
   try {
     const fileContent = await fs.readFile(filePath, 'utf-8');
-    const config = JSON.parse(stripJsonComments(fileContent));
+    const config = JSON5.parse(fileContent);
     return repomixConfigFileSchema.parse(config);
   } catch (error) {
     rethrowValidationErrorIfZodError(error, 'Invalid config schema');
     if (error instanceof SyntaxError) {
-      throw new RepomixError(`Invalid JSON in config file ${filePath}: ${error.message}`);
+      throw new RepomixError(`Invalid JSON5 in config file ${filePath}: ${error.message}`);
     }
     if (error instanceof Error) {
       throw new RepomixError(`Error loading config from ${filePath}: ${error.message}`);

--- a/src/config/configLoad.ts
+++ b/src/config/configLoad.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs/promises';
 import path from 'node:path';
-import pc from 'picocolors';
 import JSON5 from 'json5';
+import pc from 'picocolors';
 import { RepomixError, rethrowValidationErrorIfZodError } from '../shared/errorHandle.js';
 import { logger } from '../shared/logger.js';
 import {

--- a/tests/config/configLoad.test.ts
+++ b/tests/config/configLoad.test.ts
@@ -107,6 +107,37 @@ describe('configLoad', () => {
         ignore: { useGitignore: true },
       });
     });
+
+    test('should parse config file with JSON5 features', async () => {
+      const configWithJSON5Features = `{
+        // Output configuration
+        output: {
+          filePath: 'test-output.txt',
+          style: 'plain',
+        },
+        /* Ignore configuration */
+        ignore: {
+          useGitignore: true, // Use .gitignore file
+          customPatterns: [
+            '*.log',
+            '*.tmp',
+            '*.temp', // Trailing comma
+          ],
+        },
+      }`;
+
+      vi.mocked(fs.readFile).mockResolvedValue(configWithJSON5Features);
+      vi.mocked(fs.stat).mockResolvedValue({ isFile: () => true } as Stats);
+
+      const result = await loadFileConfig(process.cwd(), 'test-config.json');
+      expect(result).toEqual({
+        output: { filePath: 'test-output.txt', style: 'plain' },
+        ignore: { 
+          useGitignore: true,
+          customPatterns: ['*.log', '*.tmp', '*.temp']
+        },
+      });
+    });
   });
 
   describe('mergeConfigs', () => {

--- a/tests/config/configLoad.test.ts
+++ b/tests/config/configLoad.test.ts
@@ -132,9 +132,9 @@ describe('configLoad', () => {
       const result = await loadFileConfig(process.cwd(), 'test-config.json');
       expect(result).toEqual({
         output: { filePath: 'test-output.txt', style: 'plain' },
-        ignore: { 
+        ignore: {
           useGitignore: true,
-          customPatterns: ['*.log', '*.tmp', '*.temp']
+          customPatterns: ['*.log', '*.tmp', '*.temp'],
         },
       });
     });


### PR DESCRIPTION
Closes #346

## Description
This PR adds support for JSON5 in configuration files, allowing for a more flexible and developer-friendly configuration experience.

### Changes
- Replace JSON.parse with JSON5.parse for configuration file loading
- Update tests to cover JSON5 features (comments, trailing commas)
- Update documentation to reflect JSON5 support
- Add json5 package as a dependency

### Testing
- Added new test cases specifically for JSON5 features
- Tested with configuration files containing comments and trailing commas
- Verified backward compatibility with standard JSON

### Documentation
- Updated README.md to document JSON5 support and features
- Added example configuration using JSON5 syntax