### PR TITLE
feat(cli): Set exit code when repomix fails

### DIFF
--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -140,7 +140,7 @@ export const run = async () => {
     await program.parseAsync(process.argv);
   } catch (error) {
     handleError(error);
-    process.exit(1)
+    process.exit(1);
   }
 };
 

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -140,6 +140,7 @@ export const run = async () => {
     await program.parseAsync(process.argv);
   } catch (error) {
     handleError(error);
+    process.exit(1)
   }
 };
 

--- a/tests/cli/cliRun.test.ts
+++ b/tests/cli/cliRun.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { program } from 'commander';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as defaultAction from '../../src/cli/actions/defaultAction.js';
 import * as initAction from '../../src/cli/actions/initAction.js';
 import * as remoteAction from '../../src/cli/actions/remoteAction.js';
@@ -156,11 +156,16 @@ describe('cliRun', () => {
 
   test('should call process.exit(1) on error', async () => {
     const exitSpy = vi.spyOn(process, 'exit').mockImplementationOnce(() => undefined as never);
-    const parseSpy = vi.spyOn(program, 'description').mockImplementationOnce(() => { throw Error() });
+    const parseSpy = vi.spyOn(program, 'description').mockImplementationOnce(() => {
+      throw Error();
+    });
+    const handleErrorSpy = vi.spyOn(logger, 'error');
     await expect(run()).resolves.not.toThrow();
-    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(handleErrorSpy).toHaveBeenCalled();
     exitSpy.mockReset();
     parseSpy.mockReset();
+    handleErrorSpy.mockReset();
   });
 
   describe('executeAction', () => {

--- a/tests/cli/cliRun.test.ts
+++ b/tests/cli/cliRun.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { program } from 'commander';
 import * as defaultAction from '../../src/cli/actions/defaultAction.js';
 import * as initAction from '../../src/cli/actions/initAction.js';
 import * as remoteAction from '../../src/cli/actions/remoteAction.js';
@@ -34,16 +35,6 @@ vi.mock('../../src/shared/logger', () => ({
     getLogLevel: vi.fn(() => logLevel),
   },
   setLogLevelByEnv: vi.fn(),
-}));
-
-vi.mock('commander', () => ({
-  program: {
-    description: vi.fn().mockReturnThis(),
-    arguments: vi.fn().mockReturnThis(),
-    option: vi.fn().mockReturnThis(),
-    action: vi.fn().mockReturnThis(),
-    parseAsync: vi.fn().mockResolvedValue(undefined),
-  },
 }));
 
 vi.mock('../../src/cli/actions/defaultAction');
@@ -163,8 +154,13 @@ describe('cliRun', () => {
     vi.mocked(versionAction.runVersionAction).mockResolvedValue();
   });
 
-  test('should run without arguments', async () => {
+  test('should call process.exit(1) on error', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementationOnce(() => undefined as never);
+    const parseSpy = vi.spyOn(program, 'description').mockImplementationOnce(() => { throw Error() });
     await expect(run()).resolves.not.toThrow();
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    exitSpy.mockReset();
+    parseSpy.mockReset();
   });
 
   describe('executeAction', () => {


### PR DESCRIPTION
<!-- Please include a summary of the changes -->

Hello! Thank you for this great tool.

I noticed that repomix returns exit code 0 even when it fails with errors.

```console
$ repomix --config /dev/zero; echo $?
✖ Config file not found at /dev/zero
Need help?
• File an issue on GitHub: https://github.com/yamadashy/repomix/issues
• Join our Discord community: https://discord.gg/wNYzTwZFku
0
```

It would be helpful to be able to detect error exit when using repomix in scripts.

## Changes

- Modified `src/cli/cliRun.ts` to call `process.exit(1)` when errors occur in the `run()` function

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
