### PR TITLE
fix(mcp): Change readRepomixOutputTool response from resource to text

### DIFF
--- a/src/mcp/tools/readRepomixOutputTool.ts
+++ b/src/mcp/tools/readRepomixOutputTool.ts
@@ -54,12 +54,12 @@ export const registerReadRepomixOutputTool = (mcpServer: McpServer) => {
         return {
           content: [
             {
-              type: 'resource',
-              resource: {
-                text: content,
-                uri: `file://${filePath}`,
-                mimeType: 'application/xml',
-              },
+              type: 'text',
+              text: `Content of Repomix output file (ID: ${outputId}):`,
+            },
+            {
+              type: 'text',
+              text: content,
             },
           ],
         };


### PR DESCRIPTION
<!-- Please include a summary of the changes -->

Changed the response type of the MCP tool (`readRepomixOutputTool`) from `resource` to `text`.

related:

- https://github.com/yamadashy/repomix/issues/472

## Background / Reason

In the Cursor environment, MCP tool responses of type `resource` are not properly recognized or displayed. To ensure compatibility and correct display, the response is now returned as `text`.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
