### PR TITLE
Update GitHub stars link in HomeBadges component

### DIFF
--- a/website/client/components/HomeBadges.vue
+++ b/website/client/components/HomeBadges.vue
@@ -30,7 +30,7 @@
         alt="Sponsors"
       />
     </a>
-    <a href="https://github.com/yamadashy/repomix/stargazers" target="_blank" rel="noopener noreferrer">
+    <a href="https://github.com/yamadashy/repomix" target="_blank" rel="noopener noreferrer">
       <img
         src="https://img.shields.io/github/stars/yamadashy/repomix?style=flat&logo=github"
         alt="GitHub stars"


### PR DESCRIPTION
Correct the link to the GitHub stars in the HomeBadges component to point directly to the repository.