### PR TITLE
Fix brace expansion and whitespace in CLI pattern options

### DIFF
--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -10,6 +10,7 @@ import {
 import { type PackResult, pack } from '../../core/packager.js';
 import { rethrowValidationErrorIfZodError } from '../../shared/errorHandle.js';
 import { logger } from '../../shared/logger.js';
+import { splitPatterns } from '../../shared/patternUtils.js';
 import { printCompletion, printSecurityCheck, printSummary, printTopFiles } from '../cliPrint.js';
 import { Spinner } from '../cliSpinner.js';
 import type { CliOptions } from '../types.js';
@@ -104,10 +105,10 @@ const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
     cliConfig.output = { filePath: options.output };
   }
   if (options.include) {
-    cliConfig.include = options.include.split(',');
+    cliConfig.include = splitPatterns(options.include);
   }
   if (options.ignore) {
-    cliConfig.ignore = { customPatterns: options.ignore.split(',') };
+    cliConfig.ignore = { customPatterns: splitPatterns(options.ignore) };
   }
   // Only apply gitignore setting if explicitly set to false
   if (options.gitignore === false) {

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -65,8 +65,8 @@ const isGitWorktreeRef = async (gitPath: string): Promise<boolean> => {
 export const escapeGlobPattern = (pattern: string): string => {
   // First escape backslashes
   const escapedBackslashes = pattern.replace(/\\/g, '\\\\');
-  // Then escape special characters
-  return escapedBackslashes.replace(/[()[\]{}]/g, '\\$&');
+  // Then escape special characters () and [], but NOT {}
+  return escapedBackslashes.replace(/[()[\]]/g, '\\$&');
 };
 
 /**

--- a/src/shared/patternUtils.ts
+++ b/src/shared/patternUtils.ts
@@ -6,14 +6,14 @@
  */
 export const splitPatterns = (patterns: string): string[] => {
   if (!patterns) return [];
-  
+
   const result: string[] = [];
   let currentPattern = '';
   let braceLevel = 0;
-  
+
   for (let i = 0; i < patterns.length; i++) {
     const char = patterns[i];
-    
+
     if (char === '{') {
       braceLevel++;
       currentPattern += char;
@@ -30,11 +30,11 @@ export const splitPatterns = (patterns: string): string[] => {
       currentPattern += char;
     }
   }
-  
+
   // Add the last pattern
   if (currentPattern) {
     result.push(currentPattern.trim());
   }
-  
+
   return result;
-} 
+};

--- a/src/shared/patternUtils.ts
+++ b/src/shared/patternUtils.ts
@@ -1,0 +1,40 @@
+/**
+ * Splits comma-separated glob patterns while preserving brace expansion patterns.
+ * This ensures patterns with braces are treated as a single pattern,
+ * rather than being split at commas inside the braces.
+ * Whitespace around patterns is also trimmed.
+ */
+export const splitPatterns = (patterns: string): string[] => {
+  if (!patterns) return [];
+  
+  const result: string[] = [];
+  let currentPattern = '';
+  let braceLevel = 0;
+  
+  for (let i = 0; i < patterns.length; i++) {
+    const char = patterns[i];
+    
+    if (char === '{') {
+      braceLevel++;
+      currentPattern += char;
+    } else if (char === '}') {
+      braceLevel--;
+      currentPattern += char;
+    } else if (char === ',' && braceLevel === 0) {
+      // Only split on commas when not inside braces
+      if (currentPattern) {
+        result.push(currentPattern.trim());
+        currentPattern = '';
+      }
+    } else {
+      currentPattern += char;
+    }
+  }
+  
+  // Add the last pattern
+  if (currentPattern) {
+    result.push(currentPattern.trim());
+  }
+  
+  return result;
+} 

--- a/src/shared/patternUtils.ts
+++ b/src/shared/patternUtils.ts
@@ -4,7 +4,7 @@
  * rather than being split at commas inside the braces.
  * Whitespace around patterns is also trimmed.
  */
-export const splitPatterns = (patterns: string): string[] => {
+export const splitPatterns = (patterns?: string): string[] => {
   if (!patterns) return [];
 
   const result: string[] = [];

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -382,11 +382,6 @@ node_modules
       expect(escapeGlobPattern(pattern)).toBe('src/\\(categories\\)/**/*.ts');
     });
 
-    test('should escape multiple types of brackets', () => {
-      const pattern = 'src/(auth)/[id]/{slug}/**/*.ts';
-      expect(escapeGlobPattern(pattern)).toBe('src/\\(auth\\)/\\[id\\]/\\{slug\\}/**/*.ts');
-    });
-
     test('should handle nested brackets', () => {
       const pattern = 'src/(auth)/([id])/**/*.ts';
       expect(escapeGlobPattern(pattern)).toBe('src/\\(auth\\)/\\(\\[id\\]\\)/**/*.ts');
@@ -415,11 +410,6 @@ node_modules
   test('should handle patterns with already escaped special characters', () => {
     const pattern = 'src\\\\(categories)';
     expect(escapeGlobPattern(pattern)).toBe('src\\\\\\\\\\(categories\\)');
-  });
-
-  test('should handle patterns with mixed backslashes and special characters', () => {
-    const pattern = 'src\\temp\\[id]\\{slug}';
-    expect(escapeGlobPattern(pattern)).toBe('src\\\\temp\\\\\\[id\\]\\\\\\{slug\\}');
   });
 
   describe('normalizeGlobPattern', () => {

--- a/tests/shared/patternUtils.test.ts
+++ b/tests/shared/patternUtils.test.ts
@@ -51,4 +51,4 @@ describe('patternUtils', () => {
       expect(result).toEqual(['src/**', 'tests/**', '**/*.js']);
     });
   });
-}); 
+});

--- a/tests/shared/patternUtils.test.ts
+++ b/tests/shared/patternUtils.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { splitPatterns } from '../../src/shared/patternUtils.js';
+
+describe('patternUtils', () => {
+  describe('splitPatterns', () => {
+    it('should correctly split patterns without braces', () => {
+      const patterns = 'src/**,tests/**,*.js';
+      const result = splitPatterns(patterns);
+      expect(result).toEqual(['src/**', 'tests/**', '*.js']);
+    });
+
+    it('should preserve brace expansion patterns', () => {
+      const patterns = 'src/**,**/{__tests__,theme}/**,*.{js,ts}';
+      const result = splitPatterns(patterns);
+      expect(result).toEqual(['src/**', '**/{__tests__,theme}/**', '*.{js,ts}']);
+    });
+
+    it('should handle nested braces', () => {
+      const patterns = 'src/{components/{Button,Input},utils}/**';
+      const result = splitPatterns(patterns);
+      expect(result).toEqual(['src/{components/{Button,Input},utils}/**']);
+    });
+
+    it('should handle empty patterns', () => {
+      expect(splitPatterns('')).toEqual([]);
+      expect(splitPatterns(undefined)).toEqual([]);
+    });
+
+    it('should handle patterns with escaped braces', () => {
+      const patterns = 'src/\\{file\\}.js,tests/**';
+      const result = splitPatterns(patterns);
+      // Note: Escaped braces are treated as regular characters, not brace delimiters
+      expect(result).toEqual(['src/\\{file\\}.js', 'tests/**']);
+    });
+
+    it('should handle trailing commas', () => {
+      const patterns = 'src/**,tests/**,';
+      const result = splitPatterns(patterns);
+      expect(result).toEqual(['src/**', 'tests/**']);
+    });
+
+    it('should handle leading commas', () => {
+      const patterns = ',src/**,tests/**';
+      const result = splitPatterns(patterns);
+      expect(result).toEqual(['src/**', 'tests/**']);
+    });
+
+    it('should trim whitespace around patterns', () => {
+      const patterns = ' src/** , tests/** , **/*.js ';
+      const result = splitPatterns(patterns);
+      expect(result).toEqual(['src/**', 'tests/**', '**/*.js']);
+    });
+  });
+}); 


### PR DESCRIPTION
Issue
The CLI --include and --ignore options had two issues with pattern handling:
- Brace expansion patterns like **/{__tests__,theme}/** were incorrectly split at the comma inside braces, resulting in broken patterns ["**/{__tests__", "theme}/**"]
- Whitespace in patterns like **/__tests__/**, **/theme/** was preserved, causing unexpected behavior with leading/trailing spaces

Solution
- Added a new splitPatterns utility function that tracks brace nesting level to preserve brace expansion patterns
- Enhanced pattern handling to trim whitespace from each pattern
- Added comprehensive tests for both behaviors

Before :
```
"**/{__tests__,theme}/**" → ["**/{__tests__", "theme}/**"] // Incorrectly split brace pattern
"**/__tests__/**, **/theme/**" → ["**/__tests__/**", " **/theme/**"] // Note the leading space
```

After :
```
"**/{__tests__,theme}/**" → ["**/{__tests__,theme}/**"] // Correctly preserves brace expansion
"**/__tests__/**, **/theme/**" → ["**/__tests__/**", "**/theme/**"] // Whitespace trimmed
```

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
