### PR TITLE
feat: add wl-copy support

### DIFF
--- a/src/core/packager/copyToClipboardIfEnabled.ts
+++ b/src/core/packager/copyToClipboardIfEnabled.ts
@@ -17,7 +17,7 @@ export const copyToClipboardIfEnabled = async (
     try {
       await new Promise<void>((resolve, reject) => {
         const proc = spawn('wl-copy', [], { stdio: ['pipe', 'ignore', 'ignore'] });
-        proc.on('error', reject);
+        proc.on('error', (err) => reject(new Error(`Failed to execute wl-copy: ${err.message}`)));
         proc.on('close', (code) => (code ? reject(new Error(`wl-copy exited with code ${code}`)) : resolve()));
         proc.stdin.end(output);
       });

--- a/src/core/packager/copyToClipboardIfEnabled.ts
+++ b/src/core/packager/copyToClipboardIfEnabled.ts
@@ -1,17 +1,39 @@
+import { spawn } from 'node:child_process';
 import clipboard from 'clipboardy';
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
 
-// Additionally copy to clipboard if flag is raised
 export const copyToClipboardIfEnabled = async (
   output: string,
   progressCallback: RepomixProgressCallback,
   config: RepomixConfigMerged,
-): Promise<undefined> => {
-  if (config.output.copyToClipboard) {
-    progressCallback('Copying to clipboard...');
-    logger.trace('Copying output to clipboard');
+): Promise<void> => {
+  if (!config.output.copyToClipboard) return;
+
+  progressCallback('Copying to clipboard...');
+
+  if (process.env.WAYLAND_DISPLAY) {
+    logger.trace('Wayland environment detected; attempting wl-copy.');
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const child = spawn('wl-copy', [], { stdio: ['pipe', 'ignore', 'ignore'] });
+        child.on('error', reject);
+        child.on('close', (code) => (code ? reject(new Error(`wl-copy exited with code ${code}`)) : resolve()));
+        child.stdin.end(output);
+      });
+      logger.trace('Successfully copied using wl-copy.');
+      return;
+    } catch (error: any) {
+      logger.warn(`wl-copy failed (${error.message}); falling back to clipboardy.`);
+    }
+  }
+
+  try {
+    logger.trace('Using clipboardy for copying.');
     await clipboard.write(output);
+    logger.trace('Successfully copied using clipboardy.');
+  } catch (error: any) {
+    logger.error(`clipboardy failed: ${error.message}`);
   }
 };


### PR DESCRIPTION
Add Wayland copy support; `repomix --copy` does not copy anything when on a Wayland compositor as clipboardy package is stale.