### PR TITLE
Validate Git URL before executing ls-remote command

### DIFF
--- a/src/core/git/gitCommand.ts
+++ b/src/core/git/gitCommand.ts
@@ -90,6 +90,8 @@ export const execLsRemote = async (
     execFileAsync,
   },
 ): Promise<string> => {
+  validateGitUrl(url);
+
   try {
     const result = await deps.execFileAsync('git', ['ls-remote', '--heads', '--tags', url]);
     return result.stdout || '';


### PR DESCRIPTION
Ensure the Git URL is validated prior to executing the ls-remote command to prevent errors and improve reliability.