### PR TITLE
feat(config): Add support for .jsonc extension with priority order

### DIFF
--- a/src/config/configLoad.ts
+++ b/src/config/configLoad.ts
@@ -22,16 +22,22 @@ const getGlobalConfigPaths = () => {
   return defaultConfigPaths.map((configPath) => path.join(globalDir, configPath));
 };
 
+const checkFileExists = async (filePath: string): Promise<boolean> => {
+  try {
+    const stats = await fs.stat(filePath);
+    return stats.isFile();
+  } catch {
+    return false;
+  }
+};
+
 export const loadFileConfig = async (rootDir: string, argConfigPath: string | null): Promise<RepomixConfigFile> => {
   if (argConfigPath) {
     // If a specific config path is provided, use it directly
     const fullPath = path.resolve(rootDir, argConfigPath);
     logger.trace('Loading local config from:', fullPath);
 
-    const isLocalFileExists = await fs
-      .stat(fullPath)
-      .then((stats) => stats.isFile())
-      .catch(() => false);
+    const isLocalFileExists = await checkFileExists(fullPath);
 
     if (isLocalFileExists) {
       return await loadAndValidateConfig(fullPath);
@@ -44,10 +50,7 @@ export const loadFileConfig = async (rootDir: string, argConfigPath: string | nu
     const fullPath = path.resolve(rootDir, configPath);
     logger.trace('Checking for local config at:', fullPath);
 
-    const isLocalFileExists = await fs
-      .stat(fullPath)
-      .then((stats) => stats.isFile())
-      .catch(() => false);
+    const isLocalFileExists = await checkFileExists(fullPath);
 
     if (isLocalFileExists) {
       logger.trace('Found local config at:', fullPath);
@@ -60,10 +63,7 @@ export const loadFileConfig = async (rootDir: string, argConfigPath: string | nu
   for (const globalConfigPath of globalConfigPaths) {
     logger.trace('Checking for global config at:', globalConfigPath);
 
-    const isGlobalFileExists = await fs
-      .stat(globalConfigPath)
-      .then((stats) => stats.isFile())
-      .catch(() => false);
+    const isGlobalFileExists = await checkFileExists(globalConfigPath);
 
     if (isGlobalFileExists) {
       logger.trace('Found global config at:', globalConfigPath);


### PR DESCRIPTION
Add support for .jsonc config files alongside existing .json5 and .json files.

## Changes
- Implement priority order: repomix.config.json5 → repomix.config.jsonc → repomix.config.json
- Update config file discovery for both local and global configurations
- Add comprehensive tests for JSONC support and priority ordering
- JSON5 parser already supports JSONC format (JSON with comments)

Fixes #618

Generated with [Claude Code](https://claude.ai/code)