### PR TITLE
Add --stdout option for CLI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ Instruction
 
 #### Output Options
 - `-o, --output <file>`: Specify the output file name
+- `--stdout`: Output to stdout instead of writing to a file (cannot be used with `--output` option)
 - `--style <style>`: Specify the output style (`xml`, `markdown`, `plain`)
 - `--parsable-style`: Enable parsable output based on the chosen style schema. Note that this can increase token count.
 - `--compress`: Perform intelligent code extraction, focusing on essential function and class signatures to reduce token count
@@ -485,12 +486,32 @@ Instruction
 Examples:
 
 ```bash
-repomix -o custom-output.txt
-repomix -i "*.log,tmp" -v
-repomix -c ./custom-config.json
-repomix --style xml
-repomix --remote https://github.com/user/repo
-npx repomix src
+# Basic usage
+repomix
+
+# Custom output
+repomix -o output.xml --style xml
+
+# Output to stdout
+repomix --stdout > custom-output.txt
+
+# Send output to stdout, then pipe into another command (for example, simonw/llm)
+repomix --stdout | llm "Please explain what this code does."
+
+# Custom output with compression
+repomix --compress
+
+# Process specific files
+repomix --include "src/**/*.ts" --ignore "**/*.test.ts"
+
+# Remote repository with branch
+repomix --remote https://github.com/user/repo/tree/main
+
+# Remote repository with commit
+repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb28655d85712680f1
+
+# Remote repository with shorthand
+repomix --remote user/repo
 ```
 
 ### Updating Repomix

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -141,6 +141,12 @@ export const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
       parsableStyle: options.parsableStyle,
     };
   }
+  if (options.stdout) {
+    cliConfig.output = {
+      ...cliConfig.output,
+      stdout: true,
+    };
+  }
   // Only apply securityCheck setting if explicitly set to false
   if (options.securityCheck === false) {
     cliConfig.security = { enableSecurityCheck: options.securityCheck };

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -39,6 +39,9 @@ const semanticSuggestionMap: Record<string, string[]> = {
   reduce: ['--compress'],
   'strip-comments': ['--remove-comments'],
   'no-comments': ['--remove-comments'],
+  print: ['--stdout'],
+  console: ['--stdout'],
+  terminal: ['--stdout'],
 };
 
 export const run = async () => {
@@ -50,6 +53,7 @@ export const run = async () => {
       .option('-v, --version', 'show version information')
       // Output Options
       .option('-o, --output <file>', 'specify the output file name')
+      .addOption(new Option('--stdout', 'output to stdout instead of writing to a file').conflicts('output'))
       .option('--style <type>', 'specify the output style (xml, markdown, plain)')
       .option('--parsable-style', 'by escaping and formatting, ensure the output is parsable as a document of its type')
       .option('--compress', 'perform code compression to reduce token count')
@@ -135,6 +139,13 @@ const commanderActionEndpoint = async (directories: string[], options: CliOption
 };
 
 export const runCli = async (directories: string[], cwd: string, options: CliOptions) => {
+  // Detect stdout mode
+  // NOTE: For compatibility, currently not detecting pipe mode
+  const isForceStdoutMode = options.output === '-';
+  if (isForceStdoutMode) {
+    options.stdout = true;
+  }
+
   // Set log level based on verbose and quiet flags
   if (options.quiet) {
     logger.setLogLevel(repomixLogLevels.SILENT);
@@ -142,6 +153,11 @@ export const runCli = async (directories: string[], cwd: string, options: CliOpt
     logger.setLogLevel(repomixLogLevels.DEBUG);
   } else {
     logger.setLogLevel(repomixLogLevels.INFO);
+  }
+
+  // In stdout mode, set log level to SILENT
+  if (options.stdout) {
+    logger.setLogLevel(repomixLogLevels.SILENT);
   }
 
   logger.trace('directories:', directories);

--- a/src/cli/cliSpinner.ts
+++ b/src/cli/cliSpinner.ts
@@ -13,7 +13,7 @@ export class Spinner {
   constructor(message: string, cliOptions: CliOptions) {
     this.message = message;
     // If the user has specified the verbose flag, don't show the spinner
-    this.isQuiet = cliOptions.quiet || cliOptions.verbose || false;
+    this.isQuiet = cliOptions.quiet || cliOptions.verbose || cliOptions.stdout || false;
   }
 
   start(): void {

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -7,6 +7,7 @@ export interface CliOptions extends OptionValues {
 
   // Output Options
   output?: string;
+  stdout?: boolean;
   style?: RepomixOutputStyle;
   parsableStyle?: boolean;
   compress?: boolean;

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -125,10 +125,21 @@ export const repomixConfigDefaultSchema = z.object({
     .default({}),
 });
 
+// File-specific schema. Add options for file path and style
 export const repomixConfigFileSchema = repomixConfigBaseSchema;
 
-export const repomixConfigCliSchema = repomixConfigBaseSchema;
+// CLI-specific schema. Add options for standard output mode
+export const repomixConfigCliSchema = repomixConfigBaseSchema.and(
+  z.object({
+    output: z
+      .object({
+        stdout: z.boolean().optional(),
+      })
+      .optional(),
+  }),
+);
 
+// Merged schema for all configurations
 export const repomixConfigMergedSchema = repomixConfigDefaultSchema
   .and(repomixConfigFileSchema)
   .and(repomixConfigCliSchema)

--- a/src/core/packager/writeOutputToDisk.ts
+++ b/src/core/packager/writeOutputToDisk.ts
@@ -3,8 +3,15 @@ import path from 'node:path';
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
 
-// Write output to file. path is relative to the cwd
+// Write output to file or stdout
 export const writeOutputToDisk = async (output: string, config: RepomixConfigMerged): Promise<undefined> => {
+  // Write to stdout
+  if (config.output.stdout === true) {
+    process.stdout.write(output);
+    return;
+  }
+
+  // Normal case: write to file
   const outputPath = path.resolve(config.cwd, config.output.filePath);
   logger.trace(`Writing output to: ${outputPath}`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export { runCli } from './cli/cliRun.js';
 export { runInitAction } from './cli/actions/initAction.js';
 
 // Default action
-export { runDefaultAction } from './cli/actions/defaultAction.js';
+export { runDefaultAction, buildCliConfig } from './cli/actions/defaultAction.js';
 
 // Remote action
 export {

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -34,6 +34,7 @@ describe('defaultAction', () => {
         removeEmptyLines: false,
         compress: false,
         copyToClipboard: false,
+        stdout: false,
         git: {
           sortByChanges: true,
           sortByChangesMaxCommits: 100,
@@ -176,6 +177,46 @@ describe('defaultAction', () => {
           output: {
             parsableStyle: false,
           },
+        }),
+      );
+    });
+  });
+
+  describe('stdout flag', () => {
+    it('should set stdout to true when --stdout flag is set', async () => {
+      const options: CliOptions = {
+        stdout: true,
+      };
+
+      await runDefaultAction(['.'], process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
+        expect.objectContaining({
+          output: expect.objectContaining({
+            stdout: true,
+          }),
+        }),
+      );
+    });
+
+    it('should handle both --stdout and custom style', async () => {
+      const options: CliOptions = {
+        stdout: true,
+        style: 'markdown',
+      };
+
+      await runDefaultAction(['.'], process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
+        expect.objectContaining({
+          output: expect.objectContaining({
+            stdout: true,
+            style: 'markdown',
+          }),
         }),
       );
     });

--- a/tests/cli/cliRun.test.ts
+++ b/tests/cli/cliRun.test.ts
@@ -383,23 +383,6 @@ describe('cliRun', () => {
       );
     });
 
-    test('should automatically enable stdout mode when piped', async () => {
-      // Mock pipe detection
-      process.stdout.isTTY = false;
-      const options: CliOptions = {};
-
-      await runCli(['.'], process.cwd(), options);
-
-      // stdout should be true in the merged options
-      expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
-        ['.'],
-        process.cwd(),
-        expect.objectContaining({
-          stdout: true,
-        }),
-      );
-    });
-
     test('should not enable stdout mode when explicitly setting output', async () => {
       // Mock pipe detection
       process.stdout.isTTY = false;

--- a/tests/cli/cliRun.test.ts
+++ b/tests/cli/cliRun.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as defaultAction from '../../src/cli/actions/defaultAction.js';
 import * as initAction from '../../src/cli/actions/initAction.js';
 import * as remoteAction from '../../src/cli/actions/remoteAction.js';
@@ -64,6 +64,7 @@ describe('cliRun', () => {
         output: {
           filePath: 'repomix-output.txt',
           style: 'plain',
+          stdout: false,
           parsableStyle: false,
           fileSummary: true,
           directoryStructure: true,
@@ -113,6 +114,7 @@ describe('cliRun', () => {
         },
         output: {
           filePath: 'repomix-output.txt',
+          stdout: false,
           style: 'plain',
           parsableStyle: false,
           fileSummary: true,
@@ -355,6 +357,73 @@ describe('cliRun', () => {
       await runCli(['.'], process.cwd(), options);
 
       expect(logger.getLogLevel()).toBe(repomixLogLevels.INFO);
+    });
+  });
+
+  describe('stdout mode', () => {
+    const originalIsTTY = process.stdout.isTTY;
+
+    afterEach(() => {
+      process.stdout.isTTY = originalIsTTY;
+    });
+
+    test('should handle --stdout flag', async () => {
+      const options: CliOptions = {
+        stdout: true,
+      };
+
+      await runCli(['.'], process.cwd(), options);
+
+      expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
+        ['.'],
+        process.cwd(),
+        expect.objectContaining({
+          stdout: true,
+        }),
+      );
+    });
+
+    test('should automatically enable stdout mode when piped', async () => {
+      // Mock pipe detection
+      process.stdout.isTTY = false;
+      const options: CliOptions = {};
+
+      await runCli(['.'], process.cwd(), options);
+
+      // stdout should be true in the merged options
+      expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
+        ['.'],
+        process.cwd(),
+        expect.objectContaining({
+          stdout: true,
+        }),
+      );
+    });
+
+    test('should not enable stdout mode when explicitly setting output', async () => {
+      // Mock pipe detection
+      process.stdout.isTTY = false;
+      const options: CliOptions = {
+        output: 'custom-output.txt',
+      };
+
+      await runCli(['.'], process.cwd(), options);
+
+      // stdout should not be set
+      expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
+        ['.'],
+        process.cwd(),
+        expect.objectContaining({
+          output: 'custom-output.txt',
+        }),
+      );
+      expect(defaultAction.runDefaultAction).not.toHaveBeenCalledWith(
+        ['.'],
+        process.cwd(),
+        expect.objectContaining({
+          stdout: true,
+        }),
+      );
     });
   });
 });

--- a/tests/core/packager/writeOutputToDisk.test.ts
+++ b/tests/core/packager/writeOutputToDisk.test.ts
@@ -11,6 +11,8 @@ describe('writeOutputToDisk', () => {
   let originalStdoutWrite: typeof process.stdout.write;
 
   beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.writeFile).mockResolvedValue(undefined);
     originalStdoutWrite = process.stdout.write;
     process.stdout.write = vi.fn();
   });
@@ -34,11 +36,11 @@ describe('writeOutputToDisk', () => {
     expect(process.stdout.write).not.toHaveBeenCalled();
   });
 
-  it('should write to stdout when filePath is "-"', async () => {
+  it('should write to stdout if stdout is true', async () => {
     const output = 'test output';
     const config: RepomixConfigMerged = {
       cwd: '/test/directory',
-      output: { filePath: '-' },
+      output: { stdout: true },
     } as RepomixConfigMerged;
 
     await writeOutputToDisk(output, config);

--- a/tests/core/treeSitter/parseFile.solidity.test.ts
+++ b/tests/core/treeSitter/parseFile.solidity.test.ts
@@ -13,6 +13,7 @@ describe('Solidity File Parsing', () => {
     output: {
       filePath: 'output.txt',
       style: 'xml',
+      stdout: false,
       parsableStyle: false,
       fileSummary: true,
       directoryStructure: true,

--- a/tests/mcp/tools/packCodebaseTool.test.ts
+++ b/tests/mcp/tools/packCodebaseTool.test.ts
@@ -63,6 +63,7 @@ describe('PackCodebaseTool', () => {
           filePath: opts.output ?? '/temp/dir/repomix-output.xml',
           style: opts.style ?? 'xml',
           parsableStyle: false,
+          stdout: false,
           fileSummary: true,
           directoryStructure: true,
           removeComments: false,

--- a/website/client/src/de/guide/command-line-options.md
+++ b/website/client/src/de/guide/command-line-options.md
@@ -5,6 +5,7 @@
 
 ## Ausgabeoptionen
 - `-o, --output <file>`: Ausgabedateiname (Standard: `repomix-output.txt`)
+- `--stdout`: Ausgabe an die Standardausgabe anstatt in eine Datei (kann nicht mit der Option `--output` verwendet werden)
 - `--style <type>`: Ausgabeformat (`plain`, `xml`, `markdown`) (Standard: `xml`)
 - `--parsable-style`: Aktiviert parsbare Ausgabe basierend auf dem gewählten Formatschema (Standard: `false`)
 - `--compress`: Führt eine intelligente Code-Extraktion durch, die sich auf Funktions- und Klassensignaturen konzentriert und Implementierungsdetails entfernt. Weitere Details und Beispiele finden Sie im [Code-Komprimierungsleitfaden](code-compress)
@@ -54,6 +55,12 @@ repomix
 
 # Benutzerdefinierte Ausgabe
 repomix -o output.xml --style xml
+
+# Ausgabe an die Standardausgabe
+repomix --stdout > custom-output.txt
+
+# Ausgabe an die Standardausgabe senden, dann in einen anderen Befehl weiterleiten (zum Beispiel: simonw/llm)
+repomix --stdout | llm "Bitte erkläre, was dieser Code macht"
 
 # Benutzerdefinierte Ausgabe mit Komprimierung
 repomix --compress

--- a/website/client/src/en/guide/command-line-options.md
+++ b/website/client/src/en/guide/command-line-options.md
@@ -5,6 +5,7 @@
 
 ## Output Options
 - `-o, --output <file>`: Output file name (default: `repomix-output.txt`)
+- `--stdout`: Output to stdout instead of writing to a file (cannot be used with `--output` option)
 - `--style <type>`: Output style (`plain`, `xml`, `markdown`) (default: `xml`)
 - `--parsable-style`: Enable parsable output based on the chosen style schema (default: `false`)
 - `--compress`: Perform intelligent code extraction, focusing on essential function and class signatures while removing implementation details. For more details and examples, see [Code Compression Guide](code-compress).
@@ -55,6 +56,12 @@ repomix
 
 # Custom output
 repomix -o output.xml --style xml
+
+# Output to stdout
+repomix --stdout > custom-output.txt
+
+# Send output to stdout, then pipe into another command (for example, simonw/llm)
+repomix --stdout | llm "Please explain what this code does."
 
 # Custom output with compression
 repomix --compress

--- a/website/client/src/es/guide/command-line-options.md
+++ b/website/client/src/es/guide/command-line-options.md
@@ -5,6 +5,7 @@
 
 ## Opciones de Salida
 - `-o, --output <file>`: Nombre del archivo de salida (predeterminado: `repomix-output.txt`)
+- `--stdout`: Salida a la salida estándar en lugar de escribir a un archivo (no puede usarse con la opción `--output`)
 - `--style <type>`: Estilo de salida (`plain`, `xml`, `markdown`) (predeterminado: `xml`)
 - `--parsable-style`: Habilita la salida analizable basada en el esquema del estilo elegido (predeterminado: `false`)
 - `--compress`: Realiza una extracción inteligente de código, centrándose en las firmas de funciones y clases mientras elimina los detalles de implementación. Para más detalles y ejemplos, consulte la [Guía de Compresión de Código](code-compress)
@@ -54,6 +55,12 @@ repomix
 
 # Salida personalizada
 repomix -o output.xml --style xml
+
+# Salida a la salida estándar
+repomix --stdout > custom-output.txt
+
+# Enviar salida a la salida estándar, luego canalizar a otro comando (por ejemplo, simonw/llm)
+repomix --stdout | llm "Por favor explica qué hace este código"
 
 # Salida personalizada con compresión
 repomix --compress

--- a/website/client/src/fr/guide/command-line-options.md
+++ b/website/client/src/fr/guide/command-line-options.md
@@ -5,6 +5,7 @@
 
 ## Options de sortie
 - `-o, --output <fichier>`: Nom du fichier de sortie (par défaut: `repomix-output.txt`)
+- `--stdout`: Sortie vers la sortie standard au lieu d'écrire dans un fichier (ne peut pas être utilisé avec l'option `--output`)
 - `--style <type>`: Style de sortie (`plain`, `xml`, `markdown`) (par défaut: `xml`)
 - `--parsable-style`: Activer une sortie analysable basée sur le schéma du style choisi (par défaut: `false`)
 - `--compress`: Effectuer une extraction intelligente du code, en se concentrant sur les signatures essentielles de fonctions et de classes tout en supprimant les détails d'implémentation. Pour plus de détails et d'exemples, voir [Guide de compression de code](code-compress).
@@ -51,16 +52,28 @@
 ```bash
 # Utilisation de base
 repomix
+
 # Sortie personnalisée
 repomix -o output.xml --style xml
+
+# Sortie vers la sortie standard
+repomix --stdout > custom-output.txt
+
+# Envoi de la sortie vers la sortie standard, puis redirection vers une autre commande (par exemple, simonw/llm)
+repomix --stdout | llm "Veuillez expliquer ce que fait ce code"
+
 # Sortie personnalisée avec compression
 repomix --compress
+
 # Traiter des fichiers spécifiques
 repomix --include "src/**/*.ts" --ignore "**/*.test.ts"
+
 # Dépôt distant avec branche
 repomix --remote https://github.com/user/repo/tree/main
+
 # Dépôt distant avec commit
 repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb28655d85712680f1
+
 # Dépôt distant avec format abrégé
 repomix --remote user/repo
 ```

--- a/website/client/src/ja/guide/command-line-options.md
+++ b/website/client/src/ja/guide/command-line-options.md
@@ -5,6 +5,7 @@
 
 ## 出力オプション
 - `-o, --output <file>`: 出力ファイル名（デフォルト: `repomix-output.txt`）
+- `--stdout`: ファイルに書き込む代わりに標準出力に出力（`--output`オプションと併用不可）
 - `--style <type>`: 出力形式（`plain`、`xml`、`markdown`）（デフォルト: `xml`）
 - `--parsable-style`: 選択した形式のスキーマに基づいて解析可能な出力を有効化（デフォルト: `false`）
 - `--compress`: 関数やクラスのシグネチャなどの重要な構造を保持しながら、実装の詳細を削除するインテリジェントなコード抽出を実行します。詳細と例については、[コード圧縮ガイド](code-compress)を参照してください。
@@ -55,6 +56,12 @@ repomix
 
 # カスタム出力
 repomix -o output.xml --style xml
+
+# 標準出力への出力
+repomix --stdout > custom-output.txt
+
+# 標準出力への出力後、他のコマンドへパイプ（例：simonw/llm）
+repomix --stdout | llm "このコードについて説明してください"
 
 # 圧縮を使用したカスタム出力
 repomix --compress

--- a/website/client/src/ko/guide/command-line-options.md
+++ b/website/client/src/ko/guide/command-line-options.md
@@ -5,6 +5,7 @@
 
 ## 출력 옵션
 - `-o, --output <file>`: 출력 파일 이름 (기본값: `repomix-output.txt`)
+- `--stdout`: 파일에 쓰는 대신 표준 출력으로 출력 (`--output` 옵션과 함께 사용 불가)
 - `--style <type>`: 출력 스타일 (`plain`, `xml`, `markdown`) (기본값: `xml`)
 - `--parsable-style`: 선택한 스타일 스키마에 기반한 파싱 가능한 출력 활성화 (기본값: `false`)
 - `--compress`: 함수와 클래스 시그니처에 중점을 두고 구현 세부 사항을 제거하는 지능형 코드 추출을 수행합니다. 자세한 내용과 예제는 [코드 압축 가이드](code-compress)를 참조하세요.
@@ -55,6 +56,12 @@ repomix
 
 # 사용자 정의 출력
 repomix -o output.xml --style xml
+
+# 표준 출력으로 출력
+repomix --stdout > custom-output.txt
+
+# 표준 출력으로 출력 후 다른 명령으로 파이프 (예: simonw/llm)
+repomix --stdout | llm "이 코드가 무엇을 하는지 설명해주세요"
 
 # 압축을 사용한 사용자 정의 출력
 repomix --compress

--- a/website/client/src/pt-br/guide/command-line-options.md
+++ b/website/client/src/pt-br/guide/command-line-options.md
@@ -5,6 +5,7 @@
 
 ## Opções de Saída
 - `-o, --output <file>`: Nome do arquivo de saída (padrão: `repomix-output.txt`)
+- `--stdout`: Saída para a saída padrão em vez de escrever em um arquivo (não pode ser usado com a opção `--output`)
 - `--style <type>`: Estilo de saída (`plain`, `xml`, `markdown`) (padrão: `xml`)
 - `--parsable-style`: Habilita saída analisável baseada no esquema do estilo escolhido (padrão: `false`)
 - `--compress`: Realiza extração inteligente de código, focando nas assinaturas de funções e classes enquanto remove detalhes de implementação. Para mais detalhes e exemplos, consulte o [Guia de Compressão de Código](code-compress)
@@ -55,6 +56,12 @@ repomix
 
 # Saída personalizada
 repomix -o output.xml --style xml
+
+# Saída para a saída padrão
+repomix --stdout > custom-output.txt
+
+# Enviar saída para a saída padrão, depois canalizar para outro comando (por exemplo, simonw/llm)
+repomix --stdout | llm "Por favor, explique o que este código faz"
 
 # Saída personalizada com compressão
 repomix --compress

--- a/website/client/src/zh-cn/guide/command-line-options.md
+++ b/website/client/src/zh-cn/guide/command-line-options.md
@@ -5,6 +5,7 @@
 
 ## 输出选项
 - `-o, --output <file>`: 输出文件名（默认：`repomix-output.txt`）
+- `--stdout`: 输出到标准输出而不是写入文件（不能与`--output`选项一起使用）
 - `--style <type>`: 输出样式（`plain`、`xml`、`markdown`）（默认：`xml`）
 - `--parsable-style`: 启用基于所选样式模式的可解析输出（默认：`false`）
 - `--compress`: 执行智能代码提取，专注于函数和类的签名，同时删除实现细节。有关详细信息和示例，请参阅[代码压缩指南](code-compress)。
@@ -55,6 +56,12 @@ repomix
 
 # 自定义输出
 repomix -o output.xml --style xml
+
+# 输出到标准输出
+repomix --stdout > custom-output.txt
+
+# 将输出发送到标准输出，然后通过管道传递到另一个命令（例如：simonw/llm）
+repomix --stdout | llm "请解释这段代码的功能"
 
 # 使用压缩的自定义输出
 repomix --compress

--- a/website/client/src/zh-tw/guide/command-line-options.md
+++ b/website/client/src/zh-tw/guide/command-line-options.md
@@ -5,6 +5,7 @@
 
 ## 輸出選項
 - `-o, --output <file>`: 輸出文件名（預設：`repomix-output.txt`）
+- `--stdout`: 輸出到標準輸出而不是寫入文件（不能與`--output`選項一起使用）
 - `--style <type>`: 輸出樣式（`plain`、`xml`、`markdown`）（預設：`xml`）
 - `--parsable-style`: 啟用基於所選樣式模式的可解析輸出（預設：`false`）
 - `--compress`: 執行智慧程式碼提取，專注於函數和類的簽名，同時刪除實現細節。有關詳細資訊和示例，請參閱[程式碼壓縮指南](code-compress)。
@@ -55,6 +56,12 @@ repomix
 
 # 自定義輸出
 repomix -o output.xml --style xml
+
+# 輸出到標準輸出
+repomix --stdout > custom-output.txt
+
+# 將輸出發送到標準輸出，然後通過管道傳遞到另一個命令（例如：simonw/llm）
+repomix --stdout | llm "請解釋這段程式碼的功能"
 
 # 使用壓縮的自定義輸出
 repomix --compress


### PR DESCRIPTION
Introduce a `--stdout` flag to enhance CLI flexibility by allowing output to standard output instead of a file. Update CLI configuration, documentation, and tests to support this new feature. Ensure compatibility with existing output options.