### PR TITLE
Use the contents of .git/info/exclude when useGitignore is set to true. Fixes #375

### DIFF
--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -220,5 +220,22 @@ export const getIgnorePatterns = async (rootDir: string, config: RepomixConfigMe
     }
   }
 
+  // Add patterns from .git/info/exclude if useGitignore is enabled
+  if (config.ignore.useGitignore) {
+    const excludeFilePath = path.join(rootDir, '.git/info/exclude');
+
+    try {
+      const excludeFileContent = await fs.readFile(excludeFilePath, 'utf8');
+      const excludePatterns = parseIgnoreContent(excludeFileContent);
+
+      for (const pattern of excludePatterns) {
+        ignorePatterns.add(pattern);
+      }
+    } catch (error) {
+      // File might not exist or might not be accessible, which is fine
+      logger.trace('Could not read .git/info/exclude file:', error instanceof Error ? error.message : String(error));
+    }
+  }
+
   return Array.from(ignorePatterns);
 };

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -222,7 +222,7 @@ export const getIgnorePatterns = async (rootDir: string, config: RepomixConfigMe
 
   // Add patterns from .git/info/exclude if useGitignore is enabled
   if (config.ignore.useGitignore) {
-    const excludeFilePath = path.join(rootDir, '.git/info/exclude');
+    const excludeFilePath = path.join(rootDir, '.git', 'info', 'exclude');
 
     try {
       const excludeFileContent = await fs.readFile(excludeFilePath, 'utf8');

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -143,6 +143,35 @@ describe('fileSearch', () => {
       expect(patterns).toContain('*.custom');
       expect(patterns).toContain('temp/');
     });
+
+    test('should include patterns from .git/info/exclude when useGitignore is true', async () => {
+      const mockConfig = createMockConfig({
+        ignore: {
+          useGitignore: true,
+          useDefaultPatterns: false,
+          customPatterns: [],
+        },
+      });
+
+      const mockExcludeContent = `
+# Test exclude file
+*.ignored
+temp-files/
+`;
+
+      vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
+        if (filePath.toString().endsWith('.git/info/exclude')) {
+          return mockExcludeContent;
+        }
+        return '';
+      });
+
+      const patterns = await getIgnorePatterns('/mock/root', mockConfig);
+
+      // Only test for the exclude file patterns
+      expect(patterns).toContain('*.ignored');
+      expect(patterns).toContain('temp-files/');
+    });
   });
 
   describe('parseIgnoreContent', () => {

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -160,7 +160,9 @@ temp-files/
 `;
 
       vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
-        if (filePath.toString().endsWith('.git/info/exclude')) {
+        // Use path.join to create platform-specific path for testing
+        const excludePath = path.join('.git', 'info', 'exclude');
+        if (filePath.toString().endsWith(excludePath)) {
           return mockExcludeContent;
         }
         return '';


### PR DESCRIPTION
## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
