### PR TITLE
Fix missing doc update for default switch to XML

### DIFF
--- a/website/client/src/de/guide/command-line-options.md
+++ b/website/client/src/de/guide/command-line-options.md
@@ -5,7 +5,7 @@
 
 ## Ausgabeoptionen
 - `-o, --output <file>`: Ausgabedateiname (Standard: `repomix-output.txt`)
-- `--style <type>`: Ausgabeformat (`plain`, `xml`, `markdown`) (Standard: `plain`)
+- `--style <type>`: Ausgabeformat (`plain`, `xml`, `markdown`) (Standard: `xml`)
 - `--parsable-style`: Aktiviert parsbare Ausgabe basierend auf dem gewählten Formatschema (Standard: `false`)
 - `--compress`: Führt eine intelligente Code-Extraktion durch, die sich auf Funktions- und Klassensignaturen konzentriert und Implementierungsdetails entfernt. Weitere Details und Beispiele finden Sie im [Code-Komprimierungsleitfaden](code-compress)
 - `--output-show-line-numbers`: Fügt Zeilennummern hinzu (Standard: `false`)

--- a/website/client/src/en/guide/command-line-options.md
+++ b/website/client/src/en/guide/command-line-options.md
@@ -5,7 +5,7 @@
 
 ## Output Options
 - `-o, --output <file>`: Output file name (default: `repomix-output.txt`)
-- `--style <type>`: Output style (`plain`, `xml`, `markdown`) (default: `plain`)
+- `--style <type>`: Output style (`plain`, `xml`, `markdown`) (default: `xml`)
 - `--parsable-style`: Enable parsable output based on the chosen style schema (default: `false`)
 - `--compress`: Perform intelligent code extraction, focusing on essential function and class signatures while removing implementation details. For more details and examples, see [Code Compression Guide](code-compress).
 - `--output-show-line-numbers`: Add line numbers (default: `false`)

--- a/website/client/src/es/guide/command-line-options.md
+++ b/website/client/src/es/guide/command-line-options.md
@@ -5,7 +5,7 @@
 
 ## Opciones de Salida
 - `-o, --output <file>`: Nombre del archivo de salida (predeterminado: `repomix-output.txt`)
-- `--style <type>`: Estilo de salida (`plain`, `xml`, `markdown`) (predeterminado: `plain`)
+- `--style <type>`: Estilo de salida (`plain`, `xml`, `markdown`) (predeterminado: `xml`)
 - `--parsable-style`: Habilita la salida analizable basada en el esquema del estilo elegido (predeterminado: `false`)
 - `--compress`: Realiza una extracción inteligente de código, centrándose en las firmas de funciones y clases mientras elimina los detalles de implementación. Para más detalles y ejemplos, consulte la [Guía de Compresión de Código](code-compress)
 - `--output-show-line-numbers`: Agrega números de línea (predeterminado: `false`)

--- a/website/client/src/fr/guide/command-line-options.md
+++ b/website/client/src/fr/guide/command-line-options.md
@@ -5,7 +5,7 @@
 
 ## Options de sortie
 - `-o, --output <fichier>`: Nom du fichier de sortie (par défaut: `repomix-output.txt`)
-- `--style <type>`: Style de sortie (`plain`, `xml`, `markdown`) (par défaut: `plain`)
+- `--style <type>`: Style de sortie (`plain`, `xml`, `markdown`) (par défaut: `xml`)
 - `--parsable-style`: Activer une sortie analysable basée sur le schéma du style choisi (par défaut: `false`)
 - `--compress`: Effectuer une extraction intelligente du code, en se concentrant sur les signatures essentielles de fonctions et de classes tout en supprimant les détails d'implémentation. Pour plus de détails et d'exemples, voir [Guide de compression de code](code-compress).
 - `--output-show-line-numbers`: Ajouter les numéros de ligne (par défaut: `false`)

--- a/website/client/src/ja/guide/command-line-options.md
+++ b/website/client/src/ja/guide/command-line-options.md
@@ -5,7 +5,7 @@
 
 ## 出力オプション
 - `-o, --output <file>`: 出力ファイル名（デフォルト: `repomix-output.txt`）
-- `--style <type>`: 出力形式（`plain`、`xml`、`markdown`）（デフォルト: `plain`）
+- `--style <type>`: 出力形式（`plain`、`xml`、`markdown`）（デフォルト: `xml`）
 - `--parsable-style`: 選択した形式のスキーマに基づいて解析可能な出力を有効化（デフォルト: `false`）
 - `--compress`: 関数やクラスのシグネチャなどの重要な構造を保持しながら、実装の詳細を削除するインテリジェントなコード抽出を実行します。詳細と例については、[コード圧縮ガイド](code-compress)を参照してください。
 - `--output-show-line-numbers`: 行番号を追加（デフォルト: `false`）

--- a/website/client/src/ja/index.md
+++ b/website/client/src/ja/index.md
@@ -153,11 +153,11 @@ docker run -v ./output:/app -it --rm ghcr.io/yamadashy/repomix --remote https://
 LLMによっては得意・不得意があるので、適切なフォーマットを選択してください。
 
 ```bash
-# プレーンテキストフォーマット（デフォルト）
+# プレーンテキストフォーマット
 repomix --style plain
 
 # XMLフォーマット
-repomix --style xml
+repomix --style xml（デフォルト）
 
 # Markdownフォーマット
 repomix --style markdown

--- a/website/client/src/ja/index.md
+++ b/website/client/src/ja/index.md
@@ -153,14 +153,14 @@ docker run -v ./output:/app -it --rm ghcr.io/yamadashy/repomix --remote https://
 LLMによっては得意・不得意があるので、適切なフォーマットを選択してください。
 
 ```bash
-# プレーンテキストフォーマット
-repomix --style plain
-
-# XMLフォーマット
-repomix --style xml（デフォルト）
+# XMLフォーマット（デフォルト）
+repomix --style xml
 
 # Markdownフォーマット
 repomix --style markdown
+
+# プレーンテキストフォーマット
+repomix --style plain
 ```
 
 ### カスタマイズ

--- a/website/client/src/ko/guide/command-line-options.md
+++ b/website/client/src/ko/guide/command-line-options.md
@@ -5,7 +5,7 @@
 
 ## 출력 옵션
 - `-o, --output <file>`: 출력 파일 이름 (기본값: `repomix-output.txt`)
-- `--style <type>`: 출력 스타일 (`plain`, `xml`, `markdown`) (기본값: `plain`)
+- `--style <type>`: 출력 스타일 (`plain`, `xml`, `markdown`) (기본값: `xml`)
 - `--parsable-style`: 선택한 스타일 스키마에 기반한 파싱 가능한 출력 활성화 (기본값: `false`)
 - `--compress`: 함수와 클래스 시그니처에 중점을 두고 구현 세부 사항을 제거하는 지능형 코드 추출을 수행합니다. 자세한 내용과 예제는 [코드 압축 가이드](code-compress)를 참조하세요.
 - `--output-show-line-numbers`: 줄 번호 추가 (기본값: `false`)

--- a/website/client/src/pt-br/guide/command-line-options.md
+++ b/website/client/src/pt-br/guide/command-line-options.md
@@ -5,7 +5,7 @@
 
 ## Opções de Saída
 - `-o, --output <file>`: Nome do arquivo de saída (padrão: `repomix-output.txt`)
-- `--style <type>`: Estilo de saída (`plain`, `xml`, `markdown`) (padrão: `plain`)
+- `--style <type>`: Estilo de saída (`plain`, `xml`, `markdown`) (padrão: `xml`)
 - `--parsable-style`: Habilita saída analisável baseada no esquema do estilo escolhido (padrão: `false`)
 - `--compress`: Realiza extração inteligente de código, focando nas assinaturas de funções e classes enquanto remove detalhes de implementação. Para mais detalhes e exemplos, consulte o [Guia de Compressão de Código](code-compress)
 - `--output-show-line-numbers`: Adiciona números de linha (padrão: `false`)

--- a/website/client/src/zh-cn/guide/command-line-options.md
+++ b/website/client/src/zh-cn/guide/command-line-options.md
@@ -5,7 +5,7 @@
 
 ## 输出选项
 - `-o, --output <file>`: 输出文件名（默认：`repomix-output.txt`）
-- `--style <type>`: 输出样式（`plain`、`xml`、`markdown`）（默认：`plain`）
+- `--style <type>`: 输出样式（`plain`、`xml`、`markdown`）（默认：`xml`）
 - `--parsable-style`: 启用基于所选样式模式的可解析输出（默认：`false`）
 - `--compress`: 执行智能代码提取，专注于函数和类的签名，同时删除实现细节。有关详细信息和示例，请参阅[代码压缩指南](code-compress)。
 - `--output-show-line-numbers`: 添加行号（默认：`false`）


### PR DESCRIPTION
いつのタイミングか標準outputがxmlになったようですが
一部ドキュメントがtextのままだったので修正しました

