### PR TITLE
feat(website): Show 'Open with your app' button on desktop with tooltip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,18 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Important: Continuous Knowledge Updates
+
+**ALWAYS update this CLAUDE.md file during development tasks when you learn:**
+- New project-specific patterns or conventions
+- Solutions to common problems or edge cases
+- Debugging techniques specific to this codebase
+- Tool usage patterns that improve efficiency
+- Review feedback patterns that could help future development
+- Architecture decisions and their rationale
+
+**When to update:** Don't wait until task completion - update immediately when you discover useful knowledge that would benefit future development sessions. This ensures knowledge continuity across different coding sessions.
+
 # Repomix Development Guide
 
 Repomix is a tool that packs repository contents into single files optimized for AI consumption. It converts codebases into structured formats (XML, Markdown, Plain Text) with intelligent compression, security scanning, and token counting for LLM integration.
@@ -189,3 +201,26 @@ Before marking PR as ready for merge:
 6. ✅ **Update documentation** - If architectural changes were made
 
 **Remember**: Resolving conversations shows that feedback has been addressed and helps maintainers track review progress. This is essential for efficient PR management.
+
+## Knowledge Management & Continuous Improvement
+
+### Document Learning During Development
+
+**Key principle:** Update CLAUDE.md immediately when discovering useful patterns, not at the end of tasks.
+
+**Examples of knowledge worth documenting:**
+- **Project quirks**: "Website uses `position: fixed` for tooltips due to parent `overflow: hidden`"
+- **Tool discoveries**: "Use `gh api` for line-specific PR comments, `gh pr view --comments` for general ones"
+- **Debug techniques**: "Check `canShareFiles()` implementation when Web Share API behaves unexpectedly"
+- **Performance patterns**: "Always use `{ passive: true }` for scroll listeners in Vue components"
+- **Architecture insights**: "tooltip-container pattern prevents disabled button event issues"
+
+### Maintaining This File
+
+- **Be specific**: Instead of "fix tooltip issues", write "move mouseenter to container for disabled buttons"
+- **Include context**: Explain *why* a solution works, not just *what* to do
+- **Reference locations**: Include file paths and line numbers when relevant
+- **Update immediately**: Don't batch updates - add knowledge as you learn it
+- **Cross-reference**: Link related sections (e.g., PR review patterns ↔ Vue.js best practices)
+
+This file is a living document that should grow with every development session, ensuring no valuable knowledge is lost between tasks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,10 +151,12 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 - Explain rationale for decisions when not implementing suggestions
 - Thank reviewers for their feedback
 
-**4. Resolve Conversations:**
-- CodeRabbit: Use `@coderabbitai resolve` command
-- Others: Respond with explanation, let reviewers mark as resolved
+**4. Resolve Conversations (IMPORTANT!):**
+- **Always resolve addressed feedback** - this helps track progress and shows respect for reviewers
+- CodeRabbit: Use `@coderabbitai resolve` command in PR comments
+- Others: Respond with explanation, then let reviewers mark as resolved
 - GitHub Web UI: Use "Resolve conversation" button on Files changed tab
+- **Don't forget this step** - unresolved conversations can delay PR approval
 
 ### Common Review Issues and Solutions
 
@@ -174,3 +176,16 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 - Use existing color schemes for consistency
 - Follow established patterns in the codebase
 - Maintain proper TypeScript typing
+
+### Review Process Checklist
+
+Before marking PR as ready for merge:
+
+1. ✅ **Address all feedback** - Fix high/medium priority issues
+2. ✅ **Run linting and tests** - `npm run lint && npm test`
+3. ✅ **Commit with clear messages** - Reference what was fixed
+4. ✅ **Respond to reviewers** - Explain changes and decisions
+5. ✅ **Resolve conversations** - Mark addressed feedback as resolved
+6. ✅ **Update documentation** - If architectural changes were made
+
+**Remember**: Resolving conversations shows that feedback has been addressed and helps maintainers track review progress. This is essential for efficient PR management.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,9 +104,22 @@ Repomix is a tool that packs repository contents into single files optimized for
 - Proper error propagation through async/worker boundaries
 
 ## Git Workflow
+
+### Pre-Commit Requirements (MANDATORY)
+**ALWAYS run these commands before every commit:**
+```bash
+npm run lint
+npm run test
+```
+
+- **npm run lint**: Runs Biome formatter, TypeScript type checking, and Secretlint security scan
+- **npm run test**: Executes full test suite to ensure no regressions
+- **Never commit failing code**: Fix all lint errors and test failures before committing
+- **Use `--write` flag**: Biome will auto-fix formatting issues when possible
+
+### Commit Message Format
 - Follow [Conventional Commits](https://www.conventionalcommits.org/) with scope: `type(scope): Description`
 - Write detailed commit messages focusing on the "why" rather than the "what"
-- Run `npm run lint && npm test` before committing changes
 - Examples: `feat(cli): Add new --no-progress flag`, `fix(security): Handle special characters in file paths`
 
 ## Pull Request Review Process
@@ -194,7 +207,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 Before marking PR as ready for merge:
 
 1. ✅ **Address all feedback** - Fix high/medium priority issues
-2. ✅ **Run linting and tests** - `npm run lint && npm test`
+2. ✅ **Run linting and tests (MANDATORY)** - `npm run lint && npm test` - Must pass before committing
 3. ✅ **Commit with clear messages** - Reference what was fixed
 4. ✅ **Respond to reviewers** - Explain changes and decisions
 5. ✅ **Resolve conversations** - Mark addressed feedback as resolved

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,3 +96,81 @@ Repomix is a tool that packs repository contents into single files optimized for
 - Write detailed commit messages focusing on the "why" rather than the "what"
 - Run `npm run lint && npm test` before committing changes
 - Examples: `feat(cli): Add new --no-progress flag`, `fix(security): Handle special characters in file paths`
+
+## Pull Request Review Process
+
+### Viewing PR Comments
+There are different types of comments in GitHub PRs that require different approaches to view:
+
+**1. General PR Comments (in main conversation):**
+```bash
+gh pr view {PR_NUMBER} --comments
+```
+
+**2. Specific Code Line Comments (Files changed tab):**
+```bash
+gh api repos/yamadashy/repomix/pulls/{PR_NUMBER}/comments --jq '.[] | {path: .path, line: .line, body: .body}'
+```
+
+**3. Review Comments with Status:**
+```bash
+gh api repos/yamadashy/repomix/pulls/{PR_NUMBER}/reviews --jq '.[] | select(.state == "COMMENTED" or .state == "CHANGES_REQUESTED") | .body'
+```
+
+### Automated Review Bots
+This repository uses several automated review tools:
+
+- **CodeRabbit**: AI-powered code review with actionable suggestions
+- **Gemini Code Assist**: Google's AI code reviewer with severity ratings (High/Medium/Low)
+- **Copilot Pull Request Reviewer**: GitHub's automated review suggestions
+- **Codecov**: Test coverage analysis and reporting
+
+### Responding to Review Feedback
+
+**1. Address Technical Issues First:**
+- Fix high-priority issues (security, functionality, memory leaks)
+- Address medium-priority issues (UX, maintainability)
+- Consider low-priority suggestions for future improvements
+
+**2. Commit Changes with Clear Messages:**
+```bash
+git commit -m "fix(scope): Address PR review feedback
+
+- Fix specific issue 1 (reference commit/line if applicable)
+- Improve specific aspect 2
+- Address reviewer concern about X
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+**3. Respond to Reviewers:**
+- Use `gh pr comment {PR_NUMBER} --body "message"` for general responses
+- Reference specific commits that address issues: `Fixed in commit \`abc1234\``
+- Explain rationale for decisions when not implementing suggestions
+- Thank reviewers for their feedback
+
+**4. Resolve Conversations:**
+- CodeRabbit: Use `@coderabbitai resolve` command
+- Others: Respond with explanation, let reviewers mark as resolved
+- GitHub Web UI: Use "Resolve conversation" button on Files changed tab
+
+### Common Review Issues and Solutions
+
+**Vue.js/Frontend:**
+- Event listener cleanup: Use `onUnmounted()` instead of return functions in `onMounted()`
+- Disabled element events: Move event handlers to parent containers
+- CSS positioning: Consider `position: fixed` for tooltips to avoid parent overflow issues
+- Accessibility: Maintain ARIA labels and proper focus management
+
+**Performance:**
+- Use `{ passive: true }` for scroll listeners
+- Implement proper cleanup for all event listeners
+- Consider debouncing/throttling for frequent events
+
+**Code Quality:**
+- Remove duplicate CSS definitions
+- Use existing color schemes for consistency
+- Follow established patterns in the codebase
+- Maintain proper TypeScript typing

--- a/website/client/components/Home/TryItResultContent.vue
+++ b/website/client/components/Home/TryItResultContent.vue
@@ -103,6 +103,17 @@ const updateTooltipPosition = () => {
   // Position above the button with proper spacing for the arrow (like existing tooltips)
   tooltipEl.style.top = `${containerRect.top - 46}px`;
   tooltipEl.style.left = `${containerRect.left + containerRect.width / 2}px`;
+  
+  // Show tooltip (override CSS hover states)
+  tooltipEl.style.opacity = '1';
+  tooltipEl.style.visibility = 'visible';
+};
+
+const hideTooltip = () => {
+  if (tooltipContent.value) {
+    tooltipContent.value.style.opacity = '0';
+    tooltipContent.value.style.visibility = 'hidden';
+  }
 };
 
 const messages = [
@@ -135,13 +146,23 @@ const handleResize = () => {
   isMobile.value = window.innerWidth <= 768;
 };
 
+const handleScroll = () => {
+  // Hide tooltip on scroll to prevent detachment from button
+  if (tooltipContent.value) {
+    tooltipContent.value.style.opacity = '0';
+    tooltipContent.value.style.visibility = 'hidden';
+  }
+};
+
 onMounted(() => {
   isMobile.value = window.innerWidth <= 768;
   window.addEventListener('resize', handleResize);
+  window.addEventListener('scroll', handleScroll, { passive: true });
 });
 
 onUnmounted(() => {
   window.removeEventListener('resize', handleResize);
+  window.removeEventListener('scroll', handleScroll);
 });
 </script>
 
@@ -203,7 +224,7 @@ onUnmounted(() => {
           Download
         </button>
         <div v-if="canShare" class="mobile-only" style="flex-basis: 100%"></div>
-        <div v-if="canShare" class="tooltip-container" ref="tooltipContainer" @mouseenter="updateTooltipPosition">
+        <div v-if="canShare" class="tooltip-container" ref="tooltipContainer" @mouseenter="updateTooltipPosition" @mouseleave="hideTooltip">
           <button
             class="action-button"
             @click="handleShare"

--- a/website/client/components/Home/TryItResultContent.vue
+++ b/website/client/components/Home/TryItResultContent.vue
@@ -103,7 +103,7 @@ const updateTooltipPosition = () => {
   // Position above the button with proper spacing for the arrow (like existing tooltips)
   tooltipEl.style.top = `${containerRect.top - 46}px`;
   tooltipEl.style.left = `${containerRect.left + containerRect.width / 2}px`;
-  
+
   // Show tooltip (override CSS hover states)
   tooltipEl.style.opacity = '1';
   tooltipEl.style.visibility = 'visible';

--- a/website/client/components/Home/TryItResultContent.vue
+++ b/website/client/components/Home/TryItResultContent.vue
@@ -90,10 +90,10 @@ const handleEditorMount = (editor: Ace.Editor) => {
 
 const updateTooltipPosition = () => {
   if (!tooltipContainer.value || !tooltipContent.value || isMobile.value) return;
-  
+
   const containerRect = tooltipContainer.value.getBoundingClientRect();
   const tooltipEl = tooltipContent.value;
-  
+
   // Position above the button with proper spacing for the arrow (like existing tooltips)
   tooltipEl.style.top = `${containerRect.top - 46}px`;
   tooltipEl.style.left = `${containerRect.left + containerRect.width / 2}px`;
@@ -127,13 +127,13 @@ const supportMessage = computed(() => ({
 
 onMounted(() => {
   isMobile.value = window.innerWidth <= 768;
-  
+
   const handleResize = () => {
     isMobile.value = window.innerWidth <= 768;
   };
-  
+
   window.addEventListener('resize', handleResize);
-  
+
   return () => {
     window.removeEventListener('resize', handleResize);
   };


### PR DESCRIPTION
## Summary
- Display the "Open with your app" button on both desktop and mobile devices
- Add informative tooltip on desktop indicating mobile-only functionality
- Improve user experience by showing available features with clear limitations

## Changes
- Show share button on desktop with disabled state and tooltip
- Use position: fixed to avoid parent overflow: hidden issues  
- Match existing tooltip design for UI consistency
- Support both light and dark modes

## Test plan
- [ ] Verify button appears on desktop and is disabled
- [ ] Confirm tooltip shows "Only available on mobile devices" on hover
- [ ] Test button works normally on mobile devices
- [ ] Check tooltip design matches existing tooltips (Compress Code, etc.)
- [ ] Verify both light and dark mode appearances

🤖 Generated with [Claude Code](https://claude.ai/code)