### PR TITLE
allow ! ( and ) in ignorePatterns via website

### DIFF
--- a/website/server/src/schemas/request.ts
+++ b/website/server/src/schemas/request.ts
@@ -2,8 +2,8 @@ import { isValidRemoteValue } from 'repomix';
 import { z } from 'zod';
 
 // Regular expression to validate ignore patterns
-// Allowed characters: alphanumeric, *, ?, /, -, _, ., space, comma
-const ignorePatternRegex = /^[a-zA-Z0-9*?\/\-_., ]*$/;
+// Allowed characters: alphanumeric, *, ?, /, -, _, ., !, (, ), space, comma
+const ignorePatternRegex = /^[a-zA-Z0-9*?\/\-_.,!()\s]*$/;
 
 export const packOptionsSchema = z
   .object({


### PR DESCRIPTION
Allow `!` `(` and `)` in ignorePatterns submitted via the website.

These are useful if you want to have a pattern like `!.(cursor)/**` which ignores all dot-prefixed folders in the root *except* `.cursor/`.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`


## Manual test

you can manually test that negations `!` and parentheses `()` are not just valid but useful in the ignorePattern using this script:

```
#!/bin/bash

# Set up error handling
set -e

# Create a temporary test directory
echo "📁 Creating test directory structure..."
TEST_DIR="repomix-test"
mkdir -p "$TEST_DIR"
cd "$TEST_DIR"

# Create test directories and files
echo "📝 Creating test files..."
mkdir -p .hidden .cursor .git
echo "Hidden file content" > .hidden/file.txt
echo "Cursor file content" > .cursor/file.txt
echo "Git file content" > .git/file.txt
echo "Regular file content" > regular.txt

# Create repomix config
echo "⚙️ Creating repomix configuration..."
cat > repomix.config.json << 'EOF'
{
  "output": {
    "filePath": "test-output.txt"
  },
  "ignore": {
    "useGitignore": false,
    "useDefaultPatterns": false,
    "customPatterns": [
      "**/.!(cursor)/**"
    ]
  }
}
EOF

# Show the created structure
echo -e "\n📂 Created directory structure:"
ls -la

# Run repomix
echo -e "\n🚀 Running repomix..."
npx repomix -c repomix.config.json

# Show the contents of the output file
echo -e "\n📄 Contents of test-output.txt:"
cat test-output.txt

# Clean up
echo -e "\n🧹 Cleaning up..."
cd ..
rm -rf "$TEST_DIR"

echo -e "\n✨ Demo completed successfully!" 
```