### PR TITLE
feat(mcp): Added the ability to read files and directories to MCP. Files that are read are checked by Secretlint.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "rimraf": "^6.0.1",
         "secretlint": "^9.2.0",
         "typescript": "^5.8.2",
-        "vite": "^5.4.14",
         "vitest": "^3.0.8"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "rimraf": "^6.0.1",
     "secretlint": "^9.2.0",
     "typescript": "^5.8.2",
-    "vite": "^5.4.14",
     "vitest": "^3.0.8"
   },
   "engines": {

--- a/src/cli/actions/mcpAction.ts
+++ b/src/cli/actions/mcpAction.ts
@@ -1,4 +1,4 @@
-import { runMcpServer } from '../../core/mcp/mcpServer.js';
+import { runMcpServer } from '../../mcp/mcpServer.js';
 import { logger } from '../../shared/logger.js';
 
 export const runMcpAction = async (): Promise<void> => {

--- a/src/core/security/workers/securityCheckWorker.ts
+++ b/src/core/security/workers/securityCheckWorker.ts
@@ -8,6 +8,11 @@ export interface SecurityCheckTask {
   content: string;
 }
 
+export interface SuspiciousFileResult {
+  filePath: string;
+  messages: string[];
+}
+
 export default async ({ filePath, content }: SecurityCheckTask) => {
   const config = createSecretLintConfig();
 
@@ -27,7 +32,11 @@ export default async ({ filePath, content }: SecurityCheckTask) => {
   }
 };
 
-export const runSecretLint = async (filePath: string, content: string, config: SecretLintCoreConfig) => {
+export const runSecretLint = async (
+  filePath: string,
+  content: string,
+  config: SecretLintCoreConfig,
+): Promise<SuspiciousFileResult | null> => {
   const result = await lintSource({
     source: {
       filePath: filePath,

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -1,7 +1,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { logger } from '../shared/logger.js';
 import { getVersion } from '../core/file/packageJsonParse.js';
+import { logger } from '../shared/logger.js';
+import { registerPackRemoteRepositoryPrompt } from './prompts/packRemoteRepositoryPrompts.js';
 import { registerPackCodebaseTool } from './tools/packCodebaseTool.js';
 import { registerPackRemoteRepositoryTool } from './tools/packRemoteRepositoryTool.js';
 import { registerReadRepomixOutputTool } from './tools/readRepomixOutputTool.js';
@@ -11,6 +12,9 @@ export const createMcpServer = async () => {
     name: 'repomix-mcp-server',
     version: await getVersion(),
   });
+
+  // Register the prompts
+  registerPackRemoteRepositoryPrompt(mcpServer);
 
   // Register the tools
   registerPackCodebaseTool(mcpServer);

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -3,6 +3,8 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { getVersion } from '../core/file/packageJsonParse.js';
 import { logger } from '../shared/logger.js';
 import { registerPackRemoteRepositoryPrompt } from './prompts/packRemoteRepositoryPrompts.js';
+import { registerFileSystemReadDirectoryTool } from './tools/fileSystemReadDirectoryTool.js';
+import { registerFileSystemReadFileTool } from './tools/fileSystemReadFileTool.js';
 import { registerPackCodebaseTool } from './tools/packCodebaseTool.js';
 import { registerPackRemoteRepositoryTool } from './tools/packRemoteRepositoryTool.js';
 import { registerReadRepomixOutputTool } from './tools/readRepomixOutputTool.js';
@@ -20,6 +22,8 @@ export const createMcpServer = async () => {
   registerPackCodebaseTool(mcpServer);
   registerPackRemoteRepositoryTool(mcpServer);
   registerReadRepomixOutputTool(mcpServer);
+  registerFileSystemReadFileTool(mcpServer);
+  registerFileSystemReadDirectoryTool(mcpServer);
 
   return mcpServer;
 };

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { logger } from '../../shared/logger.js';
-import { getVersion } from '../file/packageJsonParse.js';
+import { logger } from '../shared/logger.js';
+import { getVersion } from '../core/file/packageJsonParse.js';
 import { registerPackCodebaseTool } from './tools/packCodebaseTool.js';
 import { registerPackRemoteRepositoryTool } from './tools/packRemoteRepositoryTool.js';
 import { registerReadRepomixOutputTool } from './tools/readRepomixOutputTool.js';

--- a/src/mcp/prompts/packRemoteRepositoryPrompts.ts
+++ b/src/mcp/prompts/packRemoteRepositoryPrompts.ts
@@ -1,0 +1,52 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+/**
+ * Register Repomix-related prompts to the MCP server
+ */
+export const registerPackRemoteRepositoryPrompt = (mcpServer: McpServer) => {
+  // Pack Remote Repository Prompt
+  mcpServer.prompt(
+    'pack_remote_repository',
+    'Pack a remote GitHub repository for analysis',
+    {
+      repository: z.string().describe('GitHub repository URL or owner/repo format (e.g., "yamadashy/repomix")'),
+      includePatterns: z
+        .string()
+        .optional()
+        .describe('Comma-separated list of glob patterns to include (e.g., "src/**,lib/**")'),
+      ignorePatterns: z
+        .string()
+        .optional()
+        .describe('Comma-separated list of glob patterns to ignore (e.g., "**/*.test.js,**/*.spec.js")'),
+    },
+    async ({ repository, includePatterns, ignorePatterns }) => {
+      // Convert compress string to boolean
+      return {
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: `Please analyze the GitHub repository at ${repository}.
+
+First, use the pack_remote_repository tool with these parameters:
+- repository: "${repository}"
+${includePatterns ? `- includePatterns: "${includePatterns}"` : ''}
+${ignorePatterns ? `- ignorePatterns: "${ignorePatterns}"` : ''}
+
+Once you have the packed repository:
+1. Read the code using the outputId from the tool response
+2. Give me a high-level overview of this project
+3. Explain its architecture and main components
+4. Identify the key technologies and dependencies used
+5. Highlight any interesting patterns or design decisions
+
+Please be thorough in your analysis.`,
+            },
+          },
+        ],
+      };
+    },
+  );
+};

--- a/src/mcp/tools/fileSystemReadDirectoryTool.ts
+++ b/src/mcp/tools/fileSystemReadDirectoryTool.ts
@@ -1,0 +1,93 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import { logger } from '../../shared/logger.js';
+
+/**
+ * Register file system directory listing tool
+ */
+export const registerFileSystemReadDirectoryTool = (mcpServer: McpServer) => {
+  mcpServer.tool(
+    'file_system_read_directory',
+    'List contents of a directory using an absolute path.',
+    {
+      path: z.string().describe('Absolute path to the directory to list'),
+    },
+    async ({ path: directoryPath }): Promise<CallToolResult> => {
+      try {
+        logger.trace(`Listing directory at absolute path: ${directoryPath}`);
+
+        // Ensure path is absolute
+        if (!path.isAbsolute(directoryPath)) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: `Error: Path must be absolute. Received: ${directoryPath}`,
+              },
+            ],
+          };
+        }
+
+        // Check if directory exists
+        try {
+          const stats = await fs.stat(directoryPath);
+          if (!stats.isDirectory()) {
+            return {
+              isError: true,
+              content: [
+                {
+                  type: 'text',
+                  text: `Error: The specified path is not a directory: ${directoryPath}. Use file_system_read_file for files.`,
+                },
+              ],
+            };
+          }
+        } catch {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: `Error: Directory not found at path: ${directoryPath}`,
+              },
+            ],
+          };
+        }
+
+        // Read directory contents
+        const entries = await fs.readdir(directoryPath, { withFileTypes: true });
+        const formatted = entries
+          .map((entry) => `${entry.isDirectory() ? '[DIR]' : '[FILE]'} ${entry.name}`)
+          .join('\n');
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Contents of ${directoryPath}:`,
+            },
+            {
+              type: 'text',
+              text: formatted || '(empty directory)',
+            },
+          ],
+        };
+      } catch (error) {
+        logger.error(`Error in file_system_read_directory tool: ${error}`);
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `Error listing directory: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    },
+  );
+};

--- a/src/mcp/tools/fileSystemReadFileTool.ts
+++ b/src/mcp/tools/fileSystemReadFileTool.ts
@@ -1,0 +1,112 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { SuspiciousFileResult } from '../../core/security/securityCheck.js';
+import { createSecretLintConfig, runSecretLint } from '../../core/security/workers/securityCheckWorker.js';
+import { logger } from '../../shared/logger.js';
+
+/**
+ * Register file system read file tool with security checks
+ */
+export const registerFileSystemReadFileTool = (mcpServer: McpServer) => {
+  mcpServer.tool(
+    'file_system_read_file',
+    'Read a file using an absolute path with security validation.',
+    {
+      path: z.string().describe('Absolute path to the file to read'),
+    },
+    async ({ path: filePath }): Promise<CallToolResult> => {
+      try {
+        logger.trace(`Reading file at absolute path: ${filePath}`);
+
+        // Ensure path is absolute
+        if (!path.isAbsolute(filePath)) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: `Error: Path must be absolute. Received: ${filePath}`,
+              },
+            ],
+          };
+        }
+
+        // Check if file exists
+        try {
+          await fs.access(filePath);
+        } catch {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: `Error: File not found at path: ${filePath}`,
+              },
+            ],
+          };
+        }
+
+        // Check if it's a directory
+        const stats = await fs.stat(filePath);
+        if (stats.isDirectory()) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: `Error: The specified path is a directory, not a file: ${filePath}. Use file_system_read_directory for directories.`,
+              },
+            ],
+          };
+        }
+
+        // Read file content
+        const fileContent = await fs.readFile(filePath, 'utf8');
+
+        // Perform security check using the existing worker
+        const config = createSecretLintConfig();
+        const securityCheckResult = await runSecretLint(filePath, fileContent, config);
+
+        // If security check found issues, block the file
+        if (securityCheckResult !== null) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: `Error: Security check failed. The file at ${filePath} may contain sensitive information.`,
+              },
+            ],
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Content of ${filePath}:`,
+            },
+            {
+              type: 'text',
+              text: fileContent,
+            },
+          ],
+        };
+      } catch (error) {
+        logger.error(`Error in file_system_read_file tool: ${error}`);
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `Error reading file: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    },
+  );
+};

--- a/src/mcp/tools/mcpToolRuntime.ts
+++ b/src/mcp/tools/mcpToolRuntime.ts
@@ -114,7 +114,7 @@ export const formatToolResponse = (
       },
       {
         type: 'text',
-        text: `To read the full contents of the packed codebase when direct file access is not possible (e.g., in web environments or sandboxed applications), use the read_repomix_output tool with the outputId: ${outputId}`,
+        text: `For environments without direct file access (e.g., web browsers or sandboxed apps), use the read_repomix_output tool with this outputId: ${outputId} to access the packed codebase contents.`,
       },
     ],
   };

--- a/src/mcp/tools/mcpToolRuntime.ts
+++ b/src/mcp/tools/mcpToolRuntime.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { logger } from '../../../shared/logger.js';
+import { logger } from '../../shared/logger.js';
 
 // Map to store generated output files
 const outputFileRegistry = new Map<string, string>();

--- a/src/mcp/tools/packCodebaseTool.ts
+++ b/src/mcp/tools/packCodebaseTool.ts
@@ -2,8 +2,8 @@ import path from 'node:path';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
-import { runCli } from '../../../cli/cliRun.js';
-import type { CliOptions } from '../../../cli/types.js';
+import { runCli } from '../../cli/cliRun.js';
+import type { CliOptions } from '../../cli/types.js';
 import { createToolWorkspace, formatToolError, formatToolResponse } from './mcpToolRuntime.js';
 
 export const registerPackCodebaseTool = (mcpServer: McpServer) => {

--- a/src/mcp/tools/packRemoteRepositoryTool.ts
+++ b/src/mcp/tools/packRemoteRepositoryTool.ts
@@ -2,8 +2,8 @@ import path from 'node:path';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
-import { runCli } from '../../../cli/cliRun.js';
-import type { CliOptions } from '../../../cli/types.js';
+import { runCli } from '../../cli/cliRun.js';
+import type { CliOptions } from '../../cli/types.js';
 import { createToolWorkspace, formatToolError, formatToolResponse } from './mcpToolRuntime.js';
 
 export const registerPackRemoteRepositoryTool = (mcpServer: McpServer) => {

--- a/src/mcp/tools/readRepomixOutputTool.ts
+++ b/src/mcp/tools/readRepomixOutputTool.ts
@@ -11,7 +11,7 @@ import { getOutputFilePath } from './mcpToolRuntime.js';
 export const registerReadRepomixOutputTool = (mcpServer: McpServer) => {
   mcpServer.tool(
     'read_repomix_output',
-    'Read the contents of a Repomix output file when direct file access is not possible. Use this tool when the client cannot access the file system directly, such as in web-based environments or sandboxed applications.',
+    'Read the contents of a Repomix output file in environments where direct file access is not possible. This tool is specifically intended for cases where the client cannot access the file system directly, such as in web-based environments or sandboxed applications. For systems with direct file access, use standard file operations instead.',
     {
       outputId: z.string().describe('ID of the Repomix output file to read'),
     },

--- a/src/mcp/tools/readRepomixOutputTool.ts
+++ b/src/mcp/tools/readRepomixOutputTool.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
-import { logger } from '../../../shared/logger.js';
+import { logger } from '../../shared/logger.js';
 import { getOutputFilePath } from './mcpToolRuntime.js';
 
 /**


### PR DESCRIPTION
<!-- Please include a summary of the changes -->

pack with compress
<img width="756" alt="スクリーンショット 2025-03-15 14 28 28" src="https://github.com/user-attachments/assets/48780368-20eb-49ac-beba-ecb61db7861e" />

read
<img width="749" alt="スクリーンショット 2025-03-15 14 29 23" src="https://github.com/user-attachments/assets/27ac4c4d-468e-4c0d-b0a4-88b78c47cb0a" />


## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
