### PR TITLE
feat(output): Add git diff support with --diffs flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ Instruction
 - `--header-text <text>`: Custom text to include in the file header
 - `--instruction-file-path <path>`: Path to a file containing detailed custom instructions
 - `--include-empty-directories`: Include empty directories in the output
+- `--include-diffs`: Include git diffs in the output (includes both work tree and staged changes separately)
 - `--no-git-sort-by-changes`: Disable sorting files by git change count (enabled by default)
 
 #### Filter Options
@@ -730,6 +731,7 @@ Here's an explanation of the configuration options:
 | `output.includeEmptyDirectories` | Whether to include empty directories in the repository structure                                                             | `false`                |
 | `output.git.sortByChanges`       | Whether to sort files by git change count (files with more changes appear at the bottom)                                     | `true`                 |
 | `output.git.sortByChangesMaxCommits` | Maximum number of commits to analyze for git changes                                                                     | `100`                  |
+| `output.git.includeDiffs`       | Whether to include git diffs in the output (includes both work tree and staged changes separately)                          | `false`                |
 | `include`                        | Patterns of files to include (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax))  | `[]`                   |
 | `ignore.useGitignore`            | Whether to use patterns from the project's `.gitignore` file                                                                 | `true`                 |
 | `ignore.useDefaultPatterns`      | Whether to use default ignore patterns                                                                                       | `true`                 |

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -220,6 +220,16 @@ export const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
     };
   }
 
+  if (options.diffs) {
+    cliConfig.output = {
+      ...cliConfig.output,
+      git: {
+        ...cliConfig.output?.git,
+        includeDiffs: true,
+      },
+    };
+  }
+
   try {
     return repomixConfigCliSchema.parse(cliConfig);
   } catch (error) {

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -68,7 +68,7 @@ export const runDefaultAction = async (
     logger.log('');
   }
 
-  printSecurityCheck(cwd, packResult.suspiciousFilesResults, config);
+  printSecurityCheck(cwd, packResult.suspiciousFilesResults, packResult.suspiciousGitDiffResults, config);
   logger.log('');
 
   printSummary(packResult, config);

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -71,14 +71,7 @@ export const runDefaultAction = async (
   printSecurityCheck(cwd, packResult.suspiciousFilesResults, config);
   logger.log('');
 
-  printSummary(
-    packResult.totalFiles,
-    packResult.totalCharacters,
-    packResult.totalTokens,
-    config.output.filePath,
-    packResult.suspiciousFilesResults,
-    config,
-  );
+  printSummary(packResult, config);
   logger.log('');
 
   printCompletion();
@@ -220,7 +213,7 @@ export const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
     };
   }
 
-  if (options.diffs) {
+  if (options.includeDiffs) {
     cliConfig.output = {
       ...cliConfig.output,
       git: {

--- a/src/cli/cliPrint.ts
+++ b/src/cli/cliPrint.ts
@@ -9,7 +9,7 @@ export const printSummary = (
   totalCharacters: number,
   totalTokens: number,
   outputPath: string,
-  suspiciousFilesResults: SuspiciousFileResult[],
+  suspiciousFilesResults: SuspiciousFileResult[] & { diffTokenCount?: number },
   config: RepomixConfigMerged,
 ) => {
   let securityCheckMessage = '';
@@ -32,6 +32,13 @@ export const printSummary = (
   logger.log(`${pc.white(' Total Tokens:')} ${pc.white(totalTokens.toLocaleString())} tokens`);
   logger.log(`${pc.white('       Output:')} ${pc.white(outputPath)}`);
   logger.log(`${pc.white('     Security:')} ${pc.white(securityCheckMessage)}`);
+
+  if (config.output.git?.includeDiffs) {
+    const diffTokens = suspiciousFilesResults.diffTokenCount
+      ? ` (${suspiciousFilesResults.diffTokenCount.toLocaleString()} tokens)`
+      : '';
+    logger.log(`${pc.white('   Git Diffs:')} ${pc.green('✔')} ${pc.white(`Working tree diffs included${diffTokens}`)}`);
+  }
 };
 
 export const printSecurityCheck = (

--- a/src/cli/cliPrint.ts
+++ b/src/cli/cliPrint.ts
@@ -30,7 +30,7 @@ export const printSummary = (packResult: PackResult, config: RepomixConfigMerged
   if (config.output.git?.includeDiffs) {
     let gitDiffsMessage = '';
     if (packResult.diffTokenCount) {
-      gitDiffsMessage = pc.white(`✔ Working tree diffs included${packResult.diffTokenCount.toLocaleString()} tokens`);
+      gitDiffsMessage = pc.white(`✔ Working tree diffs included ${pc.dim(`(${packResult.diffTokenCount.toLocaleString()} tokens)`)}`);
     } else {
       gitDiffsMessage = pc.dim('✖ No working tree diffs included');
     }

--- a/src/cli/cliPrint.ts
+++ b/src/cli/cliPrint.ts
@@ -30,17 +30,18 @@ export const printSummary = (packResult: PackResult, config: RepomixConfigMerged
   if (config.output.git?.includeDiffs) {
     let gitDiffsMessage = '';
     if (packResult.diffTokenCount) {
-      gitDiffsMessage = pc.white(`✔ Working tree diffs included ${pc.dim(`(${packResult.diffTokenCount.toLocaleString()} tokens)`)}`);
+      gitDiffsMessage = pc.white(`✔ Git diffs included ${pc.dim(`(${packResult.diffTokenCount.toLocaleString()} tokens)`)}`);
     } else {
-      gitDiffsMessage = pc.dim('✖ No working tree diffs included');
+      gitDiffsMessage = pc.dim('✖ No git diffs included');
     }
-    logger.log(`${pc.white('   Git Diffs:')} ${gitDiffsMessage}`);
+    logger.log(`${pc.white('    Git Diffs:')} ${gitDiffsMessage}`);
   }
 };
 
 export const printSecurityCheck = (
   rootDir: string,
   suspiciousFilesResults: SuspiciousFileResult[],
+  suspiciousGitDiffResults: SuspiciousFileResult[] = [],
   config: RepomixConfigMerged,
 ) => {
   if (!config.security.enableSecurityCheck) {
@@ -50,6 +51,7 @@ export const printSecurityCheck = (
   logger.log(pc.white('🔎 Security Check:'));
   logger.log(pc.dim('──────────────────'));
 
+  // Print results for files
   if (suspiciousFilesResults.length === 0) {
     logger.log(`${pc.green('✔')} ${pc.white('No suspicious files detected.')}`);
   } else {
@@ -61,6 +63,18 @@ export const printSecurityCheck = (
     });
     logger.log(pc.yellow('\nThese files have been excluded from the output for security reasons.'));
     logger.log(pc.yellow('Please review these files for potential sensitive information.'));
+  }
+
+  // Print results for git diffs
+  if (suspiciousGitDiffResults.length > 0) {
+    logger.log('');
+    logger.log(pc.yellow(`${suspiciousGitDiffResults.length} security issue(s) found in Git diffs:`));
+    suspiciousGitDiffResults.forEach((suspiciousResult, index) => {
+      logger.log(`${pc.white(`${index + 1}.`)} ${pc.white(suspiciousResult.filePath)}`);
+      logger.log(pc.dim(`   - ${suspiciousResult.messages.join('\n   - ')}`));
+    });
+    logger.log(pc.yellow('\nNote: Git diffs with security issues are still included in the output.'));
+    logger.log(pc.yellow('Please review the diffs before sharing the output.'));
   }
 };
 

--- a/src/cli/cliPrint.ts
+++ b/src/cli/cliPrint.ts
@@ -29,8 +29,10 @@ export const printSummary = (packResult: PackResult, config: RepomixConfigMerged
 
   if (config.output.git?.includeDiffs) {
     let gitDiffsMessage = '';
-    if (packResult.diffTokenCount) {
-      gitDiffsMessage = pc.white(`✔ Git diffs included ${pc.dim(`(${packResult.diffTokenCount.toLocaleString()} tokens)`)}`);
+    if (packResult.gitDiffTokenCount) {
+      gitDiffsMessage = pc.white(
+        `✔ Git diffs included ${pc.dim(`(${packResult.gitDiffTokenCount.toLocaleString()} tokens)`)}`,
+      );
     } else {
       gitDiffsMessage = pc.dim('✖ No git diffs included');
     }
@@ -41,7 +43,7 @@ export const printSummary = (packResult: PackResult, config: RepomixConfigMerged
 export const printSecurityCheck = (
   rootDir: string,
   suspiciousFilesResults: SuspiciousFileResult[],
-  suspiciousGitDiffResults: SuspiciousFileResult[] = [],
+  suspiciousGitDiffResults: SuspiciousFileResult[],
   config: RepomixConfigMerged,
 ) => {
   if (!config.security.enableSecurityCheck) {

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -64,7 +64,7 @@ export const run = async () => {
       .option('--instruction-file-path <path>', 'path to a file containing detailed custom instructions')
       .option('--include-empty-directories', 'include empty directories in the output')
       .option('--no-git-sort-by-changes', 'disable sorting files by git change count')
-      .option('--diffs', 'include git diffs from the worktree in the output')
+      .option('--include-diffs', 'include git diffs from the worktree in the output')
       // Filter Options
       .option('--include <patterns>', 'list of include patterns (comma-separated)')
       .option('-i, --ignore <patterns>', 'additional ignore patterns (comma-separated)')

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -64,6 +64,7 @@ export const run = async () => {
       .option('--instruction-file-path <path>', 'path to a file containing detailed custom instructions')
       .option('--include-empty-directories', 'include empty directories in the output')
       .option('--no-git-sort-by-changes', 'disable sorting files by git change count')
+      .option('--diffs', 'include git diffs from the worktree in the output')
       // Filter Options
       .option('--include <patterns>', 'list of include patterns (comma-separated)')
       .option('-i, --ignore <patterns>', 'additional ignore patterns (comma-separated)')

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -64,7 +64,10 @@ export const run = async () => {
       .option('--instruction-file-path <path>', 'path to a file containing detailed custom instructions')
       .option('--include-empty-directories', 'include empty directories in the output')
       .option('--no-git-sort-by-changes', 'disable sorting files by git change count')
-      .option('--include-diffs', 'include git diffs in the output (includes both work tree and staged changes separately)')
+      .option(
+        '--include-diffs',
+        'include git diffs in the output (includes both work tree and staged changes separately)',
+      )
       // Filter Options
       .option('--include <patterns>', 'list of include patterns (comma-separated)')
       .option('-i, --ignore <patterns>', 'additional ignore patterns (comma-separated)')

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -64,7 +64,7 @@ export const run = async () => {
       .option('--instruction-file-path <path>', 'path to a file containing detailed custom instructions')
       .option('--include-empty-directories', 'include empty directories in the output')
       .option('--no-git-sort-by-changes', 'disable sorting files by git change count')
-      .option('--include-diffs', 'include git diffs from the worktree in the output')
+      .option('--include-diffs', 'include git diffs in the output (includes both work tree and staged changes separately)')
       // Filter Options
       .option('--include <patterns>', 'list of include patterns (comma-separated)')
       .option('-i, --ignore <patterns>', 'additional ignore patterns (comma-separated)')

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -21,6 +21,7 @@ export interface CliOptions extends OptionValues {
   instructionFilePath?: string;
   includeEmptyDirectories?: boolean;
   gitSortByChanges?: boolean;
+  diffs?: boolean;
 
   // Filter Options
   include?: string;

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -21,7 +21,7 @@ export interface CliOptions extends OptionValues {
   instructionFilePath?: string;
   includeEmptyDirectories?: boolean;
   gitSortByChanges?: boolean;
-  diffs?: boolean;
+  includeDiffs?: boolean;
 
   // Filter Options
   include?: string;

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -41,7 +41,6 @@ export const repomixConfigBaseSchema = z.object({
           sortByChanges: z.boolean().optional(),
           sortByChangesMaxCommits: z.number().optional(),
           includeDiffs: z.boolean().optional(),
-          diffContent: z.string().optional(),
         })
         .optional(),
     })
@@ -99,7 +98,6 @@ export const repomixConfigDefaultSchema = z.object({
           sortByChanges: z.boolean().default(true),
           sortByChangesMaxCommits: z.number().int().min(1).default(100),
           includeDiffs: z.boolean().default(false),
-          diffContent: z.string().optional(),
         })
         .default({}),
     })

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -40,6 +40,8 @@ export const repomixConfigBaseSchema = z.object({
         .object({
           sortByChanges: z.boolean().optional(),
           sortByChangesMaxCommits: z.number().optional(),
+          includeDiffs: z.boolean().optional(),
+          diffContent: z.string().optional(),
         })
         .optional(),
     })
@@ -96,6 +98,8 @@ export const repomixConfigDefaultSchema = z.object({
         .object({
           sortByChanges: z.boolean().default(true),
           sortByChangesMaxCommits: z.number().int().min(1).default(100),
+          includeDiffs: z.boolean().default(false),
+          diffContent: z.string().optional(),
         })
         .default({}),
     })

--- a/src/core/file/gitCommand.ts
+++ b/src/core/file/gitCommand.ts
@@ -39,6 +39,50 @@ export const getFileChangeCount = async (
   }
 };
 
+export const getWorkTreeDiff = async (
+  directory: string,
+  deps = {
+    execFileAsync,
+  },
+): Promise<string> => {
+  try {
+    // Check if the directory is a git repository
+    const isGitRepo = await isGitRepository(directory, deps);
+    if (!isGitRepo) {
+      logger.trace('Not a git repository, skipping diff generation');
+      return '';
+    }
+
+    // Get the diff from the working tree
+    const result = await deps.execFileAsync('git', [
+      '-C',
+      directory,
+      'diff',
+      '--no-color', // Avoid ANSI color codes
+    ]);
+
+    return result.stdout || '';
+  } catch (error) {
+    logger.trace('Failed to get working tree diff:', (error as Error).message);
+    return '';
+  }
+};
+
+export const isGitRepository = async (
+  directory: string,
+  deps = {
+    execFileAsync,
+  },
+): Promise<boolean> => {
+  try {
+    // Check if the directory is a git repository
+    await deps.execFileAsync('git', ['-C', directory, 'rev-parse', '--is-inside-work-tree']);
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
 export const isGitInstalled = async (
   deps = {
     execFileAsync,

--- a/src/core/file/gitCommand.ts
+++ b/src/core/file/gitCommand.ts
@@ -68,6 +68,36 @@ export const getWorkTreeDiff = async (
   }
 };
 
+export const getStagedDiff = async (
+  directory: string,
+  deps = {
+    execFileAsync,
+  },
+): Promise<string> => {
+  try {
+    // Check if the directory is a git repository
+    const isGitRepo = await isGitRepository(directory, deps);
+    if (!isGitRepo) {
+      logger.trace('Not a git repository, skipping staged diff generation');
+      return '';
+    }
+
+    // Get the diff from the staging area
+    const result = await deps.execFileAsync('git', [
+      '-C',
+      directory,
+      'diff',
+      '--cached',
+      '--no-color', // Avoid ANSI color codes
+    ]);
+
+    return result.stdout || '';
+  } catch (error) {
+    logger.trace('Failed to get staged diff:', (error as Error).message);
+    return '';
+  }
+};
+
 export const isGitRepository = async (
   directory: string,
   deps = {

--- a/src/core/file/gitDiff.ts
+++ b/src/core/file/gitDiff.ts
@@ -22,9 +22,15 @@ export const getGitDiffs = async (
     try {
       // Use the first directory as the git repository root
       // Usually this would be the root of the project
+      const gitRoot = rootDirs[0] || config.cwd;
+      const [workTreeDiffContent, stagedDiffContent] = await Promise.all([
+        deps.getWorkTreeDiff(gitRoot),
+        deps.getStagedDiff(gitRoot),
+      ]);
+
       gitDiffResult = {
-        workTreeDiffContent: await deps.getWorkTreeDiff(rootDirs[0] || config.cwd),
-        stagedDiffContent: await deps.getStagedDiff(rootDirs[0] || config.cwd),
+        workTreeDiffContent,
+        stagedDiffContent,
       };
     } catch (error) {
       if (error instanceof Error) {

--- a/src/core/file/gitDiff.ts
+++ b/src/core/file/gitDiff.ts
@@ -1,0 +1,37 @@
+import type { RepomixConfigMerged } from '../../config/configSchema.js';
+import { RepomixError } from '../../shared/errorHandle.js';
+import { getStagedDiff, getWorkTreeDiff } from './gitCommand.js';
+
+export interface GitDiffResult {
+  workTreeDiffContent: string;
+  stagedDiffContent: string;
+}
+
+export const getGitDiffs = async (
+  rootDirs: string[],
+  config: RepomixConfigMerged,
+  deps = {
+    getWorkTreeDiff,
+    getStagedDiff,
+  },
+): Promise<GitDiffResult | undefined> => {
+  // Get git diffs if enabled
+  let gitDiffResult: GitDiffResult | undefined;
+
+  if (config.output.git?.includeDiffs) {
+    try {
+      // Use the first directory as the git repository root
+      // Usually this would be the root of the project
+      gitDiffResult = {
+        workTreeDiffContent: await deps.getWorkTreeDiff(rootDirs[0] || config.cwd),
+        stagedDiffContent: await deps.getStagedDiff(rootDirs[0] || config.cwd),
+      };
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new RepomixError(`Failed to get git diffs: ${error.message}`);
+      }
+    }
+  }
+
+  return gitDiffResult;
+};

--- a/src/core/metrics/calculateMetrics.ts
+++ b/src/core/metrics/calculateMetrics.ts
@@ -33,19 +33,15 @@ export const calculateMetrics = async (
   let gitDiffTokenCount = 0;
   if (config.output.git?.includeDiffs && gitDiffResult) {
     const tokenCounter = new TokenCounter(config.tokenCount.encoding);
-    
+
     const countPromises = [];
     if (gitDiffResult.workTreeDiffContent) {
-      countPromises.push(
-        Promise.resolve().then(() => tokenCounter.countTokens(gitDiffResult.workTreeDiffContent))
-      );
+      countPromises.push(Promise.resolve().then(() => tokenCounter.countTokens(gitDiffResult.workTreeDiffContent)));
     }
     if (gitDiffResult.stagedDiffContent) {
-      countPromises.push(
-        Promise.resolve().then(() => tokenCounter.countTokens(gitDiffResult.stagedDiffContent))
-      );
+      countPromises.push(Promise.resolve().then(() => tokenCounter.countTokens(gitDiffResult.stagedDiffContent)));
     }
-    
+
     gitDiffTokenCount = (await Promise.all(countPromises)).reduce((sum, count) => sum + count, 0);
     tokenCounter.free();
   }

--- a/src/core/metrics/calculateMetrics.ts
+++ b/src/core/metrics/calculateMetrics.ts
@@ -11,7 +11,7 @@ export interface CalculateMetricsResult {
   totalTokens: number;
   fileCharCounts: Record<string, number>;
   fileTokenCounts: Record<string, number>;
-  diffTokenCount?: number;
+  gitDiffTokenCount: number;
 }
 
 import { TokenCounter } from './TokenCounter.js';
@@ -30,14 +30,14 @@ export const calculateMetrics = async (
   progressCallback('Calculating metrics...');
 
   // Calculate token count for git diffs if included
-  let diffTokenCount = 0;
+  let gitDiffTokenCount = 0;
   if (config.output.git?.includeDiffs) {
     const tokenCounter = new TokenCounter(config.tokenCount.encoding);
     if (gitDiffResult?.workTreeDiffContent) {
-      diffTokenCount += tokenCounter.countTokens(gitDiffResult.workTreeDiffContent);
+      gitDiffTokenCount += tokenCounter.countTokens(gitDiffResult.workTreeDiffContent);
     }
     if (gitDiffResult?.stagedDiffContent) {
-      diffTokenCount += tokenCounter.countTokens(gitDiffResult.stagedDiffContent);
+      gitDiffTokenCount += tokenCounter.countTokens(gitDiffResult.stagedDiffContent);
     }
     tokenCounter.free();
   }
@@ -63,6 +63,6 @@ export const calculateMetrics = async (
     totalTokens,
     fileCharCounts,
     fileTokenCounts,
-    diffTokenCount,
+    gitDiffTokenCount: gitDiffTokenCount,
   };
 };

--- a/src/core/metrics/calculateMetrics.ts
+++ b/src/core/metrics/calculateMetrics.ts
@@ -30,10 +30,15 @@ export const calculateMetrics = async (
   progressCallback('Calculating metrics...');
 
   // Calculate token count for git diffs if included
-  let diffTokenCount: number | undefined;
-  if (config.output.git?.includeDiffs && gitDiffResult?.workTreeDiffContent) {
+  let diffTokenCount = 0;
+  if (config.output.git?.includeDiffs) {
     const tokenCounter = new TokenCounter(config.tokenCount.encoding);
-    diffTokenCount = tokenCounter.countTokens(gitDiffResult.workTreeDiffContent);
+    if (gitDiffResult?.workTreeDiffContent) {
+      diffTokenCount += tokenCounter.countTokens(gitDiffResult.workTreeDiffContent);
+    }
+    if (gitDiffResult?.stagedDiffContent) {
+      diffTokenCount += tokenCounter.countTokens(gitDiffResult.stagedDiffContent);
+    }
     tokenCounter.free();
   }
 

--- a/src/core/metrics/calculateMetrics.ts
+++ b/src/core/metrics/calculateMetrics.ts
@@ -31,14 +31,22 @@ export const calculateMetrics = async (
 
   // Calculate token count for git diffs if included
   let gitDiffTokenCount = 0;
-  if (config.output.git?.includeDiffs) {
+  if (config.output.git?.includeDiffs && gitDiffResult) {
     const tokenCounter = new TokenCounter(config.tokenCount.encoding);
-    if (gitDiffResult?.workTreeDiffContent) {
-      gitDiffTokenCount += tokenCounter.countTokens(gitDiffResult.workTreeDiffContent);
+    
+    const countPromises = [];
+    if (gitDiffResult.workTreeDiffContent) {
+      countPromises.push(
+        Promise.resolve().then(() => tokenCounter.countTokens(gitDiffResult.workTreeDiffContent))
+      );
     }
-    if (gitDiffResult?.stagedDiffContent) {
-      gitDiffTokenCount += tokenCounter.countTokens(gitDiffResult.stagedDiffContent);
+    if (gitDiffResult.stagedDiffContent) {
+      countPromises.push(
+        Promise.resolve().then(() => tokenCounter.countTokens(gitDiffResult.stagedDiffContent))
+      );
     }
+    
+    gitDiffTokenCount = (await Promise.all(countPromises)).reduce((sum, count) => sum + count, 0);
     tokenCounter.free();
   }
 

--- a/src/core/metrics/calculateMetrics.ts
+++ b/src/core/metrics/calculateMetrics.ts
@@ -1,6 +1,7 @@
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
 import type { ProcessedFile } from '../file/fileTypes.js';
+import type { GitDiffResult } from '../file/gitDiff.js';
 import { calculateAllFileMetrics } from './calculateAllFileMetrics.js';
 import { calculateOutputMetrics } from './calculateOutputMetrics.js';
 
@@ -20,6 +21,7 @@ export const calculateMetrics = async (
   output: string,
   progressCallback: RepomixProgressCallback,
   config: RepomixConfigMerged,
+  gitDiffResult: GitDiffResult | undefined,
   deps = {
     calculateAllFileMetrics,
     calculateOutputMetrics,
@@ -29,9 +31,9 @@ export const calculateMetrics = async (
 
   // Calculate token count for git diffs if included
   let diffTokenCount: number | undefined;
-  if (config.output.git?.includeDiffs && config.output.git.diffContent) {
+  if (config.output.git?.includeDiffs && gitDiffResult?.workTreeDiffContent) {
     const tokenCounter = new TokenCounter(config.tokenCount.encoding);
-    diffTokenCount = tokenCounter.countTokens(config.output.git.diffContent);
+    diffTokenCount = tokenCounter.countTokens(gitDiffResult.workTreeDiffContent);
     tokenCounter.free();
   }
 

--- a/src/core/output/outputGeneratorTypes.ts
+++ b/src/core/output/outputGeneratorTypes.ts
@@ -1,5 +1,6 @@
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import type { ProcessedFile } from '../file/fileTypes.js';
+import type { GitDiffResult } from '../file/gitDiff.js';
 
 export interface OutputGeneratorContext {
   generationDate: string;
@@ -7,7 +8,7 @@ export interface OutputGeneratorContext {
   processedFiles: ProcessedFile[];
   config: RepomixConfigMerged;
   instruction: string;
-  gitDiffs?: string;
+  gitDiffResult: GitDiffResult | undefined;
 }
 
 export interface RenderContext {
@@ -25,5 +26,7 @@ export interface RenderContext {
   readonly filesEnabled: boolean;
   readonly escapeFileContent: boolean;
   readonly markdownCodeBlockDelimiter: string;
-  readonly gitDiffs?: string;
+  readonly gitDiffEnabled: boolean;
+  readonly gitDiffWorkTree: string | undefined;
+  readonly gitDiffStaged: string | undefined;
 }

--- a/src/core/output/outputGeneratorTypes.ts
+++ b/src/core/output/outputGeneratorTypes.ts
@@ -7,6 +7,7 @@ export interface OutputGeneratorContext {
   processedFiles: ProcessedFile[];
   config: RepomixConfigMerged;
   instruction: string;
+  gitDiffs?: string;
 }
 
 export interface RenderContext {
@@ -24,4 +25,5 @@ export interface RenderContext {
   readonly filesEnabled: boolean;
   readonly escapeFileContent: boolean;
   readonly markdownCodeBlockDelimiter: string;
+  readonly gitDiffs?: string;
 }

--- a/src/core/output/outputStyleDecorate.ts
+++ b/src/core/output/outputStyleDecorate.ts
@@ -166,5 +166,10 @@ export const generateSummaryNotes = (config: RepomixConfigMerged): string => {
     notes.push('- Files are sorted by Git change count (files with more changes are at the bottom)');
   }
 
+  // Git diffs notes
+  if (config.output.git?.includeDiffs) {
+    notes.push('- Git diffs from the worktree and staged changes are included');
+  }
+
   return notes.join('\n');
 };

--- a/src/core/output/outputStyles/markdownStyle.ts
+++ b/src/core/output/outputStyles/markdownStyle.ts
@@ -48,10 +48,16 @@ export const getMarkdownTemplate = () => {
 {{/each}}
 {{/if}}
 
-{{#if gitDiffs}}
+{{#if gitDiffEnabled}}
 # Git Diffs
+## Git Diffs Working Tree
 \`\`\`diff
-{{{gitDiffs}}}
+{{{gitDiffWorkTree}}}
+\`\`\`
+
+## Git Diffs Staged
+\`\`\`diff
+{{{gitDiffStaged}}}
 \`\`\`
 
 {{/if}}

--- a/src/core/output/outputStyles/markdownStyle.ts
+++ b/src/core/output/outputStyles/markdownStyle.ts
@@ -48,6 +48,14 @@ export const getMarkdownTemplate = () => {
 {{/each}}
 {{/if}}
 
+{{#if gitDiffs}}
+# Git Diffs
+\`\`\`diff
+{{{gitDiffs}}}
+\`\`\`
+
+{{/if}}
+
 {{#if instruction}}
 # Instruction
 {{{instruction}}}

--- a/src/core/output/outputStyles/plainStyle.ts
+++ b/src/core/output/outputStyles/plainStyle.ts
@@ -62,11 +62,18 @@ ${PLAIN_SEPARATOR}
 {{/each}}
 {{/if}}
 
-{{#if gitDiffs}}
+{{#if gitDiffEnabled}}
 ${PLAIN_LONG_SEPARATOR}
 Git Diffs
 ${PLAIN_LONG_SEPARATOR}
-{{{gitDiffs}}}
+${PLAIN_SEPARATOR}
+{{{gitDiffWorkTree}}}
+${PLAIN_SEPARATOR}
+
+${PLAIN_SEPARATOR}
+Git Diffs Staged
+${PLAIN_SEPARATOR}
+{{{gitDiffStaged}}}
 
 {{/if}}
 

--- a/src/core/output/outputStyles/plainStyle.ts
+++ b/src/core/output/outputStyles/plainStyle.ts
@@ -62,6 +62,14 @@ ${PLAIN_SEPARATOR}
 {{/each}}
 {{/if}}
 
+{{#if gitDiffs}}
+${PLAIN_LONG_SEPARATOR}
+Git Diffs
+${PLAIN_LONG_SEPARATOR}
+{{{gitDiffs}}}
+
+{{/if}}
+
 {{#if instruction}}
 ${PLAIN_LONG_SEPARATOR}
 Instruction

--- a/src/core/output/outputStyles/xmlStyle.ts
+++ b/src/core/output/outputStyles/xmlStyle.ts
@@ -56,10 +56,15 @@ This section contains the contents of the repository's files.
 </files>
 {{/if}}
 
-{{#if gitDiffs}}
-<diffs>
-{{{gitDiffs}}}
-</diffs>
+{{#if gitDiffEnabled}}
+<git_diffs>
+<git_diff_work_tree>
+{{{gitDiffWorkTree}}}
+</git_diff_work_tree>
+<git_diff_staged>
+{{{gitDiffStaged}}}
+</git_diff_staged>
+</git_diffs>
 {{/if}}
 
 {{#if instruction}}

--- a/src/core/output/outputStyles/xmlStyle.ts
+++ b/src/core/output/outputStyles/xmlStyle.ts
@@ -56,6 +56,12 @@ This section contains the contents of the repository's files.
 </files>
 {{/if}}
 
+{{#if gitDiffs}}
+<diffs>
+{{{gitDiffs}}}
+</diffs>
+{{/if}}
+
 {{#if instruction}}
 <instruction>
 {{{instruction}}}

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -18,6 +18,7 @@ export interface PackResult {
   totalTokens: number;
   fileCharCounts: Record<string, number>;
   fileTokenCounts: Record<string, number>;
+  diffTokenCount?: number;
   suspiciousFilesResults: SuspiciousFileResult[];
 }
 
@@ -93,8 +94,19 @@ export const pack = async (
 
   const metrics = await deps.calculateMetrics(processedFiles, output, progressCallback, config);
 
-  return {
+  // Create a result object that has both the metrics and the diffTokenCount at the top level
+  const result = {
     ...metrics,
     suspiciousFilesResults,
   };
+
+  // Additionally, attach diffTokenCount to the suspiciousFilesResults array
+  if (metrics.diffTokenCount !== undefined) {
+    Object.defineProperty(result.suspiciousFilesResults, 'diffTokenCount', {
+      value: metrics.diffTokenCount,
+      enumerable: true,
+    });
+  }
+
+  return result;
 };

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -19,7 +19,7 @@ export interface PackResult {
   totalTokens: number;
   fileCharCounts: Record<string, number>;
   fileTokenCounts: Record<string, number>;
-  diffTokenCount?: number;
+  gitDiffTokenCount: number;
   suspiciousFilesResults: SuspiciousFileResult[];
   suspiciousGitDiffResults: SuspiciousFileResult[];
 }
@@ -83,12 +83,8 @@ export const pack = async (
   const gitDiffResult = await deps.getGitDiffs(rootDirs, config);
 
   // Run security check and get filtered safe files
-  const { safeFilePaths, safeRawFiles, suspiciousFilesResults, suspiciousGitDiffResults } = await deps.validateFileSafety(
-    rawFiles,
-    progressCallback,
-    config,
-    gitDiffResult,
-  );
+  const { safeFilePaths, safeRawFiles, suspiciousFilesResults, suspiciousGitDiffResults } =
+    await deps.validateFileSafety(rawFiles, progressCallback, config, gitDiffResult);
 
   // Process files (remove comments, etc.)
   progressCallback('Processing files...');

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -5,6 +5,7 @@ import { sortPaths } from './file/filePathSort.js';
 import { processFiles } from './file/fileProcess.js';
 import { searchFiles } from './file/fileSearch.js';
 import type { RawFile } from './file/fileTypes.js';
+import { GitDiffResult, getGitDiffs } from './file/gitDiff.js';
 import { calculateMetrics } from './metrics/calculateMetrics.js';
 import { generateOutput } from './output/outputGenerate.js';
 import { copyToClipboardIfEnabled } from './packager/copyToClipboardIfEnabled.js';
@@ -32,6 +33,7 @@ const defaultDeps = {
   copyToClipboardIfEnabled,
   calculateMetrics,
   sortPaths,
+  getGitDiffs,
 };
 
 export const pack = async (
@@ -80,33 +82,30 @@ export const pack = async (
     progressCallback,
     config,
   );
+
   // Process files (remove comments, etc.)
   progressCallback('Processing files...');
   const processedFiles = await deps.processFiles(safeRawFiles, config, progressCallback);
 
+  // Get git diffs if enabled
+  progressCallback('Getting git diffs...');
+  const gitDiffResult = await deps.getGitDiffs(rootDirs, config);
+
   progressCallback('Generating output...');
-  const output = await deps.generateOutput(rootDirs, config, processedFiles, safeFilePaths);
+  const output = await deps.generateOutput(rootDirs, config, processedFiles, safeFilePaths, gitDiffResult);
 
   progressCallback('Writing output file...');
   await deps.handleOutput(output, config);
 
   await deps.copyToClipboardIfEnabled(output, progressCallback, config);
 
-  const metrics = await deps.calculateMetrics(processedFiles, output, progressCallback, config);
+  const metrics = await deps.calculateMetrics(processedFiles, output, progressCallback, config, gitDiffResult);
 
   // Create a result object that has both the metrics and the diffTokenCount at the top level
   const result = {
     ...metrics,
     suspiciousFilesResults,
   };
-
-  // Additionally, attach diffTokenCount to the suspiciousFilesResults array
-  if (metrics.diffTokenCount !== undefined) {
-    Object.defineProperty(result.suspiciousFilesResults, 'diffTokenCount', {
-      value: metrics.diffTokenCount,
-      enumerable: true,
-    });
-  }
 
   return result;
 };

--- a/src/core/security/securityCheck.ts
+++ b/src/core/security/securityCheck.ts
@@ -4,13 +4,12 @@ import { initPiscina } from '../../shared/processConcurrency.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
 import type { RawFile } from '../file/fileTypes.js';
 import type { GitDiffResult } from '../file/gitDiff.js';
-import type { SecurityCheckTask } from './workers/securityCheckWorker.js';
-
-export const FILE_PATH_PREFIX_GIT_DIFF = '[git-diff]';
+import type { SecurityCheckTask, SecurityCheckType } from './workers/securityCheckWorker.js';
 
 export interface SuspiciousFileResult {
   filePath: string;
   messages: string[];
+  type: SecurityCheckType;
 }
 
 const initTaskRunner = (numOfTasks: number) => {
@@ -32,15 +31,17 @@ export const runSecurityCheck = async (
   if (gitDiffResult) {
     if (gitDiffResult.workTreeDiffContent) {
       gitDiffTasks.push({
-        filePath: `${FILE_PATH_PREFIX_GIT_DIFF} Working tree changes`,
+        filePath: 'Working tree changes',
         content: gitDiffResult.workTreeDiffContent,
+        type: 'gitDiff',
       });
     }
 
     if (gitDiffResult.stagedDiffContent) {
       gitDiffTasks.push({
-        filePath: `${FILE_PATH_PREFIX_GIT_DIFF} Staged changes`,
+        filePath: 'Staged changes',
         content: gitDiffResult.stagedDiffContent,
+        type: 'gitDiff',
       });
     }
   }
@@ -51,6 +52,7 @@ export const runSecurityCheck = async (
       ({
         filePath: file.path,
         content: file.content,
+        type: 'file',
       }) satisfies SecurityCheckTask,
   );
 

--- a/src/core/security/securityCheck.ts
+++ b/src/core/security/securityCheck.ts
@@ -2,8 +2,8 @@ import pc from 'picocolors';
 import { logger } from '../../shared/logger.js';
 import { initPiscina } from '../../shared/processConcurrency.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
-import type { GitDiffResult } from '../file/gitDiff.js';
 import type { RawFile } from '../file/fileTypes.js';
+import type { GitDiffResult } from '../file/gitDiff.js';
 import type { SecurityCheckTask } from './workers/securityCheckWorker.js';
 
 export interface SuspiciousFileResult {
@@ -30,14 +30,14 @@ export const runSecurityCheck = async (
   if (gitDiffResult) {
     if (gitDiffResult.workTreeDiffContent) {
       gitDiffTasks.push({
-        filePath: "[git-diff] Working tree changes",
+        filePath: '[git-diff] Working tree changes',
         content: gitDiffResult.workTreeDiffContent,
       });
     }
 
     if (gitDiffResult.stagedDiffContent) {
       gitDiffTasks.push({
-        filePath: "[git-diff] Staged changes",
+        filePath: '[git-diff] Staged changes',
         content: gitDiffResult.stagedDiffContent,
       });
     }

--- a/src/core/security/securityCheck.ts
+++ b/src/core/security/securityCheck.ts
@@ -6,6 +6,8 @@ import type { RawFile } from '../file/fileTypes.js';
 import type { GitDiffResult } from '../file/gitDiff.js';
 import type { SecurityCheckTask } from './workers/securityCheckWorker.js';
 
+export const FILE_PATH_PREFIX_GIT_DIFF = '[git-diff]';
+
 export interface SuspiciousFileResult {
   filePath: string;
   messages: string[];
@@ -30,14 +32,14 @@ export const runSecurityCheck = async (
   if (gitDiffResult) {
     if (gitDiffResult.workTreeDiffContent) {
       gitDiffTasks.push({
-        filePath: '[git-diff] Working tree changes',
+        filePath: `${FILE_PATH_PREFIX_GIT_DIFF} Working tree changes`,
         content: gitDiffResult.workTreeDiffContent,
       });
     }
 
     if (gitDiffResult.stagedDiffContent) {
       gitDiffTasks.push({
-        filePath: '[git-diff] Staged changes',
+        filePath: `${FILE_PATH_PREFIX_GIT_DIFF} Staged changes`,
         content: gitDiffResult.stagedDiffContent,
       });
     }

--- a/src/core/security/validateFileSafety.ts
+++ b/src/core/security/validateFileSafety.ts
@@ -1,8 +1,8 @@
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
-import type { GitDiffResult } from '../file/gitDiff.js';
 import type { RawFile } from '../file/fileTypes.js';
+import type { GitDiffResult } from '../file/gitDiff.js';
 import { filterOutUntrustedFiles } from './filterOutUntrustedFiles.js';
 import { type SuspiciousFileResult, runSecurityCheck } from './securityCheck.js';
 
@@ -27,14 +27,14 @@ export const validateFileSafety = async (
     const allResults = await deps.runSecurityCheck(rawFiles, progressCallback, gitDiffResult);
 
     // Separate Git diff results from regular file results
-    suspiciousFilesResults = allResults.filter(result => !result.filePath.startsWith('[git-diff]'));
-    suspiciousGitDiffResults = allResults.filter(result => result.filePath.startsWith('[git-diff]'));
+    suspiciousFilesResults = allResults.filter((result) => !result.filePath.startsWith('[git-diff]'));
+    suspiciousGitDiffResults = allResults.filter((result) => result.filePath.startsWith('[git-diff]'));
 
     if (suspiciousGitDiffResults.length > 0) {
       logger.warn('Security issues found in Git diffs, but they will still be included in the output');
-      suspiciousGitDiffResults.forEach(result => {
+      for (const result of suspiciousGitDiffResults) {
         logger.warn(`  - ${result.filePath}: ${result.messages.join(', ')}`);
-      });
+      }
     }
   }
 

--- a/src/core/security/validateFileSafety.ts
+++ b/src/core/security/validateFileSafety.ts
@@ -1,25 +1,41 @@
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
+import type { GitDiffResult } from '../file/gitDiff.js';
 import type { RawFile } from '../file/fileTypes.js';
 import { filterOutUntrustedFiles } from './filterOutUntrustedFiles.js';
 import { type SuspiciousFileResult, runSecurityCheck } from './securityCheck.js';
 
-// marks which files are suspicious and which are safe
+// Marks which files are suspicious and which are safe
+// Returns Git diff results separately so they can be included in the output
+// even if they contain sensitive information
 export const validateFileSafety = async (
   rawFiles: RawFile[],
   progressCallback: RepomixProgressCallback,
   config: RepomixConfigMerged,
+  gitDiffResult?: GitDiffResult,
   deps = {
     runSecurityCheck,
     filterOutUntrustedFiles,
   },
 ) => {
   let suspiciousFilesResults: SuspiciousFileResult[] = [];
+  let suspiciousGitDiffResults: SuspiciousFileResult[] = [];
 
   if (config.security.enableSecurityCheck) {
     progressCallback('Running security check...');
-    suspiciousFilesResults = await deps.runSecurityCheck(rawFiles, progressCallback);
+    const allResults = await deps.runSecurityCheck(rawFiles, progressCallback, gitDiffResult);
+
+    // Separate Git diff results from regular file results
+    suspiciousFilesResults = allResults.filter(result => !result.filePath.startsWith('[git-diff]'));
+    suspiciousGitDiffResults = allResults.filter(result => result.filePath.startsWith('[git-diff]'));
+
+    if (suspiciousGitDiffResults.length > 0) {
+      logger.warn('Security issues found in Git diffs, but they will still be included in the output');
+      suspiciousGitDiffResults.forEach(result => {
+        logger.warn(`  - ${result.filePath}: ${result.messages.join(', ')}`);
+      });
+    }
   }
 
   const safeRawFiles = deps.filterOutUntrustedFiles(rawFiles, suspiciousFilesResults);
@@ -30,5 +46,6 @@ export const validateFileSafety = async (
     safeRawFiles,
     safeFilePaths,
     suspiciousFilesResults,
+    suspiciousGitDiffResults,
   };
 };

--- a/src/core/security/validateFileSafety.ts
+++ b/src/core/security/validateFileSafety.ts
@@ -4,7 +4,7 @@ import type { RepomixProgressCallback } from '../../shared/types.js';
 import type { RawFile } from '../file/fileTypes.js';
 import type { GitDiffResult } from '../file/gitDiff.js';
 import { filterOutUntrustedFiles } from './filterOutUntrustedFiles.js';
-import { FILE_PATH_PREFIX_GIT_DIFF, type SuspiciousFileResult, runSecurityCheck } from './securityCheck.js';
+import { type SuspiciousFileResult, runSecurityCheck } from './securityCheck.js';
 
 // Marks which files are suspicious and which are safe
 // Returns Git diff results separately so they can be included in the output
@@ -27,8 +27,8 @@ export const validateFileSafety = async (
     const allResults = await deps.runSecurityCheck(rawFiles, progressCallback, gitDiffResult);
 
     // Separate Git diff results from regular file results
-    suspiciousFilesResults = allResults.filter((result) => !result.filePath.startsWith(FILE_PATH_PREFIX_GIT_DIFF));
-    suspiciousGitDiffResults = allResults.filter((result) => result.filePath.startsWith(FILE_PATH_PREFIX_GIT_DIFF));
+    suspiciousFilesResults = allResults.filter((result) => result.type === 'file');
+    suspiciousGitDiffResults = allResults.filter((result) => result.type === 'gitDiff');
 
     if (suspiciousGitDiffResults.length > 0) {
       logger.warn('Security issues found in Git diffs, but they will still be included in the output');

--- a/src/core/security/validateFileSafety.ts
+++ b/src/core/security/validateFileSafety.ts
@@ -4,7 +4,7 @@ import type { RepomixProgressCallback } from '../../shared/types.js';
 import type { RawFile } from '../file/fileTypes.js';
 import type { GitDiffResult } from '../file/gitDiff.js';
 import { filterOutUntrustedFiles } from './filterOutUntrustedFiles.js';
-import { type SuspiciousFileResult, runSecurityCheck } from './securityCheck.js';
+import { FILE_PATH_PREFIX_GIT_DIFF, type SuspiciousFileResult, runSecurityCheck } from './securityCheck.js';
 
 // Marks which files are suspicious and which are safe
 // Returns Git diff results separately so they can be included in the output
@@ -27,8 +27,8 @@ export const validateFileSafety = async (
     const allResults = await deps.runSecurityCheck(rawFiles, progressCallback, gitDiffResult);
 
     // Separate Git diff results from regular file results
-    suspiciousFilesResults = allResults.filter((result) => !result.filePath.startsWith('[git-diff]'));
-    suspiciousGitDiffResults = allResults.filter((result) => result.filePath.startsWith('[git-diff]'));
+    suspiciousFilesResults = allResults.filter((result) => !result.filePath.startsWith(FILE_PATH_PREFIX_GIT_DIFF));
+    suspiciousGitDiffResults = allResults.filter((result) => result.filePath.startsWith(FILE_PATH_PREFIX_GIT_DIFF));
 
     if (suspiciousGitDiffResults.length > 0) {
       logger.warn('Security issues found in Git diffs, but they will still be included in the output');

--- a/src/mcp/tools/fileSystemReadFileTool.ts
+++ b/src/mcp/tools/fileSystemReadFileTool.ts
@@ -68,7 +68,7 @@ export const registerFileSystemReadFileTool = (mcpServer: McpServer) => {
 
         // Perform security check using the existing worker
         const config = createSecretLintConfig();
-        const securityCheckResult = await runSecretLint(filePath, fileContent, config);
+        const securityCheckResult = await runSecretLint(filePath, fileContent, 'file', config);
 
         // If security check found issues, block the file
         if (securityCheckResult !== null) {

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -37,6 +37,7 @@ describe('defaultAction', () => {
         git: {
           sortByChanges: true,
           sortByChangesMaxCommits: 100,
+          includeDiffs: false,
         },
         files: true,
       },

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -61,6 +61,8 @@ describe('defaultAction', () => {
       fileCharCounts: {},
       fileTokenCounts: {},
       suspiciousFilesResults: [],
+      suspiciousGitDiffResults: [],
+      gitDiffTokenCount: 0,
     });
   });
 

--- a/tests/cli/actions/diffsFlag.test.ts
+++ b/tests/cli/actions/diffsFlag.test.ts
@@ -3,9 +3,9 @@ import { buildCliConfig } from '../../../src/cli/actions/defaultAction.js';
 import type { CliOptions } from '../../../src/cli/types.js';
 
 describe('Diffs Flag in CLI', () => {
-  test('should set includeDiffs to true when --diffs flag is provided', () => {
+  test('should set includeDiffs to true when --include-diffs flag is provided', () => {
     const options: CliOptions = {
-      diffs: true,
+      includeDiffs: true,
     };
 
     const config = buildCliConfig(options);
@@ -13,7 +13,7 @@ describe('Diffs Flag in CLI', () => {
     expect(config.output?.git?.includeDiffs).toBe(true);
   });
 
-  test('should not set includeDiffs when --diffs flag is not provided', () => {
+  test('should not set includeDiffs when --include-diffs flag is not provided', () => {
     const options: CliOptions = {};
 
     const config = buildCliConfig(options);
@@ -21,9 +21,9 @@ describe('Diffs Flag in CLI', () => {
     expect(config.output?.git?.includeDiffs).toBeUndefined();
   });
 
-  test('should include other git options when provided alongside --diffs', () => {
+  test('should include other git options when provided alongside --include-diffs', () => {
     const options: CliOptions = {
-      diffs: true,
+      includeDiffs: true,
       gitSortByChanges: false,
     };
 

--- a/tests/cli/actions/diffsFlag.test.ts
+++ b/tests/cli/actions/diffsFlag.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test, vi } from 'vitest';
+import { buildCliConfig } from '../../../src/cli/actions/defaultAction.js';
+import type { CliOptions } from '../../../src/cli/types.js';
+
+describe('Diffs Flag in CLI', () => {
+  test('should set includeDiffs to true when --diffs flag is provided', () => {
+    const options: CliOptions = {
+      diffs: true,
+    };
+
+    const config = buildCliConfig(options);
+
+    expect(config.output?.git?.includeDiffs).toBe(true);
+  });
+
+  test('should not set includeDiffs when --diffs flag is not provided', () => {
+    const options: CliOptions = {};
+
+    const config = buildCliConfig(options);
+
+    expect(config.output?.git?.includeDiffs).toBeUndefined();
+  });
+
+  test('should include other git options when provided alongside --diffs', () => {
+    const options: CliOptions = {
+      diffs: true,
+      gitSortByChanges: false,
+    };
+
+    const config = buildCliConfig(options);
+
+    expect(config.output?.git?.includeDiffs).toBe(true);
+    expect(config.output?.git?.sortByChanges).toBe(false);
+  });
+});

--- a/tests/cli/actions/remoteAction.test.ts
+++ b/tests/cli/actions/remoteAction.test.ts
@@ -46,6 +46,8 @@ describe('remoteAction functions', () => {
                 fileCharCounts: {},
                 fileTokenCounts: {},
                 suspiciousFilesResults: [],
+                suspiciousGitDiffResults: [],
+                gitDiffTokenCount: 0,
               },
               config: createMockConfig(),
             } satisfies DefaultActionRunnerResult;

--- a/tests/cli/cliPrint.test.ts
+++ b/tests/cli/cliPrint.test.ts
@@ -30,7 +30,7 @@ describe('cliPrint', () => {
         security: { enableSecurityCheck: true },
       });
       const suspiciousFiles: SuspiciousFileResult[] = [
-        { filePath: 'suspicious.txt', messages: ['Contains sensitive data'] },
+        { filePath: 'suspicious.txt', messages: ['Contains sensitive data'], type: 'file' },
       ];
 
       const packResult: PackResult = {
@@ -102,6 +102,7 @@ describe('cliPrint', () => {
         {
           filePath: path.join('/root', configRelativePath),
           messages: ['Contains API key', 'Contains password'],
+          type: 'file',
         },
       ];
 

--- a/tests/cli/cliPrint.test.ts
+++ b/tests/cli/cliPrint.test.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { printCompletion, printSecurityCheck, printSummary, printTopFiles } from '../../src/cli/cliPrint.js';
 import type { SuspiciousFileResult } from '../../src/core/security/securityCheck.js';
+import type { PackResult } from '../../src/index.js';
 import { logger } from '../../src/shared/logger.js';
 import { createMockConfig } from '../testing/testUtils.js';
 
@@ -32,7 +33,17 @@ describe('cliPrint', () => {
         { filePath: 'suspicious.txt', messages: ['Contains sensitive data'] },
       ];
 
-      printSummary(10, 1000, 200, 'output.txt', suspiciousFiles, config);
+      const packResult: PackResult = {
+        totalFiles: 10,
+        totalCharacters: 1000,
+        totalTokens: 200,
+        fileCharCounts: { 'file1.txt': 100 },
+        fileTokenCounts: { 'file1.txt': 50 },
+        suspiciousFilesResults: suspiciousFiles,
+        diffTokenCount: 0,
+      };
+
+      printSummary(packResult, config);
 
       expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('1 suspicious file(s) detected and excluded'));
     });
@@ -42,7 +53,17 @@ describe('cliPrint', () => {
         security: { enableSecurityCheck: false },
       });
 
-      printSummary(10, 1000, 200, 'output.txt', [], config);
+      const packResult: PackResult = {
+        totalFiles: 10,
+        totalCharacters: 1000,
+        totalTokens: 200,
+        fileCharCounts: { 'file1.txt': 100 },
+        fileTokenCounts: { 'file1.txt': 50 },
+        suspiciousFilesResults: [],
+        diffTokenCount: 0,
+      };
+
+      printSummary(packResult, config);
 
       expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Security check disabled'));
     });

--- a/tests/cli/cliPrint.test.ts
+++ b/tests/cli/cliPrint.test.ts
@@ -40,7 +40,8 @@ describe('cliPrint', () => {
         fileCharCounts: { 'file1.txt': 100 },
         fileTokenCounts: { 'file1.txt': 50 },
         suspiciousFilesResults: suspiciousFiles,
-        diffTokenCount: 0,
+        suspiciousGitDiffResults: [],
+        gitDiffTokenCount: 0,
       };
 
       printSummary(packResult, config);
@@ -60,7 +61,8 @@ describe('cliPrint', () => {
         fileCharCounts: { 'file1.txt': 100 },
         fileTokenCounts: { 'file1.txt': 50 },
         suspiciousFilesResults: [],
-        diffTokenCount: 0,
+        suspiciousGitDiffResults: [],
+        gitDiffTokenCount: 0,
       };
 
       printSummary(packResult, config);
@@ -75,7 +77,7 @@ describe('cliPrint', () => {
         security: { enableSecurityCheck: false },
       });
 
-      printSecurityCheck('/root', [], config);
+      printSecurityCheck('/root', [], [], config);
       expect(logger.log).not.toHaveBeenCalled();
     });
 
@@ -84,7 +86,7 @@ describe('cliPrint', () => {
         security: { enableSecurityCheck: true },
       });
 
-      printSecurityCheck('/root', [], config);
+      printSecurityCheck('/root', [], [], config);
 
       expect(logger.log).toHaveBeenCalledWith('WHITE:🔎 Security Check:');
       expect(logger.log).toHaveBeenCalledWith('DIM:──────────────────');
@@ -103,7 +105,7 @@ describe('cliPrint', () => {
         },
       ];
 
-      printSecurityCheck('/root', suspiciousFiles, config);
+      printSecurityCheck('/root', suspiciousFiles, [], config);
 
       expect(logger.log).toHaveBeenCalledWith('YELLOW:1 suspicious file(s) detected and excluded from the output:');
       expect(logger.log).toHaveBeenCalledWith(`WHITE:1. WHITE:${configRelativePath}`);

--- a/tests/cli/cliRun.test.ts
+++ b/tests/cli/cliRun.test.ts
@@ -77,6 +77,7 @@ describe('cliRun', () => {
           git: {
             sortByChanges: true,
             sortByChangesMaxCommits: 100,
+            includeDiffs: false,
           },
         },
         include: [],
@@ -124,6 +125,7 @@ describe('cliRun', () => {
           git: {
             sortByChanges: true,
             sortByChangesMaxCommits: 100,
+            includeDiffs: false,
           },
         },
         include: [],

--- a/tests/cli/cliRun.test.ts
+++ b/tests/cli/cliRun.test.ts
@@ -100,6 +100,8 @@ describe('cliRun', () => {
         fileCharCounts: {},
         fileTokenCounts: {},
         suspiciousFilesResults: [],
+        gitDiffTokenCount: 0,
+        suspiciousGitDiffResults: [],
       } satisfies PackResult,
     });
     vi.mocked(initAction.runInitAction).mockResolvedValue();
@@ -148,6 +150,8 @@ describe('cliRun', () => {
         fileCharCounts: {},
         fileTokenCounts: {},
         suspiciousFilesResults: [],
+        gitDiffTokenCount: 0,
+        suspiciousGitDiffResults: [],
       } satisfies PackResult,
     });
     vi.mocked(versionAction.runVersionAction).mockResolvedValue();

--- a/tests/config/configSchema.test.ts
+++ b/tests/config/configSchema.test.ts
@@ -79,6 +79,7 @@ describe('configSchema', () => {
           git: {
             sortByChanges: true,
             sortByChangesMaxCommits: 100,
+            includeDiffs: false,
           },
         },
         include: [],
@@ -172,6 +173,7 @@ describe('configSchema', () => {
           git: {
             sortByChanges: true,
             sortByChangesMaxCommits: 100,
+            includeDiffs: false,
           },
         },
         include: ['**/*.js', '**/*.ts'],

--- a/tests/core/file/gitCommand.test.ts
+++ b/tests/core/file/gitCommand.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { execGitShallowClone, getFileChangeCount, isGitInstalled } from '../../../src/core/file/gitCommand.js';
+import {
+  execGitShallowClone,
+  getFileChangeCount,
+  getWorkTreeDiff,
+  isGitInstalled,
+  isGitRepository,
+} from '../../../src/core/file/gitCommand.js';
 import { logger } from '../../../src/shared/logger.js';
 
 vi.mock('../../../src/shared/logger');
@@ -97,6 +103,81 @@ file2.ts
 
       expect(result).toBe(false);
       expect(mockFileExecAsync).toHaveBeenCalledWith('git', ['--version']);
+    });
+  });
+
+  describe('isGitRepository', () => {
+    test('should return true when directory is a git repository', async () => {
+      const mockFileExecAsync = vi.fn().mockResolvedValue({ stdout: 'true', stderr: '' });
+      const directory = '/test/dir';
+
+      const result = await isGitRepository(directory, { execFileAsync: mockFileExecAsync });
+
+      expect(result).toBe(true);
+      expect(mockFileExecAsync).toHaveBeenCalledWith('git', ['-C', directory, 'rev-parse', '--is-inside-work-tree']);
+    });
+
+    test('should return false when directory is not a git repository', async () => {
+      const mockFileExecAsync = vi.fn().mockRejectedValue(new Error('Not a git repository'));
+      const directory = '/test/dir';
+
+      const result = await isGitRepository(directory, { execFileAsync: mockFileExecAsync });
+
+      expect(result).toBe(false);
+      expect(mockFileExecAsync).toHaveBeenCalledWith('git', ['-C', directory, 'rev-parse', '--is-inside-work-tree']);
+    });
+  });
+
+  describe('getWorkTreeDiff', () => {
+    test('should return diffs when directory is a git repository', async () => {
+      const mockDiff =
+        'diff --git a/file.txt b/file.txt\nindex 1234..5678 100644\n--- a/file.txt\n+++ b/file.txt\n@@ -1,5 +1,5 @@\n-old line\n+new line';
+      const mockFileExecAsync = vi
+        .fn()
+        .mockResolvedValueOnce({ stdout: 'true', stderr: '' }) // isGitRepository
+        .mockResolvedValueOnce({ stdout: mockDiff, stderr: '' }); // git diff
+
+      const directory = '/test/dir';
+      const result = await getWorkTreeDiff(directory, { execFileAsync: mockFileExecAsync });
+
+      expect(result).toBe(mockDiff);
+      expect(mockFileExecAsync).toHaveBeenNthCalledWith(1, 'git', [
+        '-C',
+        directory,
+        'rev-parse',
+        '--is-inside-work-tree',
+      ]);
+      expect(mockFileExecAsync).toHaveBeenNthCalledWith(2, 'git', ['-C', directory, 'diff', '--no-color']);
+    });
+
+    test('should return empty string when directory is not a git repository', async () => {
+      const mockFileExecAsync = vi.fn().mockRejectedValue(new Error('Not a git repository'));
+      const directory = '/test/dir';
+
+      const result = await getWorkTreeDiff(directory, { execFileAsync: mockFileExecAsync });
+
+      expect(result).toBe('');
+      expect(mockFileExecAsync).toHaveBeenCalledWith('git', ['-C', directory, 'rev-parse', '--is-inside-work-tree']);
+    });
+
+    test('should return empty string when git diff command fails', async () => {
+      const mockFileExecAsync = vi
+        .fn()
+        .mockResolvedValueOnce({ stdout: 'true', stderr: '' }) // isGitRepository success
+        .mockRejectedValueOnce(new Error('Failed to get diff')); // git diff failure
+
+      const directory = '/test/dir';
+      const result = await getWorkTreeDiff(directory, { execFileAsync: mockFileExecAsync });
+
+      expect(result).toBe('');
+      expect(mockFileExecAsync).toHaveBeenNthCalledWith(1, 'git', [
+        '-C',
+        directory,
+        'rev-parse',
+        '--is-inside-work-tree',
+      ]);
+      expect(mockFileExecAsync).toHaveBeenNthCalledWith(2, 'git', ['-C', directory, 'diff', '--no-color']);
+      expect(logger.trace).toHaveBeenCalledWith('Failed to get working tree diff:', 'Failed to get diff');
     });
   });
 

--- a/tests/core/file/gitCommand.test.ts
+++ b/tests/core/file/gitCommand.test.ts
@@ -177,7 +177,7 @@ file2.ts
         '--is-inside-work-tree',
       ]);
       expect(mockFileExecAsync).toHaveBeenNthCalledWith(2, 'git', ['-C', directory, 'diff', '--no-color']);
-      expect(logger.trace).toHaveBeenCalledWith('Failed to get working tree diff:', 'Failed to get diff');
+      expect(logger.trace).toHaveBeenCalledWith('Failed to get git diff:', 'Failed to get diff');
     });
   });
 

--- a/tests/core/metrics/calculateMetrics.test.ts
+++ b/tests/core/metrics/calculateMetrics.test.ts
@@ -1,5 +1,6 @@
 import { type Mock, describe, expect, it, vi } from 'vitest';
 import type { ProcessedFile } from '../../../src/core/file/fileTypes.js';
+import type { GitDiffResult } from '../../../src/core/file/gitDiff.js';
 import { TokenCounter } from '../../../src/core/metrics/TokenCounter.js';
 import { calculateAllFileMetrics } from '../../../src/core/metrics/calculateAllFileMetrics.js';
 import { calculateMetrics } from '../../../src/core/metrics/calculateMetrics.js';
@@ -48,7 +49,9 @@ describe('calculateMetrics', () => {
 
     const config = createMockConfig();
 
-    const result = await calculateMetrics(processedFiles, output, progressCallback, config, {
+    const gitDiffResult: GitDiffResult | undefined = undefined;
+
+    const result = await calculateMetrics(processedFiles, output, progressCallback, config, gitDiffResult, {
       calculateAllFileMetrics,
       calculateOutputMetrics: () => Promise.resolve(30),
     });

--- a/tests/core/metrics/calculateMetrics.test.ts
+++ b/tests/core/metrics/calculateMetrics.test.ts
@@ -45,6 +45,7 @@ describe('calculateMetrics', () => {
         'file1.txt': 10,
         'file2.txt': 20,
       },
+      gitDiffTokenCount: 0,
     };
 
     const config = createMockConfig();

--- a/tests/core/metrics/diffTokenCount.test.ts
+++ b/tests/core/metrics/diffTokenCount.test.ts
@@ -1,0 +1,271 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { RepomixConfigMerged } from '../../../src/config/configSchema.js';
+import type { ProcessedFile } from '../../../src/core/file/fileTypes.js';
+import { TokenCounter } from '../../../src/core/metrics/TokenCounter.js';
+import { calculateMetrics } from '../../../src/core/metrics/calculateMetrics.js';
+
+// Mock the TokenCounter
+vi.mock('../../../src/core/metrics/TokenCounter.js', () => ({
+  TokenCounter: vi.fn(),
+}));
+
+describe('Diff Token Count Calculation', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Setup TokenCounter mock
+    vi.mocked(TokenCounter).mockReturnValue({
+      countTokens: vi.fn((content) => {
+        // Simple token counting for testing
+        return content.split(/\s+/).length;
+      }),
+      free: vi.fn(),
+    } as any);
+  });
+
+  test('should calculate diff token count when diffs are included', async () => {
+    // Sample diffs
+    const sampleDiff = `diff --git a/file1.js b/file1.js
+index 123..456 100644
+--- a/file1.js
++++ b/file1.js
+@@ -1,5 +1,5 @@
+-old line of code
++new line of code
+`;
+
+    // Sample processed files
+    const processedFiles: ProcessedFile[] = [
+      {
+        path: 'test.js',
+        content: 'console.log("test");',
+        originalContent: 'console.log("test");',
+      },
+    ];
+
+    // Sample output
+    const output = 'Generated output with sample content';
+
+    // Sample config with diffs enabled
+    const config: RepomixConfigMerged = {
+      cwd: '/test',
+      input: { maxFileSize: 1000000 },
+      output: {
+        filePath: 'output.txt',
+        style: 'plain',
+        parsableStyle: false,
+        fileSummary: true,
+        directoryStructure: true,
+        files: true,
+        removeComments: false,
+        removeEmptyLines: false,
+        compress: false,
+        topFilesLength: 5,
+        showLineNumbers: false,
+        copyToClipboard: false,
+        git: {
+          sortByChanges: true,
+          sortByChangesMaxCommits: 100,
+          includeDiffs: true,
+          diffContent: sampleDiff,
+        },
+      },
+      include: [],
+      ignore: {
+        useGitignore: true,
+        useDefaultPatterns: true,
+        customPatterns: [],
+      },
+      security: {
+        enableSecurityCheck: true,
+      },
+      tokenCount: {
+        encoding: 'o200k_base',
+      },
+    };
+
+    // Mock dependency functions
+    const mockCalculateAllFileMetrics = vi.fn().mockResolvedValue([
+      {
+        path: 'test.js',
+        charCount: 20,
+        tokenCount: 5,
+      },
+    ]);
+
+    const mockCalculateOutputMetrics = vi.fn().mockResolvedValue(15);
+
+    const result = await calculateMetrics(
+      processedFiles,
+      output,
+      vi.fn(), // Progress callback
+      config,
+      {
+        calculateAllFileMetrics: mockCalculateAllFileMetrics,
+        calculateOutputMetrics: mockCalculateOutputMetrics,
+      },
+    );
+
+    // Check TokenCounter was instantiated with the correct encoding
+    expect(TokenCounter).toHaveBeenCalledWith('o200k_base');
+
+    // Check token counting was called with the diff content
+    expect(result).toHaveProperty('diffTokenCount');
+
+    // Our mock counts words as tokens - the sample diff should have multiple tokens
+    expect(result.diffTokenCount).toBeGreaterThan(0);
+  });
+
+  test('should not calculate diff token count when diffs are disabled', async () => {
+    // Sample processed files
+    const processedFiles: ProcessedFile[] = [
+      {
+        path: 'test.js',
+        content: 'console.log("test");',
+        originalContent: 'console.log("test");',
+      },
+    ];
+
+    // Sample output
+    const output = 'Generated output without diffs';
+
+    // Sample config with diffs disabled
+    const config: RepomixConfigMerged = {
+      cwd: '/test',
+      input: { maxFileSize: 1000000 },
+      output: {
+        filePath: 'output.txt',
+        style: 'plain',
+        parsableStyle: false,
+        fileSummary: true,
+        directoryStructure: true,
+        files: true,
+        removeComments: false,
+        removeEmptyLines: false,
+        compress: false,
+        topFilesLength: 5,
+        showLineNumbers: false,
+        copyToClipboard: false,
+        git: {
+          sortByChanges: true,
+          sortByChangesMaxCommits: 100,
+          includeDiffs: false,
+        },
+      },
+      include: [],
+      ignore: {
+        useGitignore: true,
+        useDefaultPatterns: true,
+        customPatterns: [],
+      },
+      security: {
+        enableSecurityCheck: true,
+      },
+      tokenCount: {
+        encoding: 'o200k_base',
+      },
+    };
+
+    // Mock dependency functions
+    const mockCalculateAllFileMetrics = vi.fn().mockResolvedValue([
+      {
+        path: 'test.js',
+        charCount: 20,
+        tokenCount: 5,
+      },
+    ]);
+
+    const mockCalculateOutputMetrics = vi.fn().mockResolvedValue(15);
+
+    const result = await calculateMetrics(
+      processedFiles,
+      output,
+      vi.fn(), // Progress callback
+      config,
+      {
+        calculateAllFileMetrics: mockCalculateAllFileMetrics,
+        calculateOutputMetrics: mockCalculateOutputMetrics,
+      },
+    );
+
+    // TokenCounter should not be called for diff content
+    expect(result.diffTokenCount).toBeUndefined();
+  });
+
+  test('should handle undefined diffContent gracefully', async () => {
+    // Sample processed files
+    const processedFiles: ProcessedFile[] = [
+      {
+        path: 'test.js',
+        content: 'console.log("test");',
+        originalContent: 'console.log("test");',
+      },
+    ];
+
+    // Sample output
+    const output = 'Generated output with diffs enabled but no content';
+
+    // Sample config with diffs enabled but no content
+    const config: RepomixConfigMerged = {
+      cwd: '/test',
+      input: { maxFileSize: 1000000 },
+      output: {
+        filePath: 'output.txt',
+        style: 'plain',
+        parsableStyle: false,
+        fileSummary: true,
+        directoryStructure: true,
+        files: true,
+        removeComments: false,
+        removeEmptyLines: false,
+        compress: false,
+        topFilesLength: 5,
+        showLineNumbers: false,
+        copyToClipboard: false,
+        git: {
+          sortByChanges: true,
+          sortByChangesMaxCommits: 100,
+          includeDiffs: true,
+          // No diffContent property
+        },
+      },
+      include: [],
+      ignore: {
+        useGitignore: true,
+        useDefaultPatterns: true,
+        customPatterns: [],
+      },
+      security: {
+        enableSecurityCheck: true,
+      },
+      tokenCount: {
+        encoding: 'o200k_base',
+      },
+    };
+
+    // Mock dependency functions
+    const mockCalculateAllFileMetrics = vi.fn().mockResolvedValue([
+      {
+        path: 'test.js',
+        charCount: 20,
+        tokenCount: 5,
+      },
+    ]);
+
+    const mockCalculateOutputMetrics = vi.fn().mockResolvedValue(15);
+
+    const result = await calculateMetrics(
+      processedFiles,
+      output,
+      vi.fn(), // Progress callback
+      config,
+      {
+        calculateAllFileMetrics: mockCalculateAllFileMetrics,
+        calculateOutputMetrics: mockCalculateOutputMetrics,
+      },
+    );
+
+    // diffTokenCount should not be set
+    expect(result.diffTokenCount).toBeUndefined();
+  });
+});

--- a/tests/core/metrics/diffTokenCount.test.ts
+++ b/tests/core/metrics/diffTokenCount.test.ts
@@ -20,7 +20,11 @@ describe('Diff Token Count Calculation', () => {
         return content.split(/\s+/).length;
       }),
       free: vi.fn(),
-    } as any);
+      encoding: {
+        encode: vi.fn(),
+        free: vi.fn(),
+      },
+    } as unknown as TokenCounter);
   });
 
   test('should calculate diff token count when diffs are included', async () => {
@@ -39,7 +43,6 @@ index 123..456 100644
       {
         path: 'test.js',
         content: 'console.log("test");',
-        originalContent: 'console.log("test");',
       },
     ];
 
@@ -122,7 +125,6 @@ index 123..456 100644
       {
         path: 'test.js',
         content: 'console.log("test");',
-        originalContent: 'console.log("test");',
       },
     ];
 
@@ -198,7 +200,6 @@ index 123..456 100644
       {
         path: 'test.js',
         content: 'console.log("test");',
-        originalContent: 'console.log("test");',
       },
     ];
 

--- a/tests/core/metrics/diffTokenCount.test.ts
+++ b/tests/core/metrics/diffTokenCount.test.ts
@@ -70,7 +70,6 @@ index 123..456 100644
           sortByChanges: true,
           sortByChangesMaxCommits: 100,
           includeDiffs: true,
-          diffContent: sampleDiff,
         },
       },
       include: [],
@@ -103,6 +102,10 @@ index 123..456 100644
       output,
       vi.fn(), // Progress callback
       config,
+      {
+        workTreeDiffContent: sampleDiff,
+        stagedDiffContent: '',
+      },
       {
         calculateAllFileMetrics: mockCalculateAllFileMetrics,
         calculateOutputMetrics: mockCalculateOutputMetrics,
@@ -184,6 +187,7 @@ index 123..456 100644
       output,
       vi.fn(), // Progress callback
       config,
+      undefined, // No diff content
       {
         calculateAllFileMetrics: mockCalculateAllFileMetrics,
         calculateOutputMetrics: mockCalculateOutputMetrics,
@@ -260,6 +264,7 @@ index 123..456 100644
       output,
       vi.fn(), // Progress callback
       config,
+      undefined, // No diff content
       {
         calculateAllFileMetrics: mockCalculateAllFileMetrics,
         calculateOutputMetrics: mockCalculateOutputMetrics,

--- a/tests/core/metrics/diffTokenCount.test.ts
+++ b/tests/core/metrics/diffTokenCount.test.ts
@@ -116,10 +116,10 @@ index 123..456 100644
     expect(TokenCounter).toHaveBeenCalledWith('o200k_base');
 
     // Check token counting was called with the diff content
-    expect(result).toHaveProperty('diffTokenCount');
+    expect(result).toHaveProperty('gitDiffTokenCount');
 
     // Our mock counts words as tokens - the sample diff should have multiple tokens
-    expect(result.diffTokenCount).toBeGreaterThan(0);
+    expect(result.gitDiffTokenCount).toBeGreaterThan(0);
   });
 
   test('should not calculate diff token count when diffs are disabled', async () => {
@@ -195,7 +195,7 @@ index 123..456 100644
     );
 
     // TokenCounter should not be called for diff content
-    expect(result.diffTokenCount).toBeUndefined();
+    expect(result.gitDiffTokenCount).toBe(0);
   });
 
   test('should handle undefined diffContent gracefully', async () => {
@@ -271,7 +271,7 @@ index 123..456 100644
       },
     );
 
-    // diffTokenCount should not be set
-    expect(result.diffTokenCount).toBeUndefined();
+    // gitDiffTokenCount should not be set
+    expect(result.gitDiffTokenCount).toBe(0);
   });
 });

--- a/tests/core/output/diffsInOutput.test.ts
+++ b/tests/core/output/diffsInOutput.test.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { RepomixConfigMerged } from '../../../src/config/configSchema.js';
+import type { ProcessedFile } from '../../../src/core/file/fileTypes.js';
+import * as gitCommandModule from '../../../src/core/file/gitCommand.js';
+import { buildOutputGeneratorContext, generateOutput } from '../../../src/core/output/outputGenerate.js';
+
+// Mock the gitCommand module
+vi.mock('../../../src/core/file/gitCommand.js', () => ({
+  getWorkTreeDiff: vi.fn(),
+  isGitRepository: vi.fn(),
+}));
+
+describe('Git Diffs in Output', () => {
+  const sampleDiff = `diff --git a/file1.js b/file1.js
+index 123..456 100644
+--- a/file1.js
++++ b/file1.js
+@@ -1,5 +1,5 @@
+-old line
++new line`;
+
+  let mockConfig: RepomixConfigMerged;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Mock the git command
+    vi.mocked(gitCommandModule.getWorkTreeDiff).mockResolvedValue(sampleDiff);
+    vi.mocked(gitCommandModule.isGitRepository).mockResolvedValue(true);
+
+    // Sample minimal config
+    mockConfig = {
+      cwd: '/test/repo',
+      input: {
+        maxFileSize: 1000000,
+      },
+      output: {
+        filePath: 'output.txt',
+        style: 'plain',
+        parsableStyle: false,
+        fileSummary: true,
+        directoryStructure: true,
+        files: true,
+        removeComments: false,
+        removeEmptyLines: false,
+        compress: false,
+        topFilesLength: 5,
+        showLineNumbers: false,
+        copyToClipboard: false,
+        git: {
+          sortByChanges: true,
+          sortByChangesMaxCommits: 100,
+          includeDiffs: false,
+        },
+      },
+      include: [],
+      ignore: {
+        useGitignore: true,
+        useDefaultPatterns: true,
+        customPatterns: [],
+      },
+      security: {
+        enableSecurityCheck: true,
+      },
+      tokenCount: {
+        encoding: 'o200k_base',
+      },
+    };
+  });
+
+  test('buildOutputGeneratorContext should include diffs when enabled', async () => {
+    // Enable diffs
+    mockConfig.output.git!.includeDiffs = true;
+
+    const rootDirs = ['/test/repo'];
+    const allFilePaths = ['file1.js', 'file2.js'];
+    const processedFiles: ProcessedFile[] = [
+      {
+        path: 'file1.js',
+        content: 'console.log("file1");',
+        originalContent: 'console.log("file1");',
+      },
+      {
+        path: 'file2.js',
+        content: 'console.log("file2");',
+        originalContent: 'console.log("file2");',
+      },
+    ];
+
+    const context = await buildOutputGeneratorContext(rootDirs, mockConfig, allFilePaths, processedFiles);
+
+    // Should call getWorkTreeDiff
+    expect(gitCommandModule.getWorkTreeDiff).toHaveBeenCalledWith('/test/repo');
+
+    // Context should include gitDiffs
+    expect(context.gitDiffs).toBe(sampleDiff);
+
+    // Config should have the diffContent
+    expect(mockConfig.output.git!.diffContent).toBe(sampleDiff);
+  });
+
+  test('buildOutputGeneratorContext should not include diffs when disabled', async () => {
+    // Disable diffs
+    mockConfig.output.git!.includeDiffs = false;
+
+    const rootDirs = ['/test/repo'];
+    const allFilePaths = ['file1.js', 'file2.js'];
+    const processedFiles: ProcessedFile[] = [
+      {
+        path: 'file1.js',
+        content: 'console.log("file1");',
+        originalContent: 'console.log("file1");',
+      },
+      {
+        path: 'file2.js',
+        content: 'console.log("file2");',
+        originalContent: 'console.log("file2");',
+      },
+    ];
+
+    const context = await buildOutputGeneratorContext(rootDirs, mockConfig, allFilePaths, processedFiles);
+
+    // Should not call getWorkTreeDiff
+    expect(gitCommandModule.getWorkTreeDiff).not.toHaveBeenCalled();
+
+    // Context should not include gitDiffs
+    expect(context.gitDiffs).toBeUndefined();
+
+    // Config should not have diffContent
+    expect(mockConfig.output.git!.diffContent).toBeUndefined();
+  });
+
+  test('generateOutput should include diffs in XML output via object', async () => {
+    // Enable diffs
+    mockConfig.output.style = 'xml';
+    mockConfig.output.git!.includeDiffs = true;
+
+    const rootDirs = ['/test/repo'];
+    const processedFiles: ProcessedFile[] = [
+      {
+        path: 'file1.js',
+        content: 'console.log("file1");',
+        originalContent: 'console.log("file1");',
+      },
+    ];
+
+    // Create a modified generateOutput with mocked deps
+    const mockBuildOutputGeneratorContext = vi.fn().mockImplementation(async () => {
+      return {
+        generationDate: '2025-05-06T00:00:00.000Z',
+        treeString: '.\n└── file1.js',
+        processedFiles,
+        config: mockConfig,
+        instruction: '',
+        gitDiffs: sampleDiff,
+      };
+    });
+
+    const mockGenerateHandlebarOutput = vi.fn().mockResolvedValue('<xml>output with diffs</xml>');
+    const mockGenerateParsableXmlOutput = vi.fn().mockImplementation(async (renderContext) => {
+      // Check that renderContext has gitDiffs
+      expect(renderContext.gitDiffs).toBe(sampleDiff);
+      return '<xml>parsable output with diffs object</xml>';
+    });
+
+    const mockSortOutputFiles = vi.fn().mockImplementation((files) => Promise.resolve(files));
+
+    // Call generateOutput with mocked deps
+    const output = await generateOutput(rootDirs, mockConfig, processedFiles, ['file1.js'], {
+      buildOutputGeneratorContext: mockBuildOutputGeneratorContext,
+      generateHandlebarOutput: mockGenerateHandlebarOutput,
+      generateParsableXmlOutput: mockGenerateParsableXmlOutput,
+      sortOutputFiles: mockSortOutputFiles,
+    });
+
+    // Check that the output was generated with the correct template
+    expect(mockBuildOutputGeneratorContext).toHaveBeenCalled();
+
+    // For non-parsable XML, should use Handlebars
+    if (!mockConfig.output.parsableStyle) {
+      expect(mockGenerateHandlebarOutput).toHaveBeenCalled();
+    } else {
+      // For parsable XML, should use XML generator
+      expect(mockGenerateParsableXmlOutput).toHaveBeenCalled();
+    }
+  });
+
+  test('generateOutput should include diffs in Markdown output', async () => {
+    // Enable diffs with markdown style
+    mockConfig.output.style = 'markdown';
+    mockConfig.output.git!.includeDiffs = true;
+
+    const rootDirs = ['/test/repo'];
+    const processedFiles: ProcessedFile[] = [
+      {
+        path: 'file1.js',
+        content: 'console.log("file1");',
+        originalContent: 'console.log("file1");',
+      },
+    ];
+
+    // Create a modified generateOutput with mocked deps
+    const mockBuildOutputGeneratorContext = vi.fn().mockImplementation(async () => {
+      return {
+        generationDate: '2025-05-06T00:00:00.000Z',
+        treeString: '.\n└── file1.js',
+        processedFiles,
+        config: mockConfig,
+        instruction: '',
+        gitDiffs: sampleDiff,
+      };
+    });
+
+    const mockGenerateHandlebarOutput = vi.fn().mockImplementation(async (config, renderContext) => {
+      // Check that renderContext has gitDiffs for markdown template
+      expect(renderContext.gitDiffs).toBe(sampleDiff);
+      return '# Markdown output with diffs\n```diff\n' + sampleDiff + '\n```';
+    });
+
+    const mockGenerateParsableXmlOutput = vi.fn();
+    const mockSortOutputFiles = vi.fn().mockImplementation((files) => Promise.resolve(files));
+
+    // Call generateOutput with mocked deps
+    const output = await generateOutput(rootDirs, mockConfig, processedFiles, ['file1.js'], {
+      buildOutputGeneratorContext: mockBuildOutputGeneratorContext,
+      generateHandlebarOutput: mockGenerateHandlebarOutput,
+      generateParsableXmlOutput: mockGenerateParsableXmlOutput,
+      sortOutputFiles: mockSortOutputFiles,
+    });
+
+    // For markdown output, should use Handlebars
+    expect(mockGenerateHandlebarOutput).toHaveBeenCalled();
+
+    // XML generator should not be called for markdown
+    expect(mockGenerateParsableXmlOutput).not.toHaveBeenCalled();
+  });
+
+  test('buildOutputGeneratorContext should handle errors gracefully', async () => {
+    // Enable diffs
+    mockConfig.output.git!.includeDiffs = true;
+
+    // Mock getWorkTreeDiff to throw an error
+    vi.mocked(gitCommandModule.getWorkTreeDiff).mockRejectedValue(new Error('Git error'));
+
+    const rootDirs = ['/test/repo'];
+    const allFilePaths = ['file1.js'];
+    const processedFiles: ProcessedFile[] = [
+      {
+        path: 'file1.js',
+        content: 'console.log("file1");',
+        originalContent: 'console.log("file1");',
+      },
+    ];
+
+    // An error should be thrown
+    await expect(buildOutputGeneratorContext(rootDirs, mockConfig, allFilePaths, processedFiles)).rejects.toThrow(
+      'Failed to get git diffs: Git error',
+    );
+  });
+});

--- a/tests/core/output/diffsInOutput.test.ts
+++ b/tests/core/output/diffsInOutput.test.ts
@@ -70,7 +70,9 @@ index 123..456 100644
 
   test('buildOutputGeneratorContext should include diffs when enabled', async () => {
     // Enable diffs
-    mockConfig.output.git!.includeDiffs = true;
+    if (mockConfig.output.git) {
+      mockConfig.output.git.includeDiffs = true;
+    }
 
     const rootDirs = ['/test/repo'];
     const allFilePaths = ['file1.js', 'file2.js'];
@@ -78,12 +80,10 @@ index 123..456 100644
       {
         path: 'file1.js',
         content: 'console.log("file1");',
-        originalContent: 'console.log("file1");',
       },
       {
         path: 'file2.js',
         content: 'console.log("file2");',
-        originalContent: 'console.log("file2");',
       },
     ];
 
@@ -96,12 +96,14 @@ index 123..456 100644
     expect(context.gitDiffs).toBe(sampleDiff);
 
     // Config should have the diffContent
-    expect(mockConfig.output.git!.diffContent).toBe(sampleDiff);
+    expect(mockConfig.output.git?.diffContent).toBe(sampleDiff);
   });
 
   test('buildOutputGeneratorContext should not include diffs when disabled', async () => {
     // Disable diffs
-    mockConfig.output.git!.includeDiffs = false;
+    if (mockConfig.output.git) {
+      mockConfig.output.git.includeDiffs = false;
+    }
 
     const rootDirs = ['/test/repo'];
     const allFilePaths = ['file1.js', 'file2.js'];
@@ -109,12 +111,10 @@ index 123..456 100644
       {
         path: 'file1.js',
         content: 'console.log("file1");',
-        originalContent: 'console.log("file1");',
       },
       {
         path: 'file2.js',
         content: 'console.log("file2");',
-        originalContent: 'console.log("file2");',
       },
     ];
 
@@ -127,20 +127,21 @@ index 123..456 100644
     expect(context.gitDiffs).toBeUndefined();
 
     // Config should not have diffContent
-    expect(mockConfig.output.git!.diffContent).toBeUndefined();
+    expect(mockConfig.output.git?.diffContent).toBeUndefined();
   });
 
   test('generateOutput should include diffs in XML output via object', async () => {
     // Enable diffs
     mockConfig.output.style = 'xml';
-    mockConfig.output.git!.includeDiffs = true;
+    if (mockConfig.output.git) {
+      mockConfig.output.git.includeDiffs = true;
+    }
 
     const rootDirs = ['/test/repo'];
     const processedFiles: ProcessedFile[] = [
       {
         path: 'file1.js',
         content: 'console.log("file1");',
-        originalContent: 'console.log("file1");',
       },
     ];
 
@@ -188,14 +189,15 @@ index 123..456 100644
   test('generateOutput should include diffs in Markdown output', async () => {
     // Enable diffs with markdown style
     mockConfig.output.style = 'markdown';
-    mockConfig.output.git!.includeDiffs = true;
+    if (mockConfig.output.git) {
+      mockConfig.output.git.includeDiffs = true;
+    }
 
     const rootDirs = ['/test/repo'];
     const processedFiles: ProcessedFile[] = [
       {
         path: 'file1.js',
         content: 'console.log("file1");',
-        originalContent: 'console.log("file1");',
       },
     ];
 
@@ -214,7 +216,7 @@ index 123..456 100644
     const mockGenerateHandlebarOutput = vi.fn().mockImplementation(async (config, renderContext) => {
       // Check that renderContext has gitDiffs for markdown template
       expect(renderContext.gitDiffs).toBe(sampleDiff);
-      return '# Markdown output with diffs\n```diff\n' + sampleDiff + '\n```';
+      return `# Markdown output with diffs\n\`\`\`diff\n${sampleDiff}\n\`\`\``;
     });
 
     const mockGenerateParsableXmlOutput = vi.fn();
@@ -237,7 +239,9 @@ index 123..456 100644
 
   test('buildOutputGeneratorContext should handle errors gracefully', async () => {
     // Enable diffs
-    mockConfig.output.git!.includeDiffs = true;
+    if (mockConfig.output.git) {
+      mockConfig.output.git.includeDiffs = true;
+    }
 
     // Mock getWorkTreeDiff to throw an error
     vi.mocked(gitCommandModule.getWorkTreeDiff).mockRejectedValue(new Error('Git error'));
@@ -248,7 +252,6 @@ index 123..456 100644
       {
         path: 'file1.js',
         content: 'console.log("file1");',
-        originalContent: 'console.log("file1");',
       },
     ];
 

--- a/tests/core/output/outputGenerate.test.ts
+++ b/tests/core/output/outputGenerate.test.ts
@@ -40,10 +40,16 @@ describe('outputGenerate', () => {
     });
     mockDeps.generateHandlebarOutput.mockResolvedValue('mock output');
 
-    const output = await generateOutput([process.cwd()], mockConfig, mockProcessedFiles, [], mockDeps);
+    const output = await generateOutput([process.cwd()], mockConfig, mockProcessedFiles, [], undefined, mockDeps);
 
     expect(mockDeps.sortOutputFiles).toHaveBeenCalledWith(mockProcessedFiles, mockConfig);
-    expect(mockDeps.buildOutputGeneratorContext).toHaveBeenCalledWith([process.cwd()], mockConfig, [], sortedFiles);
+    expect(mockDeps.buildOutputGeneratorContext).toHaveBeenCalledWith(
+      [process.cwd()],
+      mockConfig,
+      [],
+      sortedFiles,
+      undefined,
+    );
     expect(output).toBe('mock output');
   });
 

--- a/tests/core/output/outputGenerateDiffs.test.ts
+++ b/tests/core/output/outputGenerateDiffs.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test, vi } from 'vitest';
+import type { RepomixConfigMerged } from '../../../src/config/configSchema.js';
+import { generateOutput } from '../../../src/core/output/outputGenerate.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+describe('Output Generation with Diffs', () => {
+  const mockProcessedFiles = [
+    {
+      path: 'file1.ts',
+      content: 'console.log("file1");',
+      relativeMetrics: {
+        characters: 10,
+        tokens: 5,
+      },
+    },
+  ];
+
+  const sampleDiff = `diff --git a/file.ts b/file.ts
+  index 1234567..abcdefg 100644
+  --- a/file.ts
+  +++ b/file.ts
+  @@ -1,5 +1,5 @@
+   const a = 1;
+  -const b = 2;
+  +const b = 3;
+   const c = 3;`;
+
+  const allFilePaths = ['file1.ts'];
+  const rootDirs = ['/test/repo'];
+
+  // Create a mock config for testing
+  const mockConfig: RepomixConfigMerged = createMockConfig({
+    cwd: '/test',
+    output: {
+      files: true,
+      directoryStructure: true,
+      fileSummary: true,
+      style: 'xml',
+      git: {
+        includeDiffs: true,
+        diffContent: sampleDiff,
+      },
+    },
+  });
+
+  // Mock dependencies
+  const mockDeps = {
+    buildOutputGeneratorContext: vi.fn().mockImplementation(async () => ({
+      generationDate: '2025-05-05T12:00:00Z',
+      treeString: 'mock-tree',
+      processedFiles: mockProcessedFiles,
+      config: mockConfig,
+      instruction: '',
+      gitDiffs: sampleDiff,
+    })),
+    generateHandlebarOutput: vi.fn(),
+    generateParsableXmlOutput: vi.fn(),
+    sortOutputFiles: vi.fn().mockResolvedValue(mockProcessedFiles),
+  };
+
+  test('XML style output should include diffs section when includeDiffs is enabled', async () => {
+    // Explicitly set XML style and parsable to false to use the template
+    mockConfig.output.style = 'xml';
+    mockConfig.output.parsableStyle = false;
+
+    // Mock the Handlebars output function to check for diffs in the template
+    mockDeps.generateHandlebarOutput.mockImplementation((config, renderContext) => {
+      // Verify that the renderContext has the gitDiffs property
+      expect(renderContext.gitDiffs).toBe(sampleDiff);
+
+      // Simulate the rendered output to check later
+      return `<diffs>${renderContext.gitDiffs}</diffs>`;
+    });
+
+    // Generate the output
+    const output = await generateOutput(rootDirs, mockConfig, mockProcessedFiles, allFilePaths, mockDeps);
+
+    // Verify the diffs are included in the output
+    expect(output).toContain('<diffs>');
+    expect(output).toContain(sampleDiff);
+    expect(output).toContain('</diffs>');
+
+    // Verify that the generateHandlebarOutput function was called
+    expect(mockDeps.generateHandlebarOutput).toHaveBeenCalled();
+  });
+
+  test('XML style output with parsableStyle should include diffs section', async () => {
+    // Set XML style and parsable to true
+    mockConfig.output.style = 'xml';
+    mockConfig.output.parsableStyle = true;
+
+    // Mock the parsable XML output function
+    mockDeps.generateParsableXmlOutput.mockImplementation((renderContext) => {
+      // Verify that the renderContext has the gitDiffs property
+      expect(renderContext.gitDiffs).toBe(sampleDiff);
+
+      // Simulate the XML output
+      return `<repomix><diffs>${renderContext.gitDiffs}</diffs></repomix>`;
+    });
+
+    // Generate the output
+    const output = await generateOutput(rootDirs, mockConfig, mockProcessedFiles, allFilePaths, mockDeps);
+
+    // Verify the diffs are included in the output
+    expect(output).toContain('<repomix><diffs>');
+    expect(output).toContain(sampleDiff);
+    expect(output).toContain('</diffs></repomix>');
+
+    // Verify that the generateParsableXmlOutput function was called
+    expect(mockDeps.generateParsableXmlOutput).toHaveBeenCalled();
+  });
+
+  test('Markdown style output should include diffs section when includeDiffs is enabled', async () => {
+    // Set markdown style
+    mockConfig.output.style = 'markdown';
+    mockConfig.output.parsableStyle = false;
+
+    // Mock the Handlebars output function for markdown
+    mockDeps.generateHandlebarOutput.mockImplementation((config, renderContext) => {
+      // Verify that the renderContext has the gitDiffs property
+      expect(renderContext.gitDiffs).toBe(sampleDiff);
+
+      // Simulate the markdown output
+      return `# Git Diffs\n\`\`\`diff\n${renderContext.gitDiffs}\n\`\`\``;
+    });
+
+    // Generate the output
+    const output = await generateOutput(rootDirs, mockConfig, mockProcessedFiles, allFilePaths, mockDeps);
+
+    // Verify the diffs are included in the output
+    expect(output).toContain('# Git Diffs');
+    expect(output).toContain('```diff');
+    expect(output).toContain(sampleDiff);
+    expect(output).toContain('```');
+
+    // Verify that the generateHandlebarOutput function was called
+    expect(mockDeps.generateHandlebarOutput).toHaveBeenCalled();
+  });
+
+  test('Plain style output should include diffs section when includeDiffs is enabled', async () => {
+    // Set plain style
+    mockConfig.output.style = 'plain';
+    mockConfig.output.parsableStyle = false;
+
+    // Mock the Handlebars output function for plain text
+    mockDeps.generateHandlebarOutput.mockImplementation((config, renderContext) => {
+      // Verify that the renderContext has the gitDiffs property
+      expect(renderContext.gitDiffs).toBe(sampleDiff);
+
+      // Simulate the plain text output
+      return `===============\nGit Diffs\n===============\n${renderContext.gitDiffs}`;
+    });
+
+    // Generate the output
+    const output = await generateOutput(rootDirs, mockConfig, mockProcessedFiles, allFilePaths, mockDeps);
+
+    // Verify the diffs are included in the output
+    expect(output).toContain('===============\nGit Diffs\n===============');
+    expect(output).toContain(sampleDiff);
+
+    // Verify that the generateHandlebarOutput function was called
+    expect(mockDeps.generateHandlebarOutput).toHaveBeenCalled();
+  });
+
+  test('Output should not include diffs section when includeDiffs is disabled', async () => {
+    // Disable the includeDiffs option
+    mockConfig.output.git!.includeDiffs = false;
+
+    // Update the mock to not include diffs
+    mockDeps.buildOutputGeneratorContext.mockImplementationOnce(async () => ({
+      generationDate: '2025-05-05T12:00:00Z',
+      treeString: 'mock-tree',
+      processedFiles: mockProcessedFiles,
+      config: mockConfig,
+      instruction: '',
+      // No gitDiffs property
+    }));
+
+    // Mock the Handlebars output function
+    mockDeps.generateHandlebarOutput.mockImplementation((config, renderContext) => {
+      // Verify that the renderContext does not have the gitDiffs property
+      expect(renderContext.gitDiffs).toBeUndefined();
+
+      // Simulate the output without diffs
+      return `Output without diffs`;
+    });
+
+    // Generate the output
+    const output = await generateOutput(rootDirs, mockConfig, mockProcessedFiles, allFilePaths, mockDeps);
+
+    // Verify the diffs are not included in the output
+    expect(output).not.toContain('Git Diffs');
+    expect(output).not.toContain(sampleDiff);
+
+    // Verify that the generateHandlebarOutput function was called
+    expect(mockDeps.generateHandlebarOutput).toHaveBeenCalled();
+  });
+});

--- a/tests/core/output/outputGenerateDiffs.test.ts
+++ b/tests/core/output/outputGenerateDiffs.test.ts
@@ -164,7 +164,9 @@ describe('Output Generation with Diffs', () => {
 
   test('Output should not include diffs section when includeDiffs is disabled', async () => {
     // Disable the includeDiffs option
-    mockConfig.output.git!.includeDiffs = false;
+    if (mockConfig.output.git) {
+      mockConfig.output.git.includeDiffs = false;
+    }
 
     // Update the mock to not include diffs
     mockDeps.buildOutputGeneratorContext.mockImplementationOnce(async () => ({
@@ -182,7 +184,7 @@ describe('Output Generation with Diffs', () => {
       expect(renderContext.gitDiffs).toBeUndefined();
 
       // Simulate the output without diffs
-      return `Output without diffs`;
+      return 'Output without diffs';
     });
 
     // Generate the output

--- a/tests/core/packager.test.ts
+++ b/tests/core/packager.test.ts
@@ -81,7 +81,13 @@ describe('packager', () => {
 
     expect(mockDeps.validateFileSafety).toHaveBeenCalledWith(mockRawFiles, progressCallback, mockConfig);
     expect(mockDeps.processFiles).toHaveBeenCalledWith(mockSafeRawFiles, mockConfig, progressCallback);
-    expect(mockDeps.generateOutput).toHaveBeenCalledWith(['root'], mockConfig, mockProcessedFiles, mockFilePaths);
+    expect(mockDeps.generateOutput).toHaveBeenCalledWith(
+      ['root'],
+      mockConfig,
+      mockProcessedFiles,
+      mockFilePaths,
+      undefined,
+    );
     expect(mockDeps.handleOutput).toHaveBeenCalledWith(mockOutput, mockConfig);
     expect(mockDeps.copyToClipboardIfEnabled).toHaveBeenCalledWith(mockOutput, progressCallback, mockConfig);
     expect(mockDeps.calculateMetrics).toHaveBeenCalledWith(
@@ -89,6 +95,7 @@ describe('packager', () => {
       mockOutput,
       progressCallback,
       mockConfig,
+      undefined,
     );
 
     // Check the result of pack function

--- a/tests/core/packager.test.ts
+++ b/tests/core/packager.test.ts
@@ -79,7 +79,7 @@ describe('packager', () => {
     expect(mockDeps.generateOutput).toHaveBeenCalled();
     expect(mockDeps.calculateMetrics).toHaveBeenCalled();
 
-    expect(mockDeps.validateFileSafety).toHaveBeenCalledWith(mockRawFiles, progressCallback, mockConfig);
+    expect(mockDeps.validateFileSafety).toHaveBeenCalledWith(mockRawFiles, progressCallback, mockConfig, undefined);
     expect(mockDeps.processFiles).toHaveBeenCalledWith(mockSafeRawFiles, mockConfig, progressCallback);
     expect(mockDeps.generateOutput).toHaveBeenCalledWith(
       ['root'],

--- a/tests/core/packager/diffsFunctionality.test.ts
+++ b/tests/core/packager/diffsFunctionality.test.ts
@@ -142,7 +142,7 @@ index 123..456 100644
       totalTokens: 10,
       fileCharCounts: { 'test.js': 10 },
       fileTokenCounts: { 'test.js': 5 },
-      diffTokenCount: 15, // Mock diff token count
+      gitDiffTokenCount: 15, // Mock diff token count
     });
     const mockSortPaths = vi.fn().mockImplementation((paths) => paths);
 
@@ -163,7 +163,7 @@ index 123..456 100644
       sortPaths: mockSortPaths,
     });
 
-    // Check diffTokenCount in the result
-    expect(result.diffTokenCount).toBe(15);
+    // Check gitDiffTokenCount in the result
+    expect(result.gitDiffTokenCount).toBe(15);
   });
 });

--- a/tests/core/packager/diffsFunctionality.test.ts
+++ b/tests/core/packager/diffsFunctionality.test.ts
@@ -93,7 +93,9 @@ index 123..456 100644
     const mockSortPaths = vi.fn().mockImplementation((paths) => paths);
 
     // Config with diffs disabled
-    mockConfig.output.git!.includeDiffs = false;
+    if (mockConfig.output.git) {
+      mockConfig.output.git.includeDiffs = false;
+    }
 
     await pack([mockRootDir], mockConfig, vi.fn(), {
       searchFiles: mockSearchFiles,
@@ -120,7 +122,9 @@ index 123..456 100644
     vi.mocked(gitCommandModule.getWorkTreeDiff).mockResolvedValue(sampleDiff);
 
     // Config with diffs enabled
-    mockConfig.output.git!.includeDiffs = true;
+    if (mockConfig.output.git) {
+      mockConfig.output.git.includeDiffs = true;
+    }
 
     // Test the buildOutputGeneratorContext function directly
     const rootDirs = [mockRootDir];
@@ -129,7 +133,6 @@ index 123..456 100644
       {
         path: 'file1.js',
         content: 'console.log("test");',
-        originalContent: 'console.log("test");',
       },
     ];
 
@@ -142,7 +145,7 @@ index 123..456 100644
     expect(context.gitDiffs).toBe(sampleDiff);
 
     // Config should have diffContent
-    expect(mockConfig.output.git!.diffContent).toBe(sampleDiff);
+    expect(mockConfig.output.git?.diffContent).toBe(sampleDiff);
   });
 
   test('should handle errors when getting diffs in output generation', async () => {
@@ -156,12 +159,13 @@ index 123..456 100644
       {
         path: 'file1.js',
         content: 'console.log("file1");',
-        originalContent: 'console.log("file1");',
       },
     ];
 
     // Enable diffs
-    mockConfig.output.git!.includeDiffs = true;
+    if (mockConfig.output.git) {
+      mockConfig.output.git.includeDiffs = true;
+    }
 
     // Testing the buildOutputGeneratorContext function directly, which should throw
     await expect(buildOutputGeneratorContext(rootDirs, mockConfig, allFilePaths, processedFiles)).rejects.toThrow(
@@ -175,7 +179,6 @@ index 123..456 100644
       {
         path: 'test.js',
         content: 'console.log("test");',
-        originalContent: 'console.log("test");',
       },
     ];
 
@@ -202,7 +205,9 @@ index 123..456 100644
     const mockSortPaths = vi.fn().mockImplementation((paths) => paths);
 
     // Config with diffs enabled
-    mockConfig.output.git!.includeDiffs = true;
+    if (mockConfig.output.git) {
+      mockConfig.output.git.includeDiffs = true;
+    }
 
     const result = await pack([mockRootDir], mockConfig, vi.fn(), {
       searchFiles: mockSearchFiles,

--- a/tests/core/packager/diffsFunctionality.test.ts
+++ b/tests/core/packager/diffsFunctionality.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { RepomixConfigMerged } from '../../../src/config/configSchema.js';
+import type { ProcessedFile } from '../../../src/core/file/fileTypes.js';
+import * as gitCommandModule from '../../../src/core/file/gitCommand.js';
+import { buildOutputGeneratorContext } from '../../../src/core/output/outputGenerate.js';
+import { pack } from '../../../src/core/packager.js';
+
+// Mock the dependencies
+vi.mock('../../../src/core/file/gitCommand.js', () => ({
+  getWorkTreeDiff: vi.fn(),
+  isGitRepository: vi.fn(),
+}));
+
+describe('Git Diffs Functionality', () => {
+  let mockConfig: RepomixConfigMerged;
+  const mockRootDir = '/test/repo';
+  const sampleDiff = `diff --git a/file1.js b/file1.js
+index 123..456 100644
+--- a/file1.js
++++ b/file1.js
+@@ -1,5 +1,5 @@
+-old line
++new line
+`;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Sample minimal config
+    mockConfig = {
+      cwd: mockRootDir,
+      input: {
+        maxFileSize: 50 * 1024 * 1024,
+      },
+      output: {
+        filePath: 'repomix-output.txt',
+        style: 'plain',
+        parsableStyle: false,
+        fileSummary: true,
+        directoryStructure: true,
+        files: true,
+        removeComments: false,
+        removeEmptyLines: false,
+        compress: false,
+        topFilesLength: 5,
+        showLineNumbers: false,
+        copyToClipboard: false,
+        git: {
+          sortByChanges: true,
+          sortByChangesMaxCommits: 100,
+          includeDiffs: false,
+        },
+      },
+      include: [],
+      ignore: {
+        useGitignore: true,
+        useDefaultPatterns: true,
+        customPatterns: [],
+      },
+      security: {
+        enableSecurityCheck: true,
+      },
+      tokenCount: {
+        encoding: 'o200k_base',
+      },
+    };
+
+    // Set up our mocks
+    vi.mocked(gitCommandModule.isGitRepository).mockResolvedValue(true);
+    vi.mocked(gitCommandModule.getWorkTreeDiff).mockResolvedValue(sampleDiff);
+  });
+
+  test('should not fetch diffs when includeDiffs is disabled', async () => {
+    // Mock the dependencies for pack
+    const mockSearchFiles = vi.fn().mockResolvedValue({ filePaths: [] });
+    const mockCollectFiles = vi.fn().mockResolvedValue([]);
+    const mockProcessFiles = vi.fn().mockResolvedValue([]);
+    const mockGenerateOutput = vi.fn().mockResolvedValue('mocked output');
+    const mockValidateFileSafety = vi.fn().mockResolvedValue({
+      safeFilePaths: [],
+      safeRawFiles: [],
+      suspiciousFilesResults: [],
+    });
+    const mockHandleOutput = vi.fn().mockResolvedValue(undefined);
+    const mockCopyToClipboard = vi.fn().mockResolvedValue(undefined);
+    const mockCalculateMetrics = vi.fn().mockResolvedValue({
+      totalFiles: 0,
+      totalCharacters: 0,
+      totalTokens: 0,
+      fileCharCounts: {},
+      fileTokenCounts: {},
+    });
+    const mockSortPaths = vi.fn().mockImplementation((paths) => paths);
+
+    // Config with diffs disabled
+    mockConfig.output.git!.includeDiffs = false;
+
+    await pack([mockRootDir], mockConfig, vi.fn(), {
+      searchFiles: mockSearchFiles,
+      collectFiles: mockCollectFiles,
+      processFiles: mockProcessFiles,
+      generateOutput: mockGenerateOutput,
+      validateFileSafety: mockValidateFileSafety,
+      handleOutput: mockHandleOutput,
+      copyToClipboardIfEnabled: mockCopyToClipboard,
+      calculateMetrics: mockCalculateMetrics,
+      sortPaths: mockSortPaths,
+    });
+
+    // Should not call getWorkTreeDiff
+    expect(gitCommandModule.getWorkTreeDiff).not.toHaveBeenCalled();
+  });
+
+  test('should include diffs in output context when enabled', async () => {
+    // Reset all mocks to make sure they're clean
+    vi.resetAllMocks();
+
+    // Mock the git command to return our sample diff
+    vi.mocked(gitCommandModule.isGitRepository).mockResolvedValue(true);
+    vi.mocked(gitCommandModule.getWorkTreeDiff).mockResolvedValue(sampleDiff);
+
+    // Config with diffs enabled
+    mockConfig.output.git!.includeDiffs = true;
+
+    // Test the buildOutputGeneratorContext function directly
+    const rootDirs = [mockRootDir];
+    const allFilePaths = ['file1.js'];
+    const processedFiles: ProcessedFile[] = [
+      {
+        path: 'file1.js',
+        content: 'console.log("test");',
+        originalContent: 'console.log("test");',
+      },
+    ];
+
+    const context = await buildOutputGeneratorContext(rootDirs, mockConfig, allFilePaths, processedFiles);
+
+    // Should call getWorkTreeDiff
+    expect(gitCommandModule.getWorkTreeDiff).toHaveBeenCalledWith(mockRootDir);
+
+    // Context should include gitDiffs
+    expect(context.gitDiffs).toBe(sampleDiff);
+
+    // Config should have diffContent
+    expect(mockConfig.output.git!.diffContent).toBe(sampleDiff);
+  });
+
+  test('should handle errors when getting diffs in output generation', async () => {
+    // Mock getWorkTreeDiff to throw an error
+    vi.mocked(gitCommandModule.getWorkTreeDiff).mockRejectedValue(new Error('Git error'));
+
+    // Mock the buildOutputGeneratorContext function
+    const rootDirs = ['/test/repo'];
+    const allFilePaths = ['file1.js'];
+    const processedFiles: ProcessedFile[] = [
+      {
+        path: 'file1.js',
+        content: 'console.log("file1");',
+        originalContent: 'console.log("file1");',
+      },
+    ];
+
+    // Enable diffs
+    mockConfig.output.git!.includeDiffs = true;
+
+    // Testing the buildOutputGeneratorContext function directly, which should throw
+    await expect(buildOutputGeneratorContext(rootDirs, mockConfig, allFilePaths, processedFiles)).rejects.toThrow(
+      'Failed to get git diffs: Git error',
+    );
+  });
+
+  test('should calculate diff token count correctly', async () => {
+    // Create a processed files array with a sample file
+    const processedFiles: ProcessedFile[] = [
+      {
+        path: 'test.js',
+        content: 'console.log("test");',
+        originalContent: 'console.log("test");',
+      },
+    ];
+
+    // Mock dependencies
+    const mockSearchFiles = vi.fn().mockResolvedValue({ filePaths: ['test.js'] });
+    const mockCollectFiles = vi.fn().mockResolvedValue(processedFiles);
+    const mockProcessFiles = vi.fn().mockResolvedValue(processedFiles);
+    const mockGenerateOutput = vi.fn().mockResolvedValue('Generated output with diffs included');
+    const mockValidateFileSafety = vi.fn().mockResolvedValue({
+      safeFilePaths: ['test.js'],
+      safeRawFiles: processedFiles,
+      suspiciousFilesResults: [],
+    });
+    const mockHandleOutput = vi.fn().mockResolvedValue(undefined);
+    const mockCopyToClipboard = vi.fn().mockResolvedValue(undefined);
+    const mockCalculateMetrics = vi.fn().mockResolvedValue({
+      totalFiles: 1,
+      totalCharacters: 30,
+      totalTokens: 10,
+      fileCharCounts: { 'test.js': 10 },
+      fileTokenCounts: { 'test.js': 5 },
+      diffTokenCount: 15, // Mock diff token count
+    });
+    const mockSortPaths = vi.fn().mockImplementation((paths) => paths);
+
+    // Config with diffs enabled
+    mockConfig.output.git!.includeDiffs = true;
+
+    const result = await pack([mockRootDir], mockConfig, vi.fn(), {
+      searchFiles: mockSearchFiles,
+      collectFiles: mockCollectFiles,
+      processFiles: mockProcessFiles,
+      generateOutput: mockGenerateOutput,
+      validateFileSafety: mockValidateFileSafety,
+      handleOutput: mockHandleOutput,
+      copyToClipboardIfEnabled: mockCopyToClipboard,
+      calculateMetrics: mockCalculateMetrics,
+      sortPaths: mockSortPaths,
+    });
+
+    // Check diffTokenCount in the result
+    expect(result.diffTokenCount).toBe(15);
+
+    // Check suspiciousFilesResults has diffTokenCount
+    expect(result.suspiciousFilesResults).toHaveProperty('diffTokenCount', 15);
+  });
+});

--- a/tests/core/security/filterOutUntrustedFiles.test.ts
+++ b/tests/core/security/filterOutUntrustedFiles.test.ts
@@ -4,14 +4,14 @@ import { filterOutUntrustedFiles } from '../../../src/core/security/filterOutUnt
 import type { SuspiciousFileResult } from '../../../src/core/security/securityCheck.js';
 
 describe('filterOutUntrustedFiles', () => {
-  it('should filter out untrusted files', () => {
+  it('should filter out files marked as suspicious', () => {
     const rawFiles: RawFile[] = [
       { path: 'file1.txt', content: 'content 1' },
       { path: 'file2.txt', content: 'content 2' },
       { path: 'file3.txt', content: 'content 3' },
     ];
     const suspiciousFilesResults: SuspiciousFileResult[] = [
-      { filePath: 'file2.txt', messages: ['something suspicious.'] },
+      { filePath: 'file2.txt', messages: ['something suspicious.'], type: 'file' },
     ];
     const expectedGoodFiles = [rawFiles[0], rawFiles[2]];
 

--- a/tests/core/security/securityCheck.test.ts
+++ b/tests/core/security/securityCheck.test.ts
@@ -31,9 +31,7 @@ const mockInitTaskRunner = () => {
 
 describe('runSecurityCheck', () => {
   it('should identify files with security issues', async () => {
-    const result = await runSecurityCheck(mockFiles, () => {}, {
-      initTaskRunner: mockInitTaskRunner,
-    });
+    const result = await runSecurityCheck(mockFiles, () => {}, undefined, { initTaskRunner: mockInitTaskRunner });
 
     expect(result).toHaveLength(1);
     expect(result[0].filePath).toBe('test1.js');
@@ -43,7 +41,7 @@ describe('runSecurityCheck', () => {
   it('should call progress callback with correct messages', async () => {
     const progressCallback = vi.fn();
 
-    await runSecurityCheck(mockFiles, progressCallback, {
+    await runSecurityCheck(mockFiles, progressCallback, undefined, {
       initTaskRunner: mockInitTaskRunner,
     });
 
@@ -64,7 +62,7 @@ describe('runSecurityCheck', () => {
     };
 
     await expect(
-      runSecurityCheck(mockFiles, () => {}, {
+      runSecurityCheck(mockFiles, () => {}, undefined, {
         initTaskRunner: mockErrorTaskRunner,
       }),
     ).rejects.toThrow('Worker error');
@@ -73,7 +71,7 @@ describe('runSecurityCheck', () => {
   });
 
   it('should handle empty file list', async () => {
-    const result = await runSecurityCheck([], () => {}, {
+    const result = await runSecurityCheck([], () => {}, undefined, {
       initTaskRunner: mockInitTaskRunner,
     });
 
@@ -81,7 +79,7 @@ describe('runSecurityCheck', () => {
   });
 
   it('should log performance metrics in trace mode', async () => {
-    await runSecurityCheck(mockFiles, () => {}, {
+    await runSecurityCheck(mockFiles, () => {}, undefined, {
       initTaskRunner: mockInitTaskRunner,
     });
 
@@ -92,7 +90,7 @@ describe('runSecurityCheck', () => {
   it('should process files in parallel', async () => {
     const startTime = Date.now();
 
-    await runSecurityCheck(mockFiles, () => {}, {
+    await runSecurityCheck(mockFiles, () => {}, undefined, {
       initTaskRunner: mockInitTaskRunner,
     });
 
@@ -106,7 +104,7 @@ describe('runSecurityCheck', () => {
   it('should not modify original files', async () => {
     const originalFiles = JSON.parse(JSON.stringify(mockFiles));
 
-    await runSecurityCheck(mockFiles, () => {}, {
+    await runSecurityCheck(mockFiles, () => {}, undefined, {
       initTaskRunner: mockInitTaskRunner,
     });
 

--- a/tests/core/security/validateFileSafety.test.ts
+++ b/tests/core/security/validateFileSafety.test.ts
@@ -25,14 +25,15 @@ describe('validateFileSafety', () => {
       filterOutUntrustedFiles: vi.fn().mockReturnValue(safeRawFiles),
     };
 
-    const result = await validateFileSafety(rawFiles, progressCallback, config, deps);
+    const result = await validateFileSafety(rawFiles, progressCallback, config, undefined, deps);
 
-    expect(deps.runSecurityCheck).toHaveBeenCalledWith(rawFiles, progressCallback);
+    expect(deps.runSecurityCheck).toHaveBeenCalledWith(rawFiles, progressCallback, undefined);
     expect(deps.filterOutUntrustedFiles).toHaveBeenCalledWith(rawFiles, suspiciousFilesResults);
     expect(result).toEqual({
       safeRawFiles,
       safeFilePaths: ['file1.txt', 'file2.txt'],
       suspiciousFilesResults,
+      suspiciousGitDiffResults: [],
     });
   });
 });

--- a/tests/core/security/validateFileSafety.test.ts
+++ b/tests/core/security/validateFileSafety.test.ts
@@ -18,7 +18,7 @@ describe('validateFileSafety', () => {
     } as RepomixConfigMerged;
     const progressCallback: RepomixProgressCallback = vi.fn();
     const suspiciousFilesResults: SuspiciousFileResult[] = [
-      { filePath: 'file2.txt', messages: ['something suspicious.'] },
+      { filePath: 'file2.txt', messages: ['something suspicious.'], type: 'file' },
     ];
     const deps = {
       runSecurityCheck: vi.fn().mockResolvedValue(suspiciousFilesResults),

--- a/tests/core/security/workers/securityCheckWorker.test.ts
+++ b/tests/core/security/workers/securityCheckWorker.test.ts
@@ -44,7 +44,7 @@ H4PSJT5bvaEhxRj7QCwonoX4ZpV0beTnzloS55Z65g==
     `;
     // secretlint-enable
 
-    const secretLintResult = await runSecretLint('test.md', sensitiveContent, config);
+    const secretLintResult = await runSecretLint('test.md', sensitiveContent, 'file', config);
     expect(secretLintResult).not.toBeNull();
   });
 
@@ -71,7 +71,7 @@ And here's a list:
 That's all!
     `;
 
-    const secretLintResult = await runSecretLint('normal.md', normalContent, config);
+    const secretLintResult = await runSecretLint('normal.md', normalContent, 'file', config);
     expect(secretLintResult).toBeNull();
   });
 });

--- a/tests/core/treeSitter/parseFile.solidity.test.ts
+++ b/tests/core/treeSitter/parseFile.solidity.test.ts
@@ -26,6 +26,7 @@ describe('Solidity File Parsing', () => {
       git: {
         sortByChanges: true,
         sortByChangesMaxCommits: 100,
+        includeDiffs: false,
       },
     },
     include: [],

--- a/tests/integration-tests/packager.test.ts
+++ b/tests/integration-tests/packager.test.ts
@@ -92,18 +92,23 @@ describe.runIf(!isWindows)('packager integration', () => {
         },
         generateOutput,
         validateFileSafety: (rawFiles, progressCallback, config) => {
-          return validateFileSafety(rawFiles, progressCallback, config, {
+          const gitDiffMock = {
+            workTreeDiffContent: '',
+            stagedDiffContent: '',
+          };
+          return validateFileSafety(rawFiles, progressCallback, config, gitDiffMock, {
             runSecurityCheck: async () => [],
             filterOutUntrustedFiles,
           });
         },
         handleOutput: writeOutputToDisk,
         copyToClipboardIfEnabled,
-        calculateMetrics: async (processedFiles, output, progressCallback, config) => {
+        calculateMetrics: async (processedFiles, output, progressCallback, config, gitDiffResult) => {
           return {
             totalFiles: processedFiles.length,
             totalCharacters: processedFiles.reduce((acc, file) => acc + file.content.length, 0),
             totalTokens: processedFiles.reduce((acc, file) => acc + file.content.split(/\s+/).length, 0),
+            gitDiffTokenCount: 0,
             fileCharCounts: processedFiles.reduce(
               (acc, file) => {
                 acc[file.path] = file.content.length;
@@ -118,6 +123,8 @@ describe.runIf(!isWindows)('packager integration', () => {
               },
               {} as Record<string, number>,
             ),
+            suspiciousFilesResults: [],
+            suspiciousGitDiffResults: [],
           };
         },
       });

--- a/tests/mcp/tools/packCodebaseTool.test.ts
+++ b/tests/mcp/tools/packCodebaseTool.test.ts
@@ -73,6 +73,7 @@ describe('PackCodebaseTool', () => {
           git: {
             sortByChanges: true,
             sortByChangesMaxCommits: 100,
+            includeDiffs: false,
           },
           includeEmptyDirectories: false,
         },

--- a/tests/mcp/tools/packCodebaseTool.test.ts
+++ b/tests/mcp/tools/packCodebaseTool.test.ts
@@ -30,6 +30,8 @@ describe('PackCodebaseTool', () => {
     fileCharCounts: { 'test.js': 100 },
     fileTokenCounts: { 'test.js': 50 },
     suspiciousFilesResults: [],
+    gitDiffTokenCount: 0,
+    suspiciousGitDiffResults: [],
   };
 
   beforeEach(() => {

--- a/website/client/src/de/guide/command-line-options.md
+++ b/website/client/src/de/guide/command-line-options.md
@@ -18,6 +18,7 @@
 - `--header-text <text>`: Benutzerdefinierter Text für den Dateikopf
 - `--instruction-file-path <path>`: Pfad zu einer Datei mit detaillierten benutzerdefinierten Anweisungen
 - `--include-empty-directories`: Leere Verzeichnisse in die Ausgabe einbeziehen (Standard: `false`)
+- `--include-diffs`: Git-Unterschiede in die Ausgabe einbeziehen (enthält sowohl Arbeitsbaum- als auch gestaged Änderungen separat) (Standard: `false`)
 
 ## Filteroptionen
 - `--include <patterns>`: Einzuschließende Muster (durch Komma getrennt)

--- a/website/client/src/de/guide/configuration.md
+++ b/website/client/src/de/guide/configuration.md
@@ -99,10 +99,11 @@ Weitere Details und Beispiele finden Sie im [Code-Komprimierungs-Leitfaden](code
 
 ### Git-Integration
 
-Die `output.git`-Konfiguration ermöglicht es Ihnen, die Sortierung von Dateien basierend auf der Git-Historie zu steuern:
+Die `output.git`-Konfiguration ermöglicht es Ihnen, die Sortierung von Dateien basierend auf der Git-Historie zu steuern und Git-Unterschiede einzubeziehen:
 
 - `sortByChanges`: Wenn auf `true` gesetzt, werden Dateien nach der Anzahl der Git-Änderungen (Commits, die die Datei geändert haben) sortiert. Dateien mit mehr Änderungen erscheinen am Ende der Ausgabe. Dies hilft dabei, aktiver entwickelte Dateien zu priorisieren. Standard: `true`
 - `sortByChangesMaxCommits`: Die maximale Anzahl von Commits, die bei der Zählung der Dateiänderungen analysiert werden. Standard: `100`
+- `includeDiffs`: Wenn auf `true` gesetzt, werden Git-Unterschiede in die Ausgabe einbezogen (enthält sowohl Arbeitsbaumänderungen als auch Staging-Änderungen separat). Dies ermöglicht es dem Leser, ausstehende Änderungen im Repository zu sehen. Standard: `false`
 
 Beispielkonfiguration:
 ```json
@@ -110,7 +111,8 @@ Beispielkonfiguration:
   "output": {
     "git": {
       "sortByChanges": true,
-      "sortByChangesMaxCommits": 100
+      "sortByChangesMaxCommits": 100,
+      "includeDiffs": true
     }
   }
 }

--- a/website/client/src/en/guide/command-line-options.md
+++ b/website/client/src/en/guide/command-line-options.md
@@ -18,6 +18,8 @@
 - `--header-text <text>`: Custom text to include in the file header
 - `--instruction-file-path <path>`: Path to a file containing detailed custom instructions
 - `--include-empty-directories`: Include empty directories in the output (default: `false`)
+- `--include-diffs`: Include git diffs in the output (includes both work tree and staged changes separately) (default: `false`)
+- `--no-git-sort-by-changes`: Disable sorting files by git change count (default: `true`)
 
 ## Filter Options
 - `--include <patterns>`: Include patterns (comma-separated)

--- a/website/client/src/en/guide/configuration.md
+++ b/website/client/src/en/guide/configuration.md
@@ -99,10 +99,11 @@ For more details and examples, see [Code Compression Guide](code-compress).
 
 ### Git Integration
 
-The `output.git` configuration allows you to control how files are sorted based on Git history:
+The `output.git` configuration allows you to control how files are sorted based on Git history and include Git diffs:
 
 - `sortByChanges`: When set to `true`, files are sorted by the number of Git changes (commits that modified the file). Files with more changes appear at the bottom of the output. This can help prioritize more actively developed files. Default: `true`
 - `sortByChangesMaxCommits`: The maximum number of commits to analyze when counting file changes. Default: `100`
+- `includeDiffs`: When set to `true`, includes Git diffs in the output (includes both work tree and staged changes separately). This allows the reader to see pending changes in the repository. Default: `false`
 
 Example configuration:
 ```json
@@ -110,7 +111,8 @@ Example configuration:
   "output": {
     "git": {
       "sortByChanges": true,
-      "sortByChangesMaxCommits": 100
+      "sortByChangesMaxCommits": 100,
+      "includeDiffs": true
     }
   }
 }

--- a/website/client/src/es/guide/command-line-options.md
+++ b/website/client/src/es/guide/command-line-options.md
@@ -18,6 +18,7 @@
 - `--header-text <text>`: Texto personalizado para incluir en el encabezado del archivo
 - `--instruction-file-path <path>`: Ruta al archivo con instrucciones personalizadas detalladas
 - `--include-empty-directories`: Incluye directorios vacíos en la salida (predeterminado: `false`)
+- `--include-diffs`: Incluye las diferencias de git en la salida (incluye por separado los cambios del árbol de trabajo y los cambios preparados) (predeterminado: `false`)
 
 ## Opciones de Filtrado
 - `--include <patterns>`: Patrones a incluir (separados por comas)

--- a/website/client/src/es/guide/configuration.md
+++ b/website/client/src/es/guide/configuration.md
@@ -99,10 +99,11 @@ Para más detalles y ejemplos, consulte la [Guía de Compresión de Código](cod
 
 ### Integración con Git
 
-La configuración `output.git` le permite controlar cómo se ordenan los archivos según el historial de Git:
+La configuración `output.git` le permite controlar cómo se ordenan los archivos según el historial de Git y cómo incluir diferencias de Git:
 
 - `sortByChanges`: Cuando está configurado como `true`, los archivos se ordenan por el número de cambios en Git (commits que modificaron el archivo). Los archivos con más cambios aparecen al final de la salida. Esto ayuda a priorizar los archivos más activamente desarrollados. Por defecto: `true`
 - `sortByChangesMaxCommits`: El número máximo de commits a analizar al contar los cambios de archivos. Por defecto: `100`
+- `includeDiffs`: Cuando está configurado como `true`, incluye diferencias de Git en la salida (incluye por separado tanto los cambios del árbol de trabajo como los cambios preparados). Esto permite al lector ver los cambios pendientes en el repositorio. Por defecto: `false`
 
 Ejemplo de configuración:
 ```json
@@ -110,7 +111,8 @@ Ejemplo de configuración:
   "output": {
     "git": {
       "sortByChanges": true,
-      "sortByChangesMaxCommits": 100
+      "sortByChangesMaxCommits": 100,
+      "includeDiffs": true
     }
   }
 }

--- a/website/client/src/fr/guide/command-line-options.md
+++ b/website/client/src/fr/guide/command-line-options.md
@@ -18,6 +18,7 @@
 - `--header-text <texte>`: Texte personnalisé à inclure dans l'en-tête du fichier
 - `--instruction-file-path <chemin>`: Chemin vers un fichier contenant des instructions personnalisées détaillées
 - `--include-empty-directories`: Inclure les répertoires vides dans la sortie (par défaut: `false`)
+- `--include-diffs`: Inclure les différences git dans la sortie (inclut séparément les modifications de l'arbre de travail et les modifications indexées) (par défaut: `false`)
 
 ## Options de filtrage
 - `--include <motifs>`: Motifs d'inclusion (séparés par des virgules)

--- a/website/client/src/fr/guide/configuration.md
+++ b/website/client/src/fr/guide/configuration.md
@@ -97,9 +97,10 @@ Pour plus de détails et d'exemples, consultez le [Guide de compression de code]
 
 ### Intégration Git
 
-La configuration `output.git` vous permet de contrôler comment les fichiers sont triés en fonction de l'historique Git:
+La configuration `output.git` vous permet de contrôler comment les fichiers sont triés en fonction de l'historique Git et comment inclure les différences Git:
 - `sortByChanges`: Lorsque défini sur `true`, les fichiers sont triés par nombre de changements Git (commits qui ont modifié le fichier). Les fichiers avec plus de changements apparaissent en bas de la sortie. Cela peut aider à prioriser les fichiers plus activement développés. Par défaut: `true`
 - `sortByChangesMaxCommits`: Le nombre maximum de commits à analyser lors du comptage des modifications de fichiers. Par défaut: `100`
+- `includeDiffs`: Lorsque défini sur `true`, inclut les différences Git dans la sortie (inclut séparément les modifications de l'arbre de travail et les modifications en cours). Cela permet au lecteur de voir les changements en attente dans le dépôt. Par défaut: `false`
 
 Exemple de configuration:
 ```json
@@ -107,7 +108,8 @@ Exemple de configuration:
   "output": {
     "git": {
       "sortByChanges": true,
-      "sortByChangesMaxCommits": 100
+      "sortByChangesMaxCommits": 100,
+      "includeDiffs": true
     }
   }
 }

--- a/website/client/src/ja/guide/command-line-options.md
+++ b/website/client/src/ja/guide/command-line-options.md
@@ -18,6 +18,8 @@
 - `--header-text <text>`: ファイルヘッダーに含めるカスタムテキスト
 - `--instruction-file-path <path>`: 詳細なカスタム指示を含むファイルのパス
 - `--include-empty-directories`: 空のディレクトリを出力に含める（デフォルト: `false`）
+- `--include-diffs`: Gitの差分を出力に含める（ワークツリーとステージングされた変更が別々に含まれます）（デフォルト: `false`）
+- `--no-git-sort-by-changes`: Gitの変更回数によるファイルのソートを無効化（デフォルト: `true`）
 
 ## フィルターオプション
 - `--include <patterns>`: 含めるパターン（カンマ区切り）

--- a/website/client/src/ja/guide/configuration.md
+++ b/website/client/src/ja/guide/configuration.md
@@ -99,10 +99,11 @@ dist/**
 
 ### Git統合
 
-`output.git`設定では、Gitの履歴に基づいてファイルをソートする方法を制御できます：
+`output.git`設定では、Gitの履歴に基づいてファイルをソートする方法や、Gitの差分を含める方法を制御できます：
 
 - `sortByChanges`: `true`に設定すると、ファイルはGitの変更回数（そのファイルを変更したコミット数）でソートされます。より多くの変更があるファイルが出力の下部に表示されます。これは、より活発に開発されているファイルを優先するのに役立ちます。デフォルト: `true`
 - `sortByChangesMaxCommits`: ファイルの変更回数を数える際に分析する最大コミット数。デフォルト: `100`
+- `includeDiffs`: `true`に設定すると、Git差分を出力に含めます（ワークツリーとステージング済みの変更を別々に含みます）。これにより、リポジトリの保留中の変更を確認できます。デフォルト: `false`
 
 設定例：
 ```json
@@ -110,7 +111,8 @@ dist/**
   "output": {
     "git": {
       "sortByChanges": true,
-      "sortByChangesMaxCommits": 100
+      "sortByChangesMaxCommits": 100,
+      "includeDiffs": true
     }
   }
 }

--- a/website/client/src/ko/guide/command-line-options.md
+++ b/website/client/src/ko/guide/command-line-options.md
@@ -18,6 +18,8 @@
 - `--header-text <text>`: 파일 헤더에 포함할 사용자 정의 텍스트
 - `--instruction-file-path <path>`: 상세한 사용자 정의 지침이 포함된 파일 경로
 - `--include-empty-directories`: 출력에 빈 디렉토리 포함 (기본값: `false`)
+- `--include-diffs`: git 차이점을 출력에 포함 (작업 트리 및 스테이지된 변경 사항이 별도로 포함됨) (기본값: `false`)
+- `--no-git-sort-by-changes`: git 변경 횟수로 파일 정렬 비활성화 (기본값: `true`)
 
 ## 필터 옵션
 - `--include <patterns>`: 포함할 패턴 (쉼표로 구분)

--- a/website/client/src/ko/guide/configuration.md
+++ b/website/client/src/ko/guide/configuration.md
@@ -99,10 +99,11 @@ dist/**
 
 ### Git 통합
 
-`output.git` 설정을 통해 Git 히스토리를 기반으로 파일을 정렬하는 방법을 제어할 수 있습니다:
+`output.git` 설정을 통해 Git 히스토리를 기반으로 파일을 정렬하는 방법과 Git 차이점을 포함하는 방법을 제어할 수 있습니다:
 
 - `sortByChanges`: `true`로 설정하면, 파일은 Git 변경 횟수(해당 파일을 수정한 커밋 수)에 따라 정렬됩니다. 더 많은 변경이 있는 파일이 출력의 하단에 표시됩니다. 이는 더 활발하게 개발되는 파일을 우선순위화하는 데 도움이 됩니다. 기본값: `true`
 - `sortByChangesMaxCommits`: 파일 변경 횟수를 계산할 때 분석할 최대 커밋 수입니다. 기본값: `100`
+- `includeDiffs`: `true`로 설정하면, Git 차이점을 출력에 포함합니다(작업 트리와 스테이지된 변경사항을 별도로 포함). 이를 통해 저장소의 대기 중인 변경 사항을 확인할 수 있습니다. 기본값: `false`
 
 설정 예시:
 ```json
@@ -110,7 +111,8 @@ dist/**
   "output": {
     "git": {
       "sortByChanges": true,
-      "sortByChangesMaxCommits": 100
+      "sortByChangesMaxCommits": 100,
+      "includeDiffs": true
     }
   }
 }

--- a/website/client/src/pt-br/guide/command-line-options.md
+++ b/website/client/src/pt-br/guide/command-line-options.md
@@ -18,6 +18,8 @@
 - `--header-text <text>`: Texto personalizado para incluir no cabeçalho do arquivo
 - `--instruction-file-path <path>`: Caminho para um arquivo contendo instruções personalizadas detalhadas
 - `--include-empty-directories`: Inclui diretórios vazios na saída (padrão: `false`)
+- `--include-diffs`: Inclui diferenças do git na saída (inclui separadamente as alterações da árvore de trabalho e as alterações preparadas) (padrão: `false`)
+- `--no-git-sort-by-changes`: Desabilita a ordenação de arquivos por contagem de alterações do git (padrão: `true`)
 
 ## Opções de Filtro
 - `--include <patterns>`: Padrões para incluir (separados por vírgula)

--- a/website/client/src/pt-br/guide/configuration.md
+++ b/website/client/src/pt-br/guide/configuration.md
@@ -99,10 +99,11 @@ Para mais detalhes e exemplos, consulte o [Guia de Compressão de Código](code-
 
 ### Integração com Git
 
-A configuração `output.git` permite controlar como os arquivos são ordenados com base no histórico do Git:
+A configuração `output.git` permite controlar como os arquivos são ordenados com base no histórico do Git e como incluir diferenças do Git:
 
 - `sortByChanges`: Quando configurado como `true`, os arquivos são ordenados pelo número de alterações no Git (commits que modificaram o arquivo). Arquivos com mais alterações aparecem no final da saída. Isso ajuda a priorizar arquivos mais ativamente desenvolvidos. Padrão: `true`
 - `sortByChangesMaxCommits`: O número máximo de commits a analisar ao contar as alterações de arquivos. Padrão: `100`
+- `includeDiffs`: Quando configurado como `true`, inclui diferenças do Git na saída (inclui separadamente tanto as alterações da árvore de trabalho quanto as alterações preparadas). Isso permite que o leitor veja as alterações pendentes no repositório. Padrão: `false`
 
 Exemplo de configuração:
 ```json
@@ -110,7 +111,8 @@ Exemplo de configuração:
   "output": {
     "git": {
       "sortByChanges": true,
-      "sortByChangesMaxCommits": 100
+      "sortByChangesMaxCommits": 100,
+      "includeDiffs": true
     }
   }
 }

--- a/website/client/src/zh-cn/guide/command-line-options.md
+++ b/website/client/src/zh-cn/guide/command-line-options.md
@@ -18,6 +18,8 @@
 - `--header-text <text>`: 文件头部包含的自定义文本
 - `--instruction-file-path <path>`: 包含详细自定义指令的文件路径
 - `--include-empty-directories`: 在输出中包含空目录（默认：`false`）
+- `--include-diffs`: 在输出中包含 git 差异（包括工作树和已暂存的变更，它们将分开显示）（默认：`false`）
+- `--no-git-sort-by-changes`: 禁用按 git 变更计数排序文件（默认：`true`）
 
 ## 过滤选项
 - `--include <patterns>`: 包含模式（逗号分隔）

--- a/website/client/src/zh-cn/guide/configuration.md
+++ b/website/client/src/zh-cn/guide/configuration.md
@@ -99,10 +99,11 @@ dist/**
 
 ### Git 集成
 
-`output.git` 配置允许您控制如何基于 Git 历史记录对文件进行排序：
+`output.git` 配置允许您控制如何基于 Git 历史记录对文件进行排序以及如何包含 Git 差异：
 
 - `sortByChanges`：当设置为 `true` 时，文件将按 Git 更改次数（修改该文件的提交数）进行排序。更改次数较多的文件将出现在输出的底部。这有助于优先处理更活跃开发的文件。默认值：`true`
 - `sortByChangesMaxCommits`：计算文件更改次数时要分析的最大提交数。默认值：`100`
+- `includeDiffs`：当设置为 `true` 时，在输出中包含 Git 差异（同时分别包含工作树和暂存区的更改）。这允许读者查看存储库中的待处理更改。默认值：`false`
 
 配置示例：
 ```json
@@ -110,7 +111,8 @@ dist/**
   "output": {
     "git": {
       "sortByChanges": true,
-      "sortByChangesMaxCommits": 100
+      "sortByChangesMaxCommits": 100,
+      "includeDiffs": true
     }
   }
 }

--- a/website/client/src/zh-tw/guide/command-line-options.md
+++ b/website/client/src/zh-tw/guide/command-line-options.md
@@ -18,6 +18,8 @@
 - `--header-text <text>`: 文件頭部包含的自定義文本
 - `--instruction-file-path <path>`: 包含詳細自定義指令的文件路徑
 - `--include-empty-directories`: 在輸出中包含空目錄（預設：`false`）
+- `--include-diffs`: 在輸出中包含 git 差異（包括工作樹和已暫存的變更，它們將分開顯示）（預設：`false`）
+- `--no-git-sort-by-changes`: 禁用按 git 變更計數排序文件（預設：`true`）
 
 ## 過濾選項
 - `--include <patterns>`: 包含模式（逗號分隔）

--- a/website/client/src/zh-tw/guide/configuration.md
+++ b/website/client/src/zh-tw/guide/configuration.md
@@ -98,3 +98,22 @@ dist/**
 更多詳細信息和示例，請參閱[程式碼壓縮指南](code-compress)。
 
 ### Git 集成
+
+`output.git` 配置允許您控制如何基於 Git 歷史記錄對文件進行排序以及如何包含 Git 差異：
+
+- `sortByChanges`：當設置為 `true` 時，文件將按 Git 更改次數（修改該文件的提交數）進行排序。更改次數較多的文件將出現在輸出的底部。這有助於優先處理更活躍開發的文件。默認值：`true`
+- `sortByChangesMaxCommits`：計算文件更改次數時要分析的最大提交數。默認值：`100`
+- `includeDiffs`：當設置為 `true` 時，在輸出中包含 Git 差異（同時分別包含工作樹和暫存區的更改）。這允許讀者查看存儲庫中的待處理更改。默認值：`false`
+
+配置示例：
+```json
+{
+  "output": {
+    "git": {
+      "sortByChanges": true,
+      "sortByChangesMaxCommits": 100,
+      "includeDiffs": true
+    }
+  }
+}
+```


### PR DESCRIPTION
Added git diff support with --diffs flag; showing working tree diffs. 

I think this is helpful when you are iterating against a feature/issue, so that the LLM is aware of the changes you made so far, until you've staged it. Not really sure where to put the `diffs` section, but for now I've placed it before instruction (if available).

## Checklist

- [ X] Run `npm run test`
- [ X] Run `npm run lint`
