### PR TITLE
Trim whitespace in comma-separated glob patterns

### DIFF
--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -104,10 +104,10 @@ export const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
     cliConfig.output = { filePath: options.output };
   }
   if (options.include) {
-    cliConfig.include = options.include.split(',').map(pattern => pattern.trim());
+    cliConfig.include = options.include.split(',').map((pattern) => pattern.trim());
   }
   if (options.ignore) {
-    cliConfig.ignore = { customPatterns: options.ignore.split(',').map(pattern => pattern.trim()) };
+    cliConfig.ignore = { customPatterns: options.ignore.split(',').map((pattern) => pattern.trim()) };
   }
   // Only apply gitignore setting if explicitly set to false
   if (options.gitignore === false) {

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -97,17 +97,17 @@ export const runDefaultAction = async (
  * - For --no-* flags, we only apply the setting when it's explicitly false to respect config file values
  * - This allows the config file to maintain control unless explicitly overridden by CLI
  */
-const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
+export const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
   const cliConfig: RepomixConfigCli = {};
 
   if (options.output) {
     cliConfig.output = { filePath: options.output };
   }
   if (options.include) {
-    cliConfig.include = options.include.split(',');
+    cliConfig.include = options.include.split(',').map(pattern => pattern.trim());
   }
   if (options.ignore) {
-    cliConfig.ignore = { customPatterns: options.ignore.split(',') };
+    cliConfig.ignore = { customPatterns: options.ignore.split(',').map(pattern => pattern.trim()) };
   }
   // Only apply gitignore setting if explicitly set to false
   if (options.gitignore === false) {

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -480,13 +480,13 @@ describe('defaultAction', () => {
   });
 
   it('should properly trim whitespace from comma-separated patterns', () => {
-  const options = {
-    include: 'src/**/*,  tests/**/*,   examples/**/*',
-    ignore: 'node_modules/**,  dist/**,  coverage/**',
-  };
-  const config = buildCliConfig(options as unknown as CliOptions);
-  
-  expect(config.include).toEqual(['src/**/*', 'tests/**/*', 'examples/**/*']);
-  expect(config.ignore?.customPatterns).toEqual(['node_modules/**', 'dist/**', 'coverage/**']);
-});
+    const options = {
+      include: 'src/**/*,  tests/**/*,   examples/**/*',
+      ignore: 'node_modules/**,  dist/**,  coverage/**',
+    };
+    const config = buildCliConfig(options as unknown as CliOptions);
+
+    expect(config.include).toEqual(['src/**/*', 'tests/**/*', 'examples/**/*']);
+    expect(config.ignore?.customPatterns).toEqual(['node_modules/**', 'dist/**', 'coverage/**']);
+  });
 });

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -1,6 +1,6 @@
 import process from 'node:process';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { runDefaultAction } from '../../../src/cli/actions/defaultAction.js';
+import { buildCliConfig, runDefaultAction } from '../../../src/cli/actions/defaultAction.js';
 import type { CliOptions } from '../../../src/cli/types.js';
 import * as configLoader from '../../../src/config/configLoad.js';
 import * as packageJsonParser from '../../../src/core/file/packageJsonParse.js';
@@ -478,4 +478,15 @@ describe('defaultAction', () => {
       );
     });
   });
+
+  it('should properly trim whitespace from comma-separated patterns', () => {
+  const options = {
+    include: 'src/**/*,  tests/**/*,   examples/**/*',
+    ignore: 'node_modules/**,  dist/**,  coverage/**',
+  };
+  const config = buildCliConfig(options as unknown as CliOptions);
+  
+  expect(config.include).toEqual(['src/**/*', 'tests/**/*', 'examples/**/*']);
+  expect(config.ignore?.customPatterns).toEqual(['node_modules/**', 'dist/**', 'coverage/**']);
+});
 });


### PR DESCRIPTION
Fixes an issue where whitespace after commas in CLI pattern arguments wasn't being trimmed, causing unexpected behavior with ignore patterns. Users can now write more readable comma-separated patterns with spaces (e.g., --ignore "pattern1,  pattern2") and have them correctly parsed, improving usability and making the CLI behavior more intuitive.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
