### PR TITLE
Spellcheck dot files

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -1,4 +1,6 @@
 [files]
 extend-exclude = [
-    "website/client/src/**/*.md"
+    "website/client/.vitepress/config/*.ts",
+    "website/client/src/**/*.md",
 ]
+ignore-hidden = false


### PR DESCRIPTION
`typos` by default excludes hidden files.