### PR TITLE
fix(remote): ensure output directories exist before file writing

### DIFF
--- a/src/cli/actions/remoteAction.ts
+++ b/src/cli/actions/remoteAction.ts
@@ -157,6 +157,10 @@ export const copyOutputToCurrentDirectory = async (
 
   try {
     logger.trace(`Copying output file from: ${sourcePath} to: ${targetPath}`);
+
+    // Create target directory if it doesn't exist
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+
     await fs.copyFile(sourcePath, targetPath);
   } catch (error) {
     throw new RepomixError(`Failed to copy output file: ${(error as Error).message}`);

--- a/src/core/packager/writeOutputToDisk.ts
+++ b/src/core/packager/writeOutputToDisk.ts
@@ -7,5 +7,9 @@ import { logger } from '../../shared/logger.js';
 export const writeOutputToDisk = async (output: string, config: RepomixConfigMerged): Promise<undefined> => {
   const outputPath = path.resolve(config.cwd, config.output.filePath);
   logger.trace(`Writing output to: ${outputPath}`);
+
+  // Create output directory if it doesn't exist
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+
   await fs.writeFile(outputPath, output);
 };

--- a/tests/cli/actions/remoteAction.test.ts
+++ b/tests/cli/actions/remoteAction.test.ts
@@ -15,6 +15,7 @@ vi.mock('node:fs/promises', async (importOriginal) => {
   return {
     ...actual,
     copyFile: vi.fn(),
+    mkdir: vi.fn(),
   };
 });
 vi.mock('../../../src/shared/logger');


### PR DESCRIPTION
<!-- Please include a summary of the changes -->

When using nested output paths (e.g. `--output docs/nested/file.xml`), the tool fails because parent directories are not automatically created. This PR fixes the issue by ensuring folders exist before writing files.

related: #378

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
