### PR TITLE
feat: --no-file-summary now also suppresses generationHeader; doesn't suppress headerText (fixes #554)

### DIFF
--- a/src/core/output/outputGenerate.ts
+++ b/src/core/output/outputGenerate.ts
@@ -62,7 +62,7 @@ const generateParsableXmlOutput = async (renderContext: RenderContext): Promise<
             '#text': renderContext.generationHeader,
             purpose: renderContext.summaryPurpose,
             file_format: `${renderContext.summaryFileFormat}
-4. Repository files, each consisting of:
+5. Repository files, each consisting of:
   - File path as an attribute
   - Full contents of the file`,
             usage_guidelines: renderContext.summaryUsageGuidelines,

--- a/src/core/output/outputGenerate.ts
+++ b/src/core/output/outputGenerate.ts
@@ -57,10 +57,9 @@ const generateParsableXmlOutput = async (renderContext: RenderContext): Promise<
   const xmlBuilder = new XMLBuilder({ ignoreAttributes: false });
   const xmlDocument = {
     repomix: {
-      '#text': renderContext.generationHeader,
       file_summary: renderContext.fileSummaryEnabled
         ? {
-            '#text': 'This section contains a summary of this file.',
+            '#text': renderContext.generationHeader,
             purpose: renderContext.summaryPurpose,
             file_format: `${renderContext.summaryFileFormat}
 4. Repository files, each consisting of:
@@ -68,11 +67,9 @@ const generateParsableXmlOutput = async (renderContext: RenderContext): Promise<
   - Full contents of the file`,
             usage_guidelines: renderContext.summaryUsageGuidelines,
             notes: renderContext.summaryNotes,
-            additional_info: {
-              user_provided_header: renderContext.headerText,
-            },
           }
         : undefined,
+      user_provided_header: renderContext.headerText,
       directory_structure: renderContext.directoryStructureEnabled ? renderContext.treeString : undefined,
       files: renderContext.filesEnabled
         ? {

--- a/src/core/output/outputStyles/markdownStyle.ts
+++ b/src/core/output/outputStyles/markdownStyle.ts
@@ -2,7 +2,6 @@ import Handlebars from 'handlebars';
 
 export const getMarkdownTemplate = () => {
   return /* md */ `
-
 {{#if fileSummaryEnabled}}
 {{{generationHeader}}}
 

--- a/src/core/output/outputStyles/markdownStyle.ts
+++ b/src/core/output/outputStyles/markdownStyle.ts
@@ -12,7 +12,7 @@ export const getMarkdownTemplate = () => {
 
 ## File Format
 {{{summaryFileFormat}}}
-4. Multiple file entries, each consisting of:
+5. Multiple file entries, each consisting of:
   a. A header with the file path (## File: path/to/file)
   b. The full contents of the file in a code block
 

--- a/src/core/output/outputStyles/markdownStyle.ts
+++ b/src/core/output/outputStyles/markdownStyle.ts
@@ -23,7 +23,10 @@ export const getMarkdownTemplate = () => {
 ## Notes
 {{{summaryNotes}}}
 
-## Additional Info
+{{/if}}
+{{#if headerText}}
+# User Provided Header
+{{{headerText}}}
 
 {{/if}}
 {{#if directoryStructureEnabled}}
@@ -33,13 +36,6 @@ export const getMarkdownTemplate = () => {
 \`\`\`
 
 {{/if}}
-
-{{#if headerText}}
-### User Provided Header
-{{{headerText}}}
-{{/if}}
-
-
 {{#if filesEnabled}}
 # Files
 

--- a/src/core/output/outputStyles/markdownStyle.ts
+++ b/src/core/output/outputStyles/markdownStyle.ts
@@ -2,9 +2,10 @@ import Handlebars from 'handlebars';
 
 export const getMarkdownTemplate = () => {
   return /* md */ `
-{{{generationHeader}}}
 
 {{#if fileSummaryEnabled}}
+{{{generationHeader}}}
+
 # File Summary
 
 ## Purpose
@@ -23,10 +24,6 @@ export const getMarkdownTemplate = () => {
 {{{summaryNotes}}}
 
 ## Additional Info
-{{#if headerText}}
-### User Provided Header
-{{{headerText}}}
-{{/if}}
 
 {{/if}}
 {{#if directoryStructureEnabled}}
@@ -36,6 +33,13 @@ export const getMarkdownTemplate = () => {
 \`\`\`
 
 {{/if}}
+
+{{#if headerText}}
+### User Provided Header
+{{{headerText}}}
+{{/if}}
+
+
 {{#if filesEnabled}}
 # Files
 

--- a/src/core/output/outputStyles/plainStyle.ts
+++ b/src/core/output/outputStyles/plainStyle.ts
@@ -32,15 +32,15 @@ Notes:
 ------
 {{{summaryNotes}}}
 
-Additional Info:
-----------------
-{{/if}}
-{{#if headerText}}
-User Provided Header:
------------------------
-{{{headerText}}}
 {{/if}}
 
+{{#if headerText}}
+${PLAIN_LONG_SEPARATOR}
+User Provided Header
+${PLAIN_LONG_SEPARATOR}
+{{{headerText}}}
+
+{{/if}}
 {{#if directoryStructureEnabled}}
 ${PLAIN_LONG_SEPARATOR}
 Directory Structure

--- a/src/core/output/outputStyles/plainStyle.ts
+++ b/src/core/output/outputStyles/plainStyle.ts
@@ -17,7 +17,7 @@ Purpose:
 File Format:
 ------------
 {{{summaryFileFormat}}}
-4. Multiple file entries, each consisting of:
+5. Multiple file entries, each consisting of:
   a. A separator line (================)
   b. The file path (File: path/to/file)
   c. Another separator line

--- a/src/core/output/outputStyles/plainStyle.ts
+++ b/src/core/output/outputStyles/plainStyle.ts
@@ -3,9 +3,9 @@ const PLAIN_LONG_SEPARATOR = '='.repeat(64);
 
 export const getPlainTemplate = () => {
   return `
+{{#if fileSummaryEnabled}}
 {{{generationHeader}}}
 
-{{#if fileSummaryEnabled}}
 ${PLAIN_LONG_SEPARATOR}
 File Summary
 ${PLAIN_LONG_SEPARATOR}
@@ -34,13 +34,13 @@ Notes:
 
 Additional Info:
 ----------------
+{{/if}}
 {{#if headerText}}
 User Provided Header:
 -----------------------
 {{{headerText}}}
 {{/if}}
 
-{{/if}}
 {{#if directoryStructureEnabled}}
 ${PLAIN_LONG_SEPARATOR}
 Directory Structure

--- a/src/core/output/outputStyles/xmlStyle.ts
+++ b/src/core/output/outputStyles/xmlStyle.ts
@@ -12,7 +12,7 @@ This section contains a summary of this file.
 
 <file_format>
 {{{summaryFileFormat}}}
-4. Repository files, each consisting of:
+5. Multiple file entries, each consisting of:
   - File path as an attribute
   - Full contents of the file
 </file_format>

--- a/src/core/output/outputStyles/xmlStyle.ts
+++ b/src/core/output/outputStyles/xmlStyle.ts
@@ -1,8 +1,9 @@
 export const getXmlTemplate = () => {
   return /* xml */ `
-{{{generationHeader}}}
 
 {{#if fileSummaryEnabled}}
+{{{generationHeader}}}
+
 <file_summary>
 This section contains a summary of this file.
 
@@ -25,18 +26,16 @@ This section contains a summary of this file.
 {{{summaryNotes}}}
 </notes>
 
-<additional_info>
+</file_summary>
+
+{{/if}}
+
 {{#if headerText}}
 <user_provided_header>
 {{{headerText}}}
 </user_provided_header>
 {{/if}}
 
-</additional_info>
-
-</file_summary>
-
-{{/if}}
 {{#if directoryStructureEnabled}}
 <directory_structure>
 {{{treeString}}}

--- a/src/core/output/outputStyles/xmlStyle.ts
+++ b/src/core/output/outputStyles/xmlStyle.ts
@@ -1,6 +1,5 @@
 export const getXmlTemplate = () => {
   return /* xml */ `
-
 {{#if fileSummaryEnabled}}
 {{{generationHeader}}}
 

--- a/src/core/output/outputStyles/xmlStyle.ts
+++ b/src/core/output/outputStyles/xmlStyle.ts
@@ -29,13 +29,12 @@ This section contains a summary of this file.
 </file_summary>
 
 {{/if}}
-
 {{#if headerText}}
 <user_provided_header>
 {{{headerText}}}
 </user_provided_header>
-{{/if}}
 
+{{/if}}
 {{#if directoryStructureEnabled}}
 <directory_structure>
 {{{treeString}}}

--- a/tests/core/output/outputGenerate.test.ts
+++ b/tests/core/output/outputGenerate.test.ts
@@ -138,4 +138,53 @@ describe('outputGenerate', () => {
     expect(output).toContain('## File: dir/file2.txt');
     expect(output).toContain('````\n```\ncontent2\n```\n````');
   });
+
+  test('generateOutput (txt) should omit generationHeader when fileSummaryEnabled is false, but always include headerText if provided', async () => {
+    const mockConfig = createMockConfig({
+      output: {
+        filePath: 'output.txt',
+        style: 'plain',
+        fileSummary: false,
+        headerText: 'ALWAYS SHOW THIS HEADER',
+      },
+    });
+    const mockProcessedFiles: ProcessedFile[] = [{ path: 'file1.txt', content: 'content1' }];
+    const output = await generateOutput([process.cwd()], mockConfig, mockProcessedFiles, []);
+    expect(output).not.toContain('This file is a merged representation'); // generationHeader
+    expect(output).toContain('ALWAYS SHOW THIS HEADER');
+  });
+
+  test('generateOutput (xml) omits generationHeader when fileSummaryEnabled is false, but always includes headerText', async () => {
+    const mockConfig = createMockConfig({
+      output: {
+        filePath: 'output.xml',
+        style: 'xml',
+        fileSummary: false,
+        headerText: 'XML HEADER',
+        parsableStyle: true,
+      },
+    });
+    const mockProcessedFiles: ProcessedFile[] = [{ path: 'file1.txt', content: '<div>foo</div>' }];
+    const output = await generateOutput([process.cwd()], mockConfig, mockProcessedFiles, []);
+    const parser = new XMLParser({ ignoreAttributes: false });
+    const parsedOutput = parser.parse(output);
+    expect(parsedOutput.repomix['#text']).toBeUndefined();
+    expect(parsedOutput.repomix.user_provided_header).toBe('XML HEADER');
+  });
+
+  test('generateOutput (markdown) omits generationHeader when fileSummaryEnabled is false, but always includes headerText', async () => {
+    const mockConfig = createMockConfig({
+      output: {
+        filePath: 'output.md',
+        style: 'markdown',
+        fileSummary: false,
+        headerText: 'MARKDOWN HEADER',
+        parsableStyle: false,
+      },
+    });
+    const mockProcessedFiles: ProcessedFile[] = [{ path: 'file1.txt', content: 'content1' }];
+    const output = await generateOutput([process.cwd()], mockConfig, mockProcessedFiles, []);
+    expect(output).not.toContain('This file is a merged representation');
+    expect(output).toContain('MARKDOWN HEADER');
+  });
 });

--- a/tests/core/output/outputStyles/markdownStyle.test.ts
+++ b/tests/core/output/outputStyles/markdownStyle.test.ts
@@ -1,6 +1,8 @@
 import Handlebars from 'handlebars';
 import { describe, expect, test } from 'vitest';
+import { generateOutput } from '../../../../src/core/output/outputGenerate.js';
 import { getMarkdownTemplate } from '../../../../src/core/output/outputStyles/markdownStyle.js';
+import { createMockConfig } from '../../../testing/testUtils.js';
 
 describe('markdownStyle', () => {
   describe('getMarkdownTemplate', () => {
@@ -91,6 +93,35 @@ describe('markdownStyle', () => {
 
       expect(result).toContain('# Instruction');
       expect(result).toContain('Custom Instruction Text');
+    });
+
+    test('should display headerText if specified even if fileSummary is disabled', () => {
+      const template = getMarkdownTemplate();
+      const compiledTemplate = Handlebars.compile(template);
+      const data = {
+        headerText: 'MARKDOWN HEADER',
+        fileSummaryEnabled: false,
+        directoryStructureEnabled: true,
+        processedFiles: [],
+      };
+      const result = compiledTemplate(data);
+      expect(result).not.toContain('This file is a merged representation');
+      expect(result).toContain('MARKDOWN HEADER');
+    });
+
+    test('should not display generationHeader if fileSummary is disabled', () => {
+      const template = getMarkdownTemplate();
+      const compiledTemplate = Handlebars.compile(template);
+      const data = {
+        generationHeader: 'Generated Test Header',
+        fileSummaryEnabled: false,
+        directoryStructureEnabled: true,
+        processedFiles: [],
+      };
+      const result = compiledTemplate(data);
+      expect(result).not.toContain('This file is a merged representation');
+      expect(result).not.toContain('Generated Test Header');
+      expect(result).toContain('# Directory Structure');
     });
   });
 

--- a/tests/core/output/outputStyles/markdownStyle.test.ts
+++ b/tests/core/output/outputStyles/markdownStyle.test.ts
@@ -61,7 +61,7 @@ describe('markdownStyle', () => {
 
       const result = compiledTemplate(data);
 
-      expect(result).toContain('### User Provided Header');
+      expect(result).toContain('# User Provided Header');
       expect(result).toContain('Custom Header Text');
     });
 
@@ -76,7 +76,7 @@ describe('markdownStyle', () => {
 
       const result = compiledTemplate(data);
 
-      expect(result).not.toContain('### User Provided Header');
+      expect(result).not.toContain('# User Provided Header');
     });
 
     test('should render instruction section when provided', () => {

--- a/tests/core/output/outputStyles/plainStyle.test.ts
+++ b/tests/core/output/outputStyles/plainStyle.test.ts
@@ -30,4 +30,18 @@ describe('plainStyle', () => {
     expect(output).toContain('Custom header text');
     expect(output).toContain('Files');
   });
+
+  test('plain style: headerText always present, generationHeader only if fileSummaryEnabled', async () => {
+    const mockConfig = createMockConfig({
+      output: {
+        filePath: 'output.txt',
+        style: 'plain',
+        fileSummary: false,
+        headerText: 'PLAIN HEADER',
+      },
+    });
+    const output = await generateOutput([process.cwd()], mockConfig, [], []);
+    expect(output).not.toContain('This file is a merged representation');
+    expect(output).toContain('PLAIN HEADER');
+  });
 });

--- a/tests/core/output/outputStyles/xmlStyle.test.ts
+++ b/tests/core/output/outputStyles/xmlStyle.test.ts
@@ -30,4 +30,19 @@ describe('xmlStyle', () => {
     expect(output).toContain('Custom header text');
     expect(output).toContain('files');
   });
+
+  test('xml style: headerText always present, generationHeader only if fileSummaryEnabled', async () => {
+    const mockConfig = createMockConfig({
+      output: {
+        filePath: 'output.xml',
+        style: 'xml',
+        fileSummary: false,
+        headerText: 'XML HEADER',
+        parsableStyle: false,
+      },
+    });
+    const output = await generateOutput([process.cwd()], mockConfig, [], []);
+    expect(output).not.toContain('This file is a merged representation');
+    expect(output).toContain('XML HEADER');
+  });
 });

--- a/tests/integration-tests/fixtures/packager/outputs/simple-project-output.md
+++ b/tests/integration-tests/fixtures/packager/outputs/simple-project-output.md
@@ -1,31 +1,23 @@
 This file is a merged representation of the entire codebase, combined into a single document by Repomix.
 
-================================================================
-File Summary
-================================================================
+# File Summary
 
-Purpose:
---------
+## Purpose
 This file contains a packed representation of the entire repository's contents.
 It is designed to be easily consumable by AI systems for analysis, code review,
 or other automated processes.
 
-File Format:
-------------
+## File Format
 The content is organized as follows:
 1. This summary section
 2. Repository information
 3. Directory structure
 4. Repository files (if enabled)
 4. Multiple file entries, each consisting of:
-  a. A separator line (================)
-  b. The file path (File: path/to/file)
-  c. Another separator line
-  d. The full contents of the file
-  e. A blank line
+  a. A header with the file path (## File: path/to/file)
+  b. The full contents of the file in a code block
 
-Usage Guidelines:
------------------
+## Usage Guidelines
 - This file should be treated as read-only. Any changes should be made to the
   original repository files, not this packed version.
 - When processing this file, use the file path to distinguish
@@ -34,22 +26,17 @@ Usage Guidelines:
   the same level of security as you would the original repository.
 - Pay special attention to the Repository Description. These contain important context and guidelines specific to this project.
 
-Notes:
-------
+## Notes
 - Some files may have been excluded based on .gitignore rules and Repomix's configuration
 - Binary files are not included in this packed representation. Please refer to the Repository Structure section for a complete list of file paths, including binary files
 - Files matching patterns in .gitignore are excluded
 - Files matching default ignore patterns are excluded
 
-
-================================================================
-User Provided Header
-================================================================
+# User Provided Header
 This repository is simple-project
 
-================================================================
-Directory Structure
-================================================================
+# Directory Structure
+```
 resources/
   .repomixignore
   data.txt
@@ -60,24 +47,22 @@ src/
 package.json
 README.md
 repomix.config.json
+```
 
-================================================================
-Files
-================================================================
+# Files
 
-================
-File: resources/.repomixignore
-================
+## File: resources/.repomixignore
+````
 ignored-data.txt
+````
 
-================
-File: resources/data.txt
-================
+## File: resources/data.txt
+````
 dummy data
+````
 
-================
-File: src/index.js
-================
+## File: src/index.js
+````javascript
 const { greet } = require('./utils');
 
 function main() {
@@ -85,10 +70,10 @@ function main() {
 }
 
 main();
+````
 
-================
-File: src/utils.js
-================
+## File: src/utils.js
+````javascript
 function greet(name) {
   return `Hello, ${name}!`;
 }
@@ -96,15 +81,15 @@ function greet(name) {
 module.exports = {
   greet,
 };
+````
 
-================
-File: .repomixignore
-================
+## File: .repomixignore
+````
 **/build/**
+````
 
-================
-File: package.json
-================
+## File: package.json
+````json
 {
   "name": "simple-project",
   "version": "1.0.0",
@@ -117,10 +102,10 @@ File: package.json
   "author": "Test Author",
   "license": "MIT"
 }
+````
 
-================
-File: README.md
-================
+## File: README.md
+````markdown
 # Simple Project
 
 This is a simple project used for testing Repomix.
@@ -134,10 +119,10 @@ npm start
 ```
 
 This will output a greeting message to the console.
+````
 
-================
-File: repomix.config.json
-================
+## File: repomix.config.json
+````json
 {
   "output": {
     "filePath": "repomix-output.txt",
@@ -153,10 +138,4 @@ File: repomix.config.json
     "customPatterns": []
   }
 }
-
-
-
-
-================================================================
-End of Codebase
-================================================================
+````

--- a/tests/integration-tests/fixtures/packager/outputs/simple-project-output.md
+++ b/tests/integration-tests/fixtures/packager/outputs/simple-project-output.md
@@ -13,7 +13,7 @@ The content is organized as follows:
 2. Repository information
 3. Directory structure
 4. Repository files (if enabled)
-4. Multiple file entries, each consisting of:
+5. Multiple file entries, each consisting of:
   a. A header with the file path (## File: path/to/file)
   b. The full contents of the file in a code block
 

--- a/tests/integration-tests/fixtures/packager/outputs/simple-project-output.txt
+++ b/tests/integration-tests/fixtures/packager/outputs/simple-project-output.txt
@@ -17,7 +17,7 @@ The content is organized as follows:
 2. Repository information
 3. Directory structure
 4. Repository files (if enabled)
-4. Multiple file entries, each consisting of:
+5. Multiple file entries, each consisting of:
   a. A separator line (================)
   b. The file path (File: path/to/file)
   c. Another separator line

--- a/tests/integration-tests/fixtures/packager/outputs/simple-project-output.xml
+++ b/tests/integration-tests/fixtures/packager/outputs/simple-project-output.xml
@@ -14,6 +14,7 @@ The content is organized as follows:
 1. This summary section
 2. Repository information
 3. Directory structure
+4. Repository files (if enabled)
 4. Repository files, each consisting of:
   - File path as an attribute
   - Full contents of the file
@@ -36,14 +37,11 @@ The content is organized as follows:
 - Files matching default ignore patterns are excluded
 </notes>
 
-<additional_info>
+</file_summary>
+
 <user_provided_header>
 This repository is simple-project
 </user_provided_header>
-
-</additional_info>
-
-</file_summary>
 
 <directory_structure>
 resources/

--- a/tests/integration-tests/fixtures/packager/outputs/simple-project-output.xml
+++ b/tests/integration-tests/fixtures/packager/outputs/simple-project-output.xml
@@ -15,7 +15,7 @@ The content is organized as follows:
 2. Repository information
 3. Directory structure
 4. Repository files (if enabled)
-4. Repository files, each consisting of:
+5. Multiple file entries, each consisting of:
   - File path as an attribute
   - Full contents of the file
 </file_format>

--- a/tests/integration-tests/packager.test.ts
+++ b/tests/integration-tests/packager.test.ts
@@ -36,7 +36,9 @@ describe.runIf(!isWindows)('packager integration', () => {
       desc: 'simple plain style',
       input: 'simple-project',
       output: 'simple-project-output.txt',
-      config: {},
+      config: {
+        output: { style: 'plain', filePath: 'simple-project-output.txt' },
+      },
     },
     {
       desc: 'simple xml style',
@@ -44,6 +46,14 @@ describe.runIf(!isWindows)('packager integration', () => {
       output: 'simple-project-output.xml',
       config: {
         output: { style: 'xml', filePath: 'simple-project-output.xml' },
+      },
+    },
+    {
+      desc: 'simple markdown style',
+      input: 'simple-project',
+      output: 'simple-project-output.md',
+      config: {
+        output: { style: 'markdown', filePath: 'simple-project-output.md' },
       },
     },
   ];
@@ -134,29 +144,48 @@ describe.runIf(!isWindows)('packager integration', () => {
       const actualOutput = await fs.readFile(actualOutputPath, 'utf-8');
       const expectedOutput = await fs.readFile(expectedOutputPath, 'utf-8');
 
-      // Compare the outputs - XMLとプレーンテキストで異なる場合は条件分岐
+      // Compare the outputs - XML and plain style are different
       expect(actualOutput).toContain('This file is a merged representation of the entire codebase');
 
-      if (config.output?.style === 'xml') {
-        // XML形式のテスト
-        expect(actualOutput).toContain('<file_summary>');
-        expect(actualOutput).toContain('<directory_structure>');
-        expect(actualOutput).toContain('resources/');
-        expect(actualOutput).toContain('src/');
-        expect(actualOutput).toContain('<file path="src/index.js">');
-        expect(actualOutput).toContain('function main() {');
-        expect(actualOutput).toContain('<file path="src/utils.js">');
-        expect(actualOutput).toContain('function greet(name) {');
-      } else {
-        // プレーンテキスト形式のテスト
-        expect(actualOutput).toContain('File Summary');
-        expect(actualOutput).toContain('Directory Structure');
-        expect(actualOutput).toContain('resources/');
-        expect(actualOutput).toContain('src/');
-        expect(actualOutput).toContain('File: src/index.js');
-        expect(actualOutput).toContain('function main() {');
-        expect(actualOutput).toContain('File: src/utils.js');
-        expect(actualOutput).toContain('function greet(name) {');
+      // Common assertions for all styles
+      expect(actualOutput).toContain('resources/');
+      expect(actualOutput).toContain('src/');
+      expect(actualOutput).toContain('This repository is simple-project');
+
+      switch (config.output?.style) {
+        case 'xml':
+          expect(actualOutput).toContain('<file_summary>');
+          expect(actualOutput).toContain('<user_provided_header>');
+          expect(actualOutput).toContain('</user_provided_header>');
+          expect(actualOutput).toContain('<directory_structure>');
+          expect(actualOutput).toContain('<file path="src/index.js">');
+          expect(actualOutput).toContain('function main() {');
+          expect(actualOutput).toContain('<file path="src/utils.js">');
+          expect(actualOutput).toContain('function greet(name) {');
+          break;
+
+        case 'markdown':
+          expect(actualOutput).toContain('# File Summary');
+          expect(actualOutput).toContain('# User Provided Header');
+          expect(actualOutput).toContain('# Directory Structure');
+          expect(actualOutput).toContain('## File: src/index.js');
+          expect(actualOutput).toContain('````javascript\nconst { greet }');
+          expect(actualOutput).toContain('## File: src/utils.js');
+          expect(actualOutput).toContain('````javascript\nfunction greet(name) {');
+          break;
+
+        case 'plain':
+          expect(actualOutput).toContain('File Summary');
+          expect(actualOutput).toContain('User Provided Header');
+          expect(actualOutput).toContain('Directory Structure');
+          expect(actualOutput).toContain('File: src/index.js');
+          expect(actualOutput).toContain('function main() {');
+          expect(actualOutput).toContain('File: src/utils.js');
+          expect(actualOutput).toContain('function greet(name) {');
+          break;
+
+        default:
+          throw new Error(`Unsupported style: ${config.output?.style}`);
       }
 
       // Optionally, update the expected output if explicitly requested

--- a/tests/integration-tests/packager.test.ts
+++ b/tests/integration-tests/packager.test.ts
@@ -144,7 +144,7 @@ describe.runIf(!isWindows)('packager integration', () => {
       const actualOutput = await fs.readFile(actualOutputPath, 'utf-8');
       const expectedOutput = await fs.readFile(expectedOutputPath, 'utf-8');
 
-      // Compare the outputs - XML and plain style are different
+      // Compare the outputs - styles (e.g., XML, plain, markdown) may differ
       expect(actualOutput).toContain('This file is a merged representation of the entire codebase');
 
       // Common assertions for all styles


### PR DESCRIPTION
--no-file-summary should also suppress generationHeader; should not suppress user-specified headerText ( fixes #554 )

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
