### PR TITLE
 Proper remote‐refs handling

### DIFF
--- a/src/core/git/gitCommand.ts
+++ b/src/core/git/gitCommand.ts
@@ -126,6 +126,19 @@ export const getRemoteRefs = async (
     execFileAsync,
   },
 ): Promise<string[]> => {
+  if (url.includes('--upload-pack') || url.includes('--config') || url.includes('--exec')) {
+    logger.trace(`Invalid repository URL. URL contains potentially dangerous parameters: ${url}`);
+    return [];
+  }
+
+  // Check if the URL is valid
+  try {
+    new URL(url);
+  } catch (error) {
+    logger.trace(`Invalid repository URL. Please provide a valid URL. url: ${url}`);
+    return [];
+  }
+
   try {
     const result = await deps.execFileAsync('git', ['ls-remote', '--heads', '--tags', url]);
 

--- a/src/core/git/gitCommand.ts
+++ b/src/core/git/gitCommand.ts
@@ -128,13 +128,11 @@ export const getRemoteRefs = async (
 ): Promise<string[]> => {
   // Check if the URL starts with git@ or https://
   if (!(url.startsWith('git@') || url.startsWith('https://'))) {
-    logger.trace(`Invalid remote: ${url}`);
-    return [];
+    throw new RepomixError(`Invalid remote: ${url}`);
   }
 
   if (url.includes('--upload-pack') || url.includes('--config') || url.includes('--exec')) {
-    logger.trace(`Invalid repository URL. URL contains potentially dangerous parameters: ${url}`);
-    return [];
+    throw new RepomixError(`Invalid repository URL. URL contains potentially dangerous parameters: ${url}`);
   }
 
   try {
@@ -159,7 +157,7 @@ export const getRemoteRefs = async (
     return refs;
   } catch (error) {
     logger.trace('Failed to get remote refs:', (error as Error).message);
-    return [];
+    throw new RepomixError(`Failed to get remote refs: ${(error as Error).message}`);
   }
 };
 

--- a/src/core/git/gitCommand.ts
+++ b/src/core/git/gitCommand.ts
@@ -126,16 +126,14 @@ export const getRemoteRefs = async (
     execFileAsync,
   },
 ): Promise<string[]> => {
-  if (url.includes('--upload-pack') || url.includes('--config') || url.includes('--exec')) {
-    logger.trace(`Invalid repository URL. URL contains potentially dangerous parameters: ${url}`);
+  // Check if the URL starts with git@ or https://
+  if (!(url.startsWith('git@') || url.startsWith('https://'))) {
+    logger.trace(`Invalid remote: ${url}`);
     return [];
   }
 
-  // Check if the URL is valid
-  try {
-    new URL(url);
-  } catch (error) {
-    logger.trace(`Invalid repository URL. Please provide a valid URL. url: ${url}`);
+  if (url.includes('--upload-pack') || url.includes('--config') || url.includes('--exec')) {
+    logger.trace(`Invalid repository URL. URL contains potentially dangerous parameters: ${url}`);
     return [];
   }
 

--- a/src/core/git/gitCommand.ts
+++ b/src/core/git/gitCommand.ts
@@ -135,6 +135,14 @@ export const getRemoteRefs = async (
     throw new RepomixError(`Invalid repository URL. URL contains potentially dangerous parameters: ${url}`);
   }
 
+  if (url.startsWith('https://')) {
+    try {
+      new URL(url);
+    } catch (error) {
+      throw new RepomixError(`Invalid repository URL. Please provide a valid URL: ${url}`);
+    }
+  }
+
   try {
     const result = await deps.execFileAsync('git', ['ls-remote', '--heads', '--tags', url]);
 

--- a/src/core/git/gitCommand.ts
+++ b/src/core/git/gitCommand.ts
@@ -214,7 +214,7 @@ const validateGitUrl = (url: string): void => {
 
   // Check if the URL starts with git@ or https://
   if (!(url.startsWith('git@') || url.startsWith('https://'))) {
-    throw new RepomixError(`Invalid remote: ${url}`);
+    throw new RepomixError(`Invalid URL protocol for '${url}'. URL must start with 'git@' or 'https://'`);
   }
 
   try {

--- a/src/core/git/gitCommand.ts
+++ b/src/core/git/gitCommand.ts
@@ -5,29 +5,6 @@ import { promisify } from 'node:util';
 import { RepomixError } from '../../shared/errorHandle.js';
 import { logger } from '../../shared/logger.js';
 
-/**
- * Validates a Git URL for security and format
- * @throws {RepomixError} If the URL is invalid or contains potentially dangerous parameters
- */
-const validateGitUrl = (url: string): void => {
-  if (url.includes('--upload-pack') || url.includes('--config') || url.includes('--exec')) {
-    throw new RepomixError(`Invalid repository URL. URL contains potentially dangerous parameters: ${url}`);
-  }
-
-  // Check if the URL starts with git@ or https://
-  if (!(url.startsWith('git@') || url.startsWith('https://'))) {
-    throw new RepomixError(`Invalid remote: ${url}`);
-  }
-
-  try {
-    if (url.startsWith('https://')) {
-      new URL(url);
-    }
-  } catch (error) {
-    throw new RepomixError(`Invalid repository URL. Please provide a valid URL: ${url}`);
-  }
-};
-
 const execFileAsync = promisify(execFile);
 
 export const getFileChangeCount = async (
@@ -224,4 +201,27 @@ export const execGitShallowClone = async (
 
   // Clean up .git directory
   await fs.rm(path.join(directory, '.git'), { recursive: true, force: true });
+};
+
+/**
+ * Validates a Git URL for security and format
+ * @throws {RepomixError} If the URL is invalid or contains potentially dangerous parameters
+ */
+const validateGitUrl = (url: string): void => {
+  if (url.includes('--upload-pack') || url.includes('--config') || url.includes('--exec')) {
+    throw new RepomixError(`Invalid repository URL. URL contains potentially dangerous parameters: ${url}`);
+  }
+
+  // Check if the URL starts with git@ or https://
+  if (!(url.startsWith('git@') || url.startsWith('https://'))) {
+    throw new RepomixError(`Invalid remote: ${url}`);
+  }
+
+  try {
+    if (url.startsWith('https://')) {
+      new URL(url);
+    }
+  } catch (error) {
+    throw new RepomixError(`Invalid repository URL. Please provide a valid URL: ${url}`);
+  }
 };

--- a/src/core/git/gitRemoteParse.ts
+++ b/src/core/git/gitRemoteParse.ts
@@ -26,7 +26,6 @@ export const parseRemoteValue = (
   }
 
   try {
-    // @ts-ignore - The type definition is incorrect, gitUrlParse does accept a second 'refs' parameter
     const parsedFields = gitUrlParse(remoteValue, refs) as IGitUrl;
 
     // This will make parsedFields.toString() automatically append '.git' to the returned url

--- a/src/core/git/gitRemoteParse.ts
+++ b/src/core/git/gitRemoteParse.ts
@@ -13,7 +13,10 @@ export const isValidShorthand = (remoteValue: string): boolean => {
   return validShorthandRegex.test(remoteValue);
 };
 
-export const parseRemoteValue = (remoteValue: string, refs: string[] = []): { repoUrl: string; remoteBranch: string | undefined } => {
+export const parseRemoteValue = (
+  remoteValue: string,
+  refs: string[] = [],
+): { repoUrl: string; remoteBranch: string | undefined } => {
   if (isValidShorthand(remoteValue)) {
     logger.trace(`Formatting GitHub shorthand: ${remoteValue}`);
     return {

--- a/src/core/git/gitRemoteParse.ts
+++ b/src/core/git/gitRemoteParse.ts
@@ -13,7 +13,7 @@ export const isValidShorthand = (remoteValue: string): boolean => {
   return validShorthandRegex.test(remoteValue);
 };
 
-export const parseRemoteValue = (remoteValue: string): { repoUrl: string; remoteBranch: string | undefined } => {
+export const parseRemoteValue = (remoteValue: string, refs: string[] = []): { repoUrl: string; remoteBranch: string | undefined } => {
   if (isValidShorthand(remoteValue)) {
     logger.trace(`Formatting GitHub shorthand: ${remoteValue}`);
     return {
@@ -23,7 +23,8 @@ export const parseRemoteValue = (remoteValue: string): { repoUrl: string; remote
   }
 
   try {
-    const parsedFields = gitUrlParse(remoteValue) as IGitUrl;
+    // @ts-ignore - The type definition is incorrect, gitUrlParse does accept a second 'refs' parameter
+    const parsedFields = gitUrlParse(remoteValue, refs) as IGitUrl;
 
     // This will make parsedFields.toString() automatically append '.git' to the returned url
     parsedFields.git_suffix = true;
@@ -40,7 +41,7 @@ export const parseRemoteValue = (remoteValue: string): { repoUrl: string; remote
     if (parsedFields.ref) {
       return {
         repoUrl: repoUrl,
-        remoteBranch: parsedFields.filepath ? `${parsedFields.ref}/${parsedFields.filepath}` : parsedFields.ref,
+        remoteBranch: parsedFields.ref,
       };
     }
 
@@ -60,9 +61,9 @@ export const parseRemoteValue = (remoteValue: string): { repoUrl: string; remote
   }
 };
 
-export const isValidRemoteValue = (remoteValue: string): boolean => {
+export const isValidRemoteValue = (remoteValue: string, refs: string[] = []): boolean => {
   try {
-    parseRemoteValue(remoteValue);
+    parseRemoteValue(remoteValue, refs);
     return true;
   } catch (error) {
     return false;

--- a/src/types/git-url-parse.d.ts
+++ b/src/types/git-url-parse.d.ts
@@ -1,0 +1,39 @@
+declare module 'git-url-parse' {
+  import gitUp = require('git-up');
+
+  namespace gitUrlParse {
+    interface GitUrl extends gitUp.ParsedUrl {
+      /** The Git provider (e.g. `"github.com"`). */
+      source: string;
+      /** The repository owner. */
+      owner: string;
+      /** The repository name. */
+      name: string;
+      /** The repository ref (e.g., "master" or "dev"). */
+      ref: string;
+      /** A filepath relative to the repository root. */
+      filepath: string;
+      /** The type of filepath in the url ("blob" or "tree"). */
+      filepathtype: string;
+      /** The owner and name values in the `owner/name` format. */
+      full_name: string;
+      /** The organization the owner belongs to. This is CloudForge specific. */
+      organization: string;
+      /** Whether to add the `.git` suffix or not. */
+      git_suffix?: boolean | undefined;
+      toString(type?: string): string;
+    }
+
+    function stringify(url: GitUrl, type?: string): string;
+  }
+
+  /**
+   * Parses a Git url.
+   * @param url The Git url to parse.
+   * @param refs An array of strings representing the refs. This is helpful for URLs with branches containing slashes.
+   * @returns The GitUrl object containing parsed information.
+   */
+  function gitUrlParse(url: string, refs?: string[]): gitUrlParse.GitUrl;
+
+  export = gitUrlParse;
+}

--- a/src/types/git-url-parse.d.ts
+++ b/src/types/git-url-parse.d.ts
@@ -1,26 +1,26 @@
 /**
  * Type definition extension for git-url-parse library
- * 
+ *
  * This file exists because the git-url-parse library's built-in type definitions
  * are incomplete. The library supports a second 'refs' parameter for the gitUrlParse
  * function, which is documented in the library's README but not included in its
  * type definitions.
- * 
+ *
  * Without this type definition extension, we would need to use @ts-ignore when
  * calling gitUrlParse with the refs parameter, which reduces type safety and
  * makes the code harder to maintain.
- * 
+ *
  * This file uses TypeScript's module augmentation feature to extend the existing
  * type definitions without modifying the original library code.
- * 
+ *
  * 日本語:
  * このファイルが存在する理由は、git-url-parseライブラリの組み込み型定義が不完全であるためです。
  * ライブラリはgitUrlParse関数の2番目のパラメータ'refs'をサポートしていますが、
  * これはライブラリのREADMEには記載されているものの、型定義には含まれていません。
- * 
+ *
  * この型定義拡張がなければ、refsパラメータを使用する際に@ts-ignoreを使用する必要があり、
  * 型安全性が低下し、コードの保守が難しくなります。
- * 
+ *
  * このファイルはTypeScriptのモジュール拡張機能を使用して、元のライブラリコードを
  * 変更せずに既存の型定義を拡張しています。
  */

--- a/src/types/git-url-parse.d.ts
+++ b/src/types/git-url-parse.d.ts
@@ -1,3 +1,30 @@
+/**
+ * Type definition extension for git-url-parse library
+ * 
+ * This file exists because the git-url-parse library's built-in type definitions
+ * are incomplete. The library supports a second 'refs' parameter for the gitUrlParse
+ * function, which is documented in the library's README but not included in its
+ * type definitions.
+ * 
+ * Without this type definition extension, we would need to use @ts-ignore when
+ * calling gitUrlParse with the refs parameter, which reduces type safety and
+ * makes the code harder to maintain.
+ * 
+ * This file uses TypeScript's module augmentation feature to extend the existing
+ * type definitions without modifying the original library code.
+ * 
+ * 日本語:
+ * このファイルが存在する理由は、git-url-parseライブラリの組み込み型定義が不完全であるためです。
+ * ライブラリはgitUrlParse関数の2番目のパラメータ'refs'をサポートしていますが、
+ * これはライブラリのREADMEには記載されているものの、型定義には含まれていません。
+ * 
+ * この型定義拡張がなければ、refsパラメータを使用する際に@ts-ignoreを使用する必要があり、
+ * 型安全性が低下し、コードの保守が難しくなります。
+ * 
+ * このファイルはTypeScriptのモジュール拡張機能を使用して、元のライブラリコードを
+ * 変更せずに既存の型定義を拡張しています。
+ */
+
 declare module 'git-url-parse' {
   import gitUp = require('git-up');
 

--- a/src/types/git-url-parse.d.ts
+++ b/src/types/git-url-parse.d.ts
@@ -12,17 +12,6 @@
  *
  * This file uses TypeScript's module augmentation feature to extend the existing
  * type definitions without modifying the original library code.
- *
- * 日本語:
- * このファイルが存在する理由は、git-url-parseライブラリの組み込み型定義が不完全であるためです。
- * ライブラリはgitUrlParse関数の2番目のパラメータ'refs'をサポートしていますが、
- * これはライブラリのREADMEには記載されているものの、型定義には含まれていません。
- *
- * この型定義拡張がなければ、refsパラメータを使用する際に@ts-ignoreを使用する必要があり、
- * 型安全性が低下し、コードの保守が難しくなります。
- *
- * このファイルはTypeScriptのモジュール拡張機能を使用して、元のライブラリコードを
- * 変更せずに既存の型定義を拡張しています。
  */
 
 declare module 'git-url-parse' {

--- a/tests/cli/actions/remoteAction.test.ts
+++ b/tests/cli/actions/remoteAction.test.ts
@@ -32,6 +32,7 @@ describe('remoteAction functions', () => {
           execGitShallowClone: async (url: string, directory: string) => {
             await fs.writeFile(path.join(directory, 'README.md'), 'Hello, world!');
           },
+          getRemoteRefs: async () => Promise.resolve(['main']),
           runDefaultAction: async () => {
             return {
               packResult: {

--- a/tests/core/git/gitCommand.test.ts
+++ b/tests/core/git/gitCommand.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import {
   execGitShallowClone,
   getFileChangeCount,
+  getRemoteRefs,
   getWorkTreeDiff,
   isGitInstalled,
   isGitRepository,
@@ -332,5 +333,61 @@ file2.ts
     ).rejects.toThrow('Invalid repository URL. URL contains potentially dangerous parameters');
 
     expect(mockFileExecAsync).not.toHaveBeenCalled();
+  });
+
+  describe('getRemoteRefs', () => {
+    test('should return refs when URL is valid', async () => {
+      const mockOutput = `
+a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6\trefs/heads/main
+b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7\trefs/heads/develop
+c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8\trefs/tags/v1.0.0
+`.trim();
+      const mockFileExecAsync = vi.fn().mockResolvedValue({ stdout: mockOutput });
+
+      const result = await getRemoteRefs('https://github.com/user/repo.git', { execFileAsync: mockFileExecAsync });
+
+      expect(result).toEqual(['main', 'develop', 'v1.0.0']);
+      expect(mockFileExecAsync).toHaveBeenCalledWith('git', [
+        'ls-remote',
+        '--heads',
+        '--tags',
+        'https://github.com/user/repo.git',
+      ]);
+    });
+
+    test('should throw error when URL does not start with git@ or https://', async () => {
+      const mockFileExecAsync = vi.fn();
+
+      await expect(getRemoteRefs('invalid-url', { execFileAsync: mockFileExecAsync })).rejects.toThrow(
+        'Invalid remote: invalid-url',
+      );
+
+      expect(mockFileExecAsync).not.toHaveBeenCalled();
+    });
+
+    test('should throw error when URL contains dangerous parameters', async () => {
+      const mockFileExecAsync = vi.fn();
+
+      await expect(
+        getRemoteRefs('https://github.com/user/repo.git --upload-pack=evil-command', { execFileAsync: mockFileExecAsync }),
+      ).rejects.toThrow('Invalid repository URL. URL contains potentially dangerous parameters');
+
+      expect(mockFileExecAsync).not.toHaveBeenCalled();
+    });
+
+    test('should throw error when git command fails', async () => {
+      const mockFileExecAsync = vi.fn().mockRejectedValue(new Error('git command failed'));
+
+      await expect(getRemoteRefs('https://github.com/user/repo.git', { execFileAsync: mockFileExecAsync })).rejects.toThrow(
+        'Failed to get remote refs: git command failed',
+      );
+
+      expect(mockFileExecAsync).toHaveBeenCalledWith('git', [
+        'ls-remote',
+        '--heads',
+        '--tags',
+        'https://github.com/user/repo.git',
+      ]);
+    });
   });
 });

--- a/tests/core/git/gitCommand.test.ts
+++ b/tests/core/git/gitCommand.test.ts
@@ -369,7 +369,9 @@ c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8\trefs/tags/v1.0.0
       const mockFileExecAsync = vi.fn();
 
       await expect(
-        getRemoteRefs('https://github.com/user/repo.git --upload-pack=evil-command', { execFileAsync: mockFileExecAsync }),
+        getRemoteRefs('https://github.com/user/repo.git --upload-pack=evil-command', {
+          execFileAsync: mockFileExecAsync,
+        }),
       ).rejects.toThrow('Invalid repository URL. URL contains potentially dangerous parameters');
 
       expect(mockFileExecAsync).not.toHaveBeenCalled();
@@ -378,9 +380,9 @@ c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8\trefs/tags/v1.0.0
     test('should throw error when git command fails', async () => {
       const mockFileExecAsync = vi.fn().mockRejectedValue(new Error('git command failed'));
 
-      await expect(getRemoteRefs('https://github.com/user/repo.git', { execFileAsync: mockFileExecAsync })).rejects.toThrow(
-        'Failed to get remote refs: git command failed',
-      );
+      await expect(
+        getRemoteRefs('https://github.com/user/repo.git', { execFileAsync: mockFileExecAsync }),
+      ).rejects.toThrow('Failed to get remote refs: git command failed');
 
       expect(mockFileExecAsync).toHaveBeenCalledWith('git', [
         'ls-remote',

--- a/tests/core/git/gitCommand.test.ts
+++ b/tests/core/git/gitCommand.test.ts
@@ -359,7 +359,7 @@ c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8\trefs/tags/v1.0.0
       const mockFileExecAsync = vi.fn();
 
       await expect(getRemoteRefs('invalid-url', { execFileAsync: mockFileExecAsync })).rejects.toThrow(
-        "Invalid URL protocol for 'invalid-url'. URL must start with 'git@' or 'https://'"
+        "Invalid URL protocol for 'invalid-url'. URL must start with 'git@' or 'https://'",
       );
 
       expect(mockFileExecAsync).not.toHaveBeenCalled();

--- a/tests/core/git/gitCommand.test.ts
+++ b/tests/core/git/gitCommand.test.ts
@@ -359,7 +359,7 @@ c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8\trefs/tags/v1.0.0
       const mockFileExecAsync = vi.fn();
 
       await expect(getRemoteRefs('invalid-url', { execFileAsync: mockFileExecAsync })).rejects.toThrow(
-        'Invalid remote: invalid-url',
+        "Invalid URL protocol for 'invalid-url'. URL must start with 'git@' or 'https://'"
       );
 
       expect(mockFileExecAsync).not.toHaveBeenCalled();

--- a/tests/core/git/gitRemoteParse.test.ts
+++ b/tests/core/git/gitRemoteParse.test.ts
@@ -59,7 +59,9 @@ describe('remoteAction functions', () => {
         remoteBranch: 'branchname',
       });
       expect(
-        parseRemoteValue('https://some.gitlab.domain/some/path/username/repo/-/tree/branchname/withslash'),
+        parseRemoteValue('https://some.gitlab.domain/some/path/username/repo/-/tree/branchname/withslash', [
+          'branchname/withslash',
+        ]),
       ).toEqual({
         repoUrl: 'https://some.gitlab.domain/some/path/username/repo.git',
         remoteBranch: 'branchname/withslash',


### PR DESCRIPTION
<!-- Please include a summary of the changes -->

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
