### PR TITLE
feat(file): add C++ file extensions support for comment stripping

### DIFF
--- a/src/core/file/fileManipulate.ts
+++ b/src/core/file/fileManipulate.ts
@@ -51,7 +51,7 @@ class CppManipulator extends BaseManipulator {
 
     result = result
       .split('\n')
-      .map(line => {
+      .map((line) => {
         const tripleSlashIndex = line.indexOf('///');
         if (tripleSlashIndex !== -1) {
           return line.substring(0, tripleSlashIndex).trimEnd();

--- a/src/core/file/fileManipulate.ts
+++ b/src/core/file/fileManipulate.ts
@@ -42,6 +42,28 @@ class StripCommentsManipulator extends BaseManipulator {
   }
 }
 
+class CppManipulator extends BaseManipulator {
+  removeComments(content: string): string {
+    let result = strip(content, {
+      language: 'c',
+      preserveNewlines: true,
+    });
+
+    result = result
+      .split('\n')
+      .map(line => {
+        const tripleSlashIndex = line.indexOf('///');
+        if (tripleSlashIndex !== -1) {
+          return line.substring(0, tripleSlashIndex).trimEnd();
+        }
+        return line;
+      })
+      .join('\n');
+
+    return rtrimLines(result);
+  }
+}
+
 class PythonManipulator extends BaseManipulator {
   removeDocStrings(content: string): string {
     if (!content) return '';
@@ -168,10 +190,10 @@ class CompositeManipulator extends BaseManipulator {
 const manipulators: Record<string, FileManipulator> = {
   '.c': new StripCommentsManipulator('c'),
   '.h': new StripCommentsManipulator('c'),
-  '.hpp': new StripCommentsManipulator('c'),
-  '.cpp': new StripCommentsManipulator('c'),
-  '.cc': new StripCommentsManipulator('c'),
-  '.cxx': new StripCommentsManipulator('c'),
+  '.hpp': new CppManipulator(),
+  '.cpp': new CppManipulator(),
+  '.cc': new CppManipulator(),
+  '.cxx': new CppManipulator(),
   '.cs': new StripCommentsManipulator('csharp'),
   '.css': new StripCommentsManipulator('css'),
   '.dart': new StripCommentsManipulator('c'),

--- a/src/core/file/fileManipulate.ts
+++ b/src/core/file/fileManipulate.ts
@@ -167,6 +167,11 @@ class CompositeManipulator extends BaseManipulator {
 
 const manipulators: Record<string, FileManipulator> = {
   '.c': new StripCommentsManipulator('c'),
+  '.h': new StripCommentsManipulator('c'),
+  '.hpp': new StripCommentsManipulator('c'),
+  '.cpp': new StripCommentsManipulator('c'),
+  '.cc': new StripCommentsManipulator('c'),
+  '.cxx': new StripCommentsManipulator('c'),
   '.cs': new StripCommentsManipulator('csharp'),
   '.css': new StripCommentsManipulator('css'),
   '.dart': new StripCommentsManipulator('c'),

--- a/tests/core/file/fileManipulate.test.ts
+++ b/tests/core/file/fileManipulate.test.ts
@@ -868,6 +868,59 @@ describe('fileManipulate', () => {
         </style>
 `,
     },
+    {
+      name: 'C++ triple slash comment removal (.cpp)',
+      ext: '.cpp',
+      input: `
+        /// Triple slash documentation comment
+        #include <iostream>
+        // Single line comment
+        int main() {
+          std::cout << "Hello, world!" << std::endl; /// Inline triple slash comment
+          return 0; // Normal comment
+        }
+      `,
+      expected: `
+
+        #include <iostream>
+
+        int main() {
+          std::cout << "Hello, world!" << std::endl;
+          return 0;
+        }
+`,
+    },
+    {
+      name: 'C++ triple slash comment removal (.hpp)',
+      ext: '.hpp',
+      input: `
+        /// Class documentation with triple slash
+        class Test {
+          public:
+            /// Method documentation
+            void method();
+            int value; /// Variable documentation
+        };
+      `,
+      expected: `
+
+        class Test {
+          public:
+
+            void method();
+            int value;
+        };
+`,
+    },
+    {
+      name: 'C++ triple slash comment removal',
+      ext: '.cpp',
+      input: `
+        /// This is a triple slash comment.\n        int foo = 1; /// Another triple slash comment.\n// Regular single line comment\n/* Multi-line\n   comment */\nint bar = 2; /// Comment with trailing spaces  \n`,
+      expected: `
+
+        int foo = 1;\n\n\n\nint bar = 2;\n`,
+    },
   ];
 
   for (const { name, ext, input, expected } of testCases) {

--- a/tests/core/file/fileManipulate.test.ts
+++ b/tests/core/file/fileManipulate.test.ts
@@ -24,6 +24,138 @@ describe('fileManipulate', () => {
 `,
     },
     {
+      name: 'C++ header file comment removal',
+      ext: '.h',
+      input: `
+        // Single line comment
+        #ifndef MY_HEADER_H
+        #define MY_HEADER_H
+        /* Multi-line
+           comment block */
+        class MyClass {
+          // Method comment
+          void method();
+          /**
+           * Documentation comment
+           */
+          int value;
+        };
+        #endif // MY_HEADER_H
+      `,
+      expected: `
+
+        #ifndef MY_HEADER_H
+        #define MY_HEADER_H
+
+
+        class MyClass {
+
+          void method();
+
+
+
+          int value;
+        };
+        #endif
+`,
+    },
+    {
+      name: 'C++ source file comment removal',
+      ext: '.cc',
+      input: `
+        // Single line comment
+        #include "myheader.h"
+        /* Multi-line
+           comment block */
+        void MyClass::method() {
+          // Implementation comment
+          /* Another
+             multi-line comment */
+          int x = 0; // Inline comment
+        }
+      `,
+      expected: `
+
+        #include "myheader.h"
+
+
+        void MyClass::method() {
+
+
+
+          int x = 0;
+        }
+`,
+    },
+    {
+      name: 'C++ .cpp file comment removal',
+      ext: '.cpp',
+      input: `
+        // Single line comment
+        #include <iostream>
+        /* Multi-line
+           comment block */
+        int main() {
+          // Implementation comment
+          std::cout << "Hello, world!" << std::endl; // Inline comment
+          /* Another
+             multi-line comment */
+          return 0;
+        }
+      `,
+      expected: `
+
+        #include <iostream>
+
+
+        int main() {
+
+          std::cout << "Hello, world!" << std::endl;
+
+
+          return 0;
+        }
+`,
+    },
+    {
+      name: 'C++ .hpp file comment removal',
+      ext: '.hpp',
+      input: `
+        // Single line comment
+        #pragma once
+        /* Multi-line
+           comment block */
+        namespace test {
+          // Class comment
+          template <typename T>
+          class Test {
+            /**
+             * Documentation comment
+             */
+            public:
+              T value;
+          };
+        } // namespace test
+      `,
+      expected: `
+
+        #pragma once
+
+
+        namespace test {
+
+          template <typename T>
+          class Test {
+
+
+
+            public:
+              T value;
+          };
+        }
+`,
+    },
+    {
       name: 'C# comment removal',
       ext: '.cs',
       input: `


### PR DESCRIPTION
- Add support for .h, .hpp, .cpp, .cc, and .cxx file extensions
- Configure all C++ extensions to use the existing C comment stripper
- Add comprehensive test cases for each supported C++ extension
- Verify correct handling of various comment styles in each file type

This enhancement improves code processing capabilities for C++ projects.

<!-- Please include a summary of the changes -->

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
