### PR TITLE
feat(core): Make it easier to pick & override pack's deps + core export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,12 @@ export { pack } from './core/packager.js';
 export type { PackResult } from './core/packager.js';
 
 // File
+export { collectFiles } from './core/file/fileCollect.js';
+export { sortPaths } from './core/file/filePathSort.js';
+export { processFiles } from './core/file/fileProcess.js';
 export { searchFiles } from './core/file/fileSearch.js';
 export type { FileSearchResult } from './core/file/fileSearch.js';
-export { collectFiles } from './core/file/fileCollect.js';
-export { processFiles } from './core/file/fileProcess.js';
-export { sortPaths } from './core/file/filePathSort.js';
+export { generateFileTree } from './core/file/fileTreeGenerate.js';
 
 // Security
 export { runSecurityCheck } from './core/security/securityCheck.js';
@@ -24,8 +25,8 @@ export { parseFile } from './core/treeSitter/parseFile.js';
 // ---------------------------------------------------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------------------------------------------------
-export type { RepomixConfigFile as RepomixConfig } from './config/configSchema.js';
 export { loadFileConfig, mergeConfigs } from './config/configLoad.js';
+export type { RepomixConfigFile as RepomixConfig } from './config/configSchema.js';
 export { defaultIgnoreList } from './config/defaultIgnore.js';
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -50,5 +51,7 @@ export { runInitAction } from './cli/actions/initAction.js';
 export { runDefaultAction } from './cli/actions/defaultAction.js';
 
 // Remote action
-export { runRemoteAction } from './cli/actions/remoteAction.js';
-export { isValidRemoteValue } from './cli/actions/remoteAction.js';
+export {
+  isValidRemoteValue,
+  runRemoteAction,
+} from './cli/actions/remoteAction.js';

--- a/tests/core/packager.test.ts
+++ b/tests/core/packager.test.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { TokenCounter } from '../../src/core/metrics/TokenCounter.js';
 import { pack } from '../../src/core/packager.js';
 import { createMockConfig } from '../testing/testUtils.js';
 
@@ -51,7 +50,7 @@ describe('packager', () => {
         suspiciousFilesResults: [],
       }),
       generateOutput: vi.fn().mockResolvedValue(mockOutput),
-      writeOutputToDisk: vi.fn().mockResolvedValue(undefined),
+      handleOutput: vi.fn().mockResolvedValue(undefined),
       copyToClipboardIfEnabled: vi.fn().mockResolvedValue(undefined),
       calculateMetrics: vi.fn().mockResolvedValue({
         totalFiles: 2,
@@ -76,14 +75,14 @@ describe('packager', () => {
     expect(mockDeps.collectFiles).toHaveBeenCalledWith(mockFilePaths, 'root', mockConfig, progressCallback);
     expect(mockDeps.validateFileSafety).toHaveBeenCalled();
     expect(mockDeps.processFiles).toHaveBeenCalled();
-    expect(mockDeps.writeOutputToDisk).toHaveBeenCalled();
+    expect(mockDeps.handleOutput).toHaveBeenCalled();
     expect(mockDeps.generateOutput).toHaveBeenCalled();
     expect(mockDeps.calculateMetrics).toHaveBeenCalled();
 
     expect(mockDeps.validateFileSafety).toHaveBeenCalledWith(mockRawFiles, progressCallback, mockConfig);
     expect(mockDeps.processFiles).toHaveBeenCalledWith(mockSafeRawFiles, mockConfig, progressCallback);
     expect(mockDeps.generateOutput).toHaveBeenCalledWith(['root'], mockConfig, mockProcessedFiles, mockFilePaths);
-    expect(mockDeps.writeOutputToDisk).toHaveBeenCalledWith(mockOutput, mockConfig);
+    expect(mockDeps.handleOutput).toHaveBeenCalledWith(mockOutput, mockConfig);
     expect(mockDeps.copyToClipboardIfEnabled).toHaveBeenCalledWith(mockOutput, progressCallback, mockConfig);
     expect(mockDeps.calculateMetrics).toHaveBeenCalledWith(
       mockProcessedFiles,

--- a/tests/integration-tests/packager.test.ts
+++ b/tests/integration-tests/packager.test.ts
@@ -97,7 +97,7 @@ describe.runIf(!isWindows)('packager integration', () => {
             filterOutUntrustedFiles,
           });
         },
-        writeOutputToDisk,
+        handleOutput: writeOutputToDisk,
         copyToClipboardIfEnabled,
         calculateMetrics: async (processedFiles, output, progressCallback, config) => {
           return {


### PR DESCRIPTION
Hey @yamadashy,

Looks like you've already added some of the functions I wanted to export. Here's the summary of changes:

1. Allow overriding default deps without needing to import other dependencies
2. Rename `writeOutputToDisk` to `handleOutput` with `writeOutputToDisk` as default
3. Export `generateFileTree` function from package

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
