### PR TITLE
Proper remote‐refs handling

### DIFF
--- a/src/core/git/gitRemoteParse.ts
+++ b/src/core/git/gitRemoteParse.ts
@@ -13,7 +13,10 @@ export const isValidShorthand = (remoteValue: string): boolean => {
   return validShorthandRegex.test(remoteValue);
 };
 
-export const parseRemoteValue = (remoteValue: string, refs: string[] = []): { repoUrl: string; remoteBranch: string | undefined } => {
+export const parseRemoteValue = (
+  remoteValue: string,
+  refs: string[] = [],
+): { repoUrl: string; remoteBranch: string | undefined } => {
   if (isValidShorthand(remoteValue)) {
     logger.trace(`Formatting GitHub shorthand: ${remoteValue}`);
     return {

--- a/src/core/git/gitRemoteParse.ts
+++ b/src/core/git/gitRemoteParse.ts
@@ -13,7 +13,7 @@ export const isValidShorthand = (remoteValue: string): boolean => {
   return validShorthandRegex.test(remoteValue);
 };
 
-export const parseRemoteValue = (remoteValue: string): { repoUrl: string; remoteBranch: string | undefined } => {
+export const parseRemoteValue = (remoteValue: string, refs: string[] = []): { repoUrl: string; remoteBranch: string | undefined } => {
   if (isValidShorthand(remoteValue)) {
     logger.trace(`Formatting GitHub shorthand: ${remoteValue}`);
     return {
@@ -23,7 +23,8 @@ export const parseRemoteValue = (remoteValue: string): { repoUrl: string; remote
   }
 
   try {
-    const parsedFields = gitUrlParse(remoteValue) as IGitUrl;
+    // @ts-ignore - The type definition is incorrect, gitUrlParse does accept a second 'refs' parameter
+    const parsedFields = gitUrlParse(remoteValue, refs) as IGitUrl;
 
     // This will make parsedFields.toString() automatically append '.git' to the returned url
     parsedFields.git_suffix = true;
@@ -40,7 +41,7 @@ export const parseRemoteValue = (remoteValue: string): { repoUrl: string; remote
     if (parsedFields.ref) {
       return {
         repoUrl: repoUrl,
-        remoteBranch: parsedFields.filepath ? `${parsedFields.ref}/${parsedFields.filepath}` : parsedFields.ref,
+        remoteBranch: parsedFields.ref,
       };
     }
 
@@ -60,9 +61,9 @@ export const parseRemoteValue = (remoteValue: string): { repoUrl: string; remote
   }
 };
 
-export const isValidRemoteValue = (remoteValue: string): boolean => {
+export const isValidRemoteValue = (remoteValue: string, refs: string[] = []): boolean => {
   try {
-    parseRemoteValue(remoteValue);
+    parseRemoteValue(remoteValue, refs);
     return true;
   } catch (error) {
     return false;

--- a/tests/cli/actions/remoteAction.test.ts
+++ b/tests/cli/actions/remoteAction.test.ts
@@ -32,6 +32,7 @@ describe('remoteAction functions', () => {
           execGitShallowClone: async (url: string, directory: string) => {
             await fs.writeFile(path.join(directory, 'README.md'), 'Hello, world!');
           },
+          getRemoteRefs: async () => Promise.resolve(['main']),
           runDefaultAction: async () => {
             return {
               packResult: {

--- a/tests/core/git/gitRemoteParse.test.ts
+++ b/tests/core/git/gitRemoteParse.test.ts
@@ -59,7 +59,9 @@ describe('remoteAction functions', () => {
         remoteBranch: 'branchname',
       });
       expect(
-        parseRemoteValue('https://some.gitlab.domain/some/path/username/repo/-/tree/branchname/withslash'),
+        parseRemoteValue('https://some.gitlab.domain/some/path/username/repo/-/tree/branchname/withslash', [
+          'branchname/withslash',
+        ]),
       ).toEqual({
         repoUrl: 'https://some.gitlab.domain/some/path/username/repo.git',
         remoteBranch: 'branchname/withslash',


### PR DESCRIPTION
<!-- Please include a summary of the changes -->

* Add `getRemoteRefs()` to fetch and supply branch/tag names before cloning
* Update `runRemoteAction` to use remote refs in URL parsing
* Move Git utilities into `core/git` and extract parsing logic into `gitRemoteParse.ts`
* Adjust imports and tests to match the new structure

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
