### PR TITLE
fix(option): properly handle "false" config values for --no-* options

### DIFF
--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -88,6 +88,15 @@ export const runDefaultAction = async (
   };
 };
 
+/**
+ * Builds CLI configuration from command-line options.
+ *
+ * Note: Due to Commander.js behavior with --no-* flags:
+ * - When --no-* flags are used (e.g., --no-file-summary), the options explicitly become false
+ * - When no flag is specified, Commander defaults to true (e.g., options.fileSummary === true)
+ * - For --no-* flags, we only apply the setting when it's explicitly false to respect config file values
+ * - This allows the config file to maintain control unless explicitly overridden by CLI
+ */
 const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
   const cliConfig: RepomixConfigCli = {};
 
@@ -100,10 +109,12 @@ const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
   if (options.ignore) {
     cliConfig.ignore = { customPatterns: options.ignore.split(',') };
   }
-  if (options.gitignore !== undefined) {
+  // Only apply gitignore setting if explicitly set to false
+  if (options.gitignore === false) {
     cliConfig.ignore = { ...cliConfig.ignore, useGitignore: options.gitignore };
   }
-  if (options.defaultPatterns !== undefined) {
+  // Only apply defaultPatterns setting if explicitly set to false
+  if (options.defaultPatterns === false) {
     cliConfig.ignore = {
       ...cliConfig.ignore,
       useDefaultPatterns: options.defaultPatterns,
@@ -136,19 +147,22 @@ const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
       parsableStyle: options.parsableStyle,
     };
   }
-  if (options.securityCheck !== undefined) {
+  // Only apply securityCheck setting if explicitly set to false
+  if (options.securityCheck === false) {
     cliConfig.security = { enableSecurityCheck: options.securityCheck };
   }
-  if (options.fileSummary !== undefined) {
+  // Only apply fileSummary setting if explicitly set to false
+  if (options.fileSummary === false) {
     cliConfig.output = {
       ...cliConfig.output,
-      fileSummary: options.fileSummary,
+      fileSummary: false,
     };
   }
-  if (options.directoryStructure !== undefined) {
+  // Only apply directoryStructure setting if explicitly set to false
+  if (options.directoryStructure === false) {
     cliConfig.output = {
       ...cliConfig.output,
-      directoryStructure: options.directoryStructure,
+      directoryStructure: false,
     };
   }
   if (options.removeComments !== undefined) {

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -198,11 +198,75 @@ describe('defaultAction', () => {
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
         expect.anything(),
+        expect.objectContaining({}),
+      );
+    });
+  });
+
+  describe('gitignore flag', () => {
+    it('should handle explicit --no-gitignore flag', async () => {
+      const options: CliOptions = {
+        gitignore: false,
+      };
+
+      await runDefaultAction(['.'], process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
         expect.objectContaining({
-          security: {
-            enableSecurityCheck: true,
+          ignore: {
+            useGitignore: false,
           },
         }),
+      );
+    });
+
+    it('should handle explicit --no-gitignore flag', async () => {
+      const options: CliOptions = {
+        gitignore: false,
+      };
+
+      await runDefaultAction(['.'], process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
+        expect.objectContaining({}),
+      );
+    });
+  });
+
+  describe('defaultPatterns flag', () => {
+    it('should handle explicit --no-default-patterns flag', async () => {
+      const options: CliOptions = {
+        defaultPatterns: false,
+      };
+
+      await runDefaultAction(['.'], process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
+        expect.objectContaining({
+          ignore: {
+            useDefaultPatterns: false,
+          },
+        }),
+      );
+    });
+
+    it('should handle explicit --no-default-patterns flag', async () => {
+      const options: CliOptions = {
+        defaultPatterns: false,
+      };
+
+      await runDefaultAction(['.'], process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
+        expect.objectContaining({}),
       );
     });
   });
@@ -236,11 +300,7 @@ describe('defaultAction', () => {
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
         expect.anything(),
-        expect.objectContaining({
-          output: {
-            fileSummary: true,
-          },
-        }),
+        expect.objectContaining({}),
       );
     });
   });
@@ -274,11 +334,7 @@ describe('defaultAction', () => {
       expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
         process.cwd(),
         expect.anything(),
-        expect.objectContaining({
-          output: {
-            directoryStructure: true,
-          },
-        }),
+        expect.objectContaining({}),
       );
     });
   });
@@ -353,46 +409,6 @@ describe('defaultAction', () => {
         expect.objectContaining({
           output: {
             removeEmptyLines: false,
-          },
-        }),
-      );
-    });
-  });
-
-  describe('gitignore flag', () => {
-    it('should handle explicit --no-gitignore flag', async () => {
-      const options: CliOptions = {
-        gitignore: false,
-      };
-
-      await runDefaultAction(['.'], process.cwd(), options);
-
-      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
-        process.cwd(),
-        expect.anything(),
-        expect.objectContaining({
-          ignore: {
-            useGitignore: false,
-          },
-        }),
-      );
-    });
-  });
-
-  describe('defaultPatterns flag', () => {
-    it('should handle explicit --no-default-patterns flag', async () => {
-      const options: CliOptions = {
-        defaultPatterns: false,
-      };
-
-      await runDefaultAction(['.'], process.cwd(), options);
-
-      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
-        process.cwd(),
-        expect.anything(),
-        expect.objectContaining({
-          ignore: {
-            useDefaultPatterns: false,
           },
         }),
       );


### PR DESCRIPTION
<!-- Please include a summary of the changes -->

related: #385

- Issue #385 reported that setting `"fileSummary": false` in the config file doesn't work
- The file summary still appeared in the output despite the config setting
- Investigation showed this affects all `--no-*` style CLI options

## Root Cause
- Commander.js sets options to `true` by default when not specified
- Our code was applying settings whenever `options.xyz !== undefined`
- This meant config file settings weren't being respected because CLI options always had a value

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
