### PR TITLE
feat(cli): Add --stdin flag to read file list from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,8 @@ echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
 
 The `--stdin` option allows you to pipe a list of file paths to Repomix, giving you ultimate flexibility in selecting which files to pack.
 
-**Note:** When using `--stdin`, file paths can be relative or absolute, and Repomix will automatically handle path resolution and deduplication.
+> [!NOTE]
+> When using `--stdin`, file paths can be relative or absolute, and Repomix will automatically handle path resolution and deduplication.
 
 To compress the output:
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,29 @@ repomix --remote https://github.com/yamadashy/repomix/commit/836abcd7335137228ad
 
 ```
 
+To pack files from a file list (via stdin):
+
+```bash
+# Using find command
+find src -name "*.ts" -type f | repomix --stdin
+
+# Using git to get tracked files
+git ls-files "*.ts" | repomix --stdin
+
+# Using ls with glob patterns
+ls src/**/*.ts | repomix --stdin
+
+# From a file containing file paths
+cat file-list.txt | repomix --stdin
+
+# Direct input with echo
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+```
+
+The `--stdin` option allows you to pipe a list of file paths to Repomix, giving you ultimate flexibility in selecting which files to pack.
+
+**Note:** When using `--stdin`, file paths can be relative or absolute, and Repomix will automatically handle path resolution and deduplication.
+
 To compress the output:
 
 ```bash
@@ -484,6 +507,7 @@ Instruction
 #### Filter Options
 - `--include <patterns>`: List of include patterns (comma-separated)
 - `-i, --ignore <patterns>`: Additional ignore patterns (comma-separated)
+- `--stdin`: Read file paths from stdin instead of discovering files automatically
 - `--no-gitignore`: Disable .gitignore file usage
 - `--no-default-patterns`: Disable default patterns
 

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -7,8 +7,8 @@ import {
   type RepomixOutputStyle,
   repomixConfigCliSchema,
 } from '../../config/configSchema.js';
-import { type PackResult, pack } from '../../core/packager.js';
 import { readFilePathsFromStdin } from '../../core/file/fileStdin.js';
+import { type PackResult, pack } from '../../core/packager.js';
 import { RepomixError } from '../../shared/errorHandle.js';
 import { rethrowValidationErrorIfZodError } from '../../shared/errorHandle.js';
 import { logger } from '../../shared/logger.js';
@@ -49,7 +49,9 @@ export const runDefaultAction = async (
   // Handle stdin input
   if (cliOptions.stdin) {
     if (directories.length > 1 || directories[0] !== '.') {
-      throw new RepomixError('When using --stdin, do not specify directory arguments. File paths will be read from stdin.');
+      throw new RepomixError(
+        'When using --stdin, do not specify directory arguments. File paths will be read from stdin.',
+      );
     }
 
     const spinner = new Spinner('Reading file paths from stdin...', cliOptions);
@@ -59,18 +61,23 @@ export const runDefaultAction = async (
 
     try {
       const stdinResult = await readFilePathsFromStdin(cwd);
-      
+
       spinner.update('Packing files...');
-      
+
       // Create a custom pack variant that uses the stdin file paths directly
-      packResult = await pack([cwd], config, (message) => {
-        spinner.update(message);
-      }, {
-        searchFiles: async () => ({
-          filePaths: stdinResult.filePaths.map(filePath => path.relative(cwd, filePath)),
-          emptyDirPaths: stdinResult.emptyDirPaths,
-        }),
-      });
+      packResult = await pack(
+        [cwd],
+        config,
+        (message) => {
+          spinner.update(message);
+        },
+        {
+          searchFiles: async () => ({
+            filePaths: stdinResult.filePaths.map((filePath) => path.relative(cwd, filePath)),
+            emptyDirPaths: stdinResult.emptyDirPaths,
+          }),
+        },
+      );
     } catch (error) {
       spinner.fail('Error during packing');
       throw error;

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -57,7 +57,7 @@ export const runDefaultAction = async (
 /**
  * Handles stdin processing workflow for file paths input.
  */
-const handleStdinProcessing = async (
+export const handleStdinProcessing = async (
   directories: string[],
   cwd: string,
   config: RepomixConfigMerged,
@@ -113,7 +113,7 @@ const handleStdinProcessing = async (
 /**
  * Handles normal directory processing workflow.
  */
-const handleDirectoryProcessing = async (
+export const handleDirectoryProcessing = async (
   directories: string[],
   cwd: string,
   config: RepomixConfigMerged,

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -42,7 +42,6 @@ const semanticSuggestionMap: Record<string, string[]> = {
   print: ['--stdout'],
   console: ['--stdout'],
   terminal: ['--stdout'],
-  input: ['--stdin'],
   pipe: ['--stdin'],
 };
 

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -42,6 +42,8 @@ const semanticSuggestionMap: Record<string, string[]> = {
   print: ['--stdout'],
   console: ['--stdout'],
   terminal: ['--stdout'],
+  input: ['--stdin'],
+  pipe: ['--stdin'],
 };
 
 export const run = async () => {
@@ -80,6 +82,7 @@ export const run = async () => {
       .option('-i, --ignore <patterns>', 'additional ignore patterns (comma-separated)')
       .option('--no-gitignore', 'disable .gitignore file usage')
       .option('--no-default-patterns', 'disable default patterns')
+      .option('--stdin', 'read file list from stdin')
       // Remote Repository Options
       .optionsGroup('Remote Repository Options')
       .option('--remote <url>', 'process a remote Git repository')

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -29,6 +29,7 @@ export interface CliOptions extends OptionValues {
   ignore?: string;
   gitignore?: boolean;
   defaultPatterns?: boolean;
+  stdin?: boolean;
 
   // Remote Repository Options
   remote?: string;

--- a/src/core/file/fileStdin.ts
+++ b/src/core/file/fileStdin.ts
@@ -22,7 +22,7 @@ export const readFilePathsFromStdin = async (cwd: string): Promise<StdinFileResu
     stdin.setEncoding('utf8');
 
     let data = '';
-    
+
     // Check if stdin is a TTY (interactive mode)
     if (stdin.isTTY) {
       throw new RepomixError('No data provided via stdin. Please pipe file paths to repomix when using --stdin flag.');
@@ -38,16 +38,17 @@ export const readFilePathsFromStdin = async (cwd: string): Promise<StdinFileResu
     }
 
     // Parse the input - split by lines and filter out empty lines and comments
-    const lines = data.split('\n')
-      .map(line => line.trim())
-      .filter(line => line && !line.startsWith('#'));
+    const lines = data
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith('#'));
 
     if (lines.length === 0) {
       throw new RepomixError('No valid file paths found in stdin input.');
     }
 
     // Convert relative paths to absolute paths
-    const filePaths = lines.map(line => {
+    const filePaths = lines.map((line) => {
       const filePath = path.isAbsolute(line) ? line : path.resolve(cwd, line);
       logger.trace(`Resolved path: ${line} -> ${filePath}`);
       return filePath;
@@ -63,11 +64,11 @@ export const readFilePathsFromStdin = async (cwd: string): Promise<StdinFileResu
     if (error instanceof RepomixError) {
       throw error;
     }
-    
+
     if (error instanceof Error) {
       throw new RepomixError(`Failed to read file paths from stdin: ${error.message}`);
     }
-    
+
     throw new RepomixError('An unexpected error occurred while reading from stdin.');
   }
 };

--- a/src/core/file/fileStdin.ts
+++ b/src/core/file/fileStdin.ts
@@ -1,0 +1,73 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { RepomixError } from '../../shared/errorHandle.js';
+import { logger } from '../../shared/logger.js';
+
+export interface StdinFileResult {
+  filePaths: string[];
+  emptyDirPaths: string[];
+}
+
+/**
+ * Reads file paths from stdin, one per line.
+ * Filters out empty lines and comments (lines starting with #).
+ * Converts relative paths to absolute paths based on the current working directory.
+ */
+export const readFilePathsFromStdin = async (cwd: string): Promise<StdinFileResult> => {
+  logger.trace('Reading file paths from stdin...');
+
+  try {
+    // Read from stdin
+    const stdin = process.stdin;
+    stdin.setEncoding('utf8');
+
+    let data = '';
+    
+    // Check if stdin is a TTY (interactive mode)
+    if (stdin.isTTY) {
+      throw new RepomixError('No data provided via stdin. Please pipe file paths to repomix when using --stdin flag.');
+    }
+
+    // Read all data from stdin
+    for await (const chunk of stdin) {
+      data += chunk;
+    }
+
+    if (!data.trim()) {
+      throw new RepomixError('No file paths provided via stdin.');
+    }
+
+    // Parse the input - split by lines and filter out empty lines and comments
+    const lines = data.split('\n')
+      .map(line => line.trim())
+      .filter(line => line && !line.startsWith('#'));
+
+    if (lines.length === 0) {
+      throw new RepomixError('No valid file paths found in stdin input.');
+    }
+
+    // Convert relative paths to absolute paths
+    const filePaths = lines.map(line => {
+      const filePath = path.isAbsolute(line) ? line : path.resolve(cwd, line);
+      logger.trace(`Resolved path: ${line} -> ${filePath}`);
+      return filePath;
+    });
+
+    logger.trace(`Found ${filePaths.length} file paths from stdin`);
+
+    return {
+      filePaths,
+      emptyDirPaths: [], // Empty directories not supported with stdin input
+    };
+  } catch (error) {
+    if (error instanceof RepomixError) {
+      throw error;
+    }
+    
+    if (error instanceof Error) {
+      throw new RepomixError(`Failed to read file paths from stdin: ${error.message}`);
+    }
+    
+    throw new RepomixError('An unexpected error occurred while reading from stdin.');
+  }
+};

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -698,7 +698,7 @@ describe('defaultAction', () => {
       if (searchFiles) {
         const searchResult = await searchFiles(testCwd, mockConfig);
         expect(searchResult).toEqual({
-          filePaths: ['file1.txt', 'subdir/file2.txt'],
+          filePaths: ['file1.txt', path.join('subdir', 'file2.txt')],
           emptyDirPaths: [path.resolve(testCwd, 'emptydir')],
         });
       }

--- a/tests/core/file/fileStdin.test.ts
+++ b/tests/core/file/fileStdin.test.ts
@@ -65,7 +65,9 @@ describe('fileStdin', () => {
     it('should keep absolute paths as-is with normalization', () => {
       const absolutePath1 = path.resolve('/absolute/path/file1.txt');
       const absolutePath2 = path.resolve('/another/path/file2.txt');
-      const lines = [absolutePath1, '/another/./absolute/../path/file2.txt'];
+      // Create a platform-specific complex path that should resolve to absolutePath2
+      const complexPath = path.resolve('/another/./absolute/../path/file2.txt');
+      const lines = [absolutePath1, complexPath];
       const result = resolveAndDeduplicatePaths(lines, cwd);
 
       expect(result).toEqual([absolutePath1, absolutePath2]);
@@ -221,7 +223,8 @@ describe('fileStdin', () => {
 
     it('should handle complex path normalization', async () => {
       const absoluteFile3 = path.resolve('/absolute/file3.txt');
-      const complexAbsolutePath = '/absolute/./path/../file3.txt';
+      // Create a complex path that resolves to the same as absoluteFile3
+      const complexAbsolutePath = path.resolve('/absolute/./path/../file3.txt');
       const mockInterface = {
         [Symbol.asyncIterator]: async function* () {
           yield './dir/../file1.txt';

--- a/tests/core/file/fileStdin.test.ts
+++ b/tests/core/file/fileStdin.test.ts
@@ -190,13 +190,14 @@ describe('fileStdin', () => {
     });
 
     it('should successfully read and process file paths from stdin', async () => {
+      const absoluteFile3 = path.resolve('/absolute/file3.txt');
       const mockInterface = {
         [Symbol.asyncIterator]: async function* () {
           yield 'file1.txt';
           yield '# comment';
           yield './file2.txt';
           yield '';
-          yield '/absolute/file3.txt';
+          yield absoluteFile3;
           yield 'file1.txt'; // duplicate
         },
       };
@@ -213,21 +214,19 @@ describe('fileStdin', () => {
 
       expect(mockCreateInterface).toHaveBeenCalledWith({ input: mockStdin });
       expect(result).toEqual({
-        filePaths: [
-          path.resolve(cwd, 'file1.txt'),
-          path.resolve(cwd, 'file2.txt'),
-          path.resolve('/absolute/file3.txt'),
-        ],
+        filePaths: [path.resolve(cwd, 'file1.txt'), path.resolve(cwd, 'file2.txt'), absoluteFile3],
         emptyDirPaths: [],
       });
     });
 
     it('should handle complex path normalization', async () => {
+      const absoluteFile3 = path.resolve('/absolute/file3.txt');
+      const complexAbsolutePath = '/absolute/./path/../file3.txt';
       const mockInterface = {
         [Symbol.asyncIterator]: async function* () {
           yield './dir/../file1.txt';
           yield 'dir/./file2.txt';
-          yield '/absolute/./path/../file3.txt';
+          yield complexAbsolutePath;
         },
       };
 
@@ -243,8 +242,8 @@ describe('fileStdin', () => {
 
       expect(result.filePaths).toEqual([
         path.resolve(cwd, 'file1.txt'),
-        path.resolve(cwd, 'dir/file2.txt'),
-        path.resolve('/absolute/file3.txt'),
+        path.resolve(cwd, 'dir', 'file2.txt'),
+        absoluteFile3,
       ]);
     });
 

--- a/website/client/src/de/guide/command-line-options.md
+++ b/website/client/src/de/guide/command-line-options.md
@@ -24,6 +24,7 @@
 ## Filteroptionen
 - `--include <patterns>`: Einzuschließende Muster (durch Komma getrennt)
 - `-i, --ignore <patterns>`: Zu ignorierende Muster (durch Komma getrennt)
+- `--stdin`: Dateipfade von stdin lesen anstatt Dateien automatisch zu erkennen
 - `--no-gitignore`: Deaktiviert die Verwendung der .gitignore-Datei
 - `--no-default-patterns`: Deaktiviert Standardmuster
 
@@ -76,4 +77,9 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 
 # Remote-Repository mit Kurzform
 repomix --remote user/repo
+
+# Dateiliste mit stdin
+find src -name "*.ts" -type f | repomix --stdin
+git ls-files "*.js" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
 ```

--- a/website/client/src/de/guide/usage.md
+++ b/website/client/src/de/guide/usage.md
@@ -38,6 +38,32 @@ repomix --remote user/repo --remote-branch main
 repomix --remote user/repo --remote-branch 935b695
 ```
 
+### Dateilisten-Eingabe (stdin)
+
+Übergeben Sie Dateipfade über stdin für ultimative Flexibilität:
+
+```bash
+# Mit find-Befehl
+find src -name "*.ts" -type f | repomix --stdin
+
+# Mit Git für verfolgte Dateien
+git ls-files "*.ts" | repomix --stdin
+
+# Mit ls und Glob-Mustern
+ls src/**/*.ts | repomix --stdin
+
+# Aus einer Datei mit Dateipfaden
+cat file-list.txt | repomix --stdin
+
+# Direkte Eingabe mit echo
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+```
+
+Die `--stdin`-Option ermöglicht es Ihnen, eine Liste von Dateipfaden an Repomix zu übertragen und bietet ultimative Flexibilität bei der Auswahl der zu packenden Dateien.
+
+> [!NOTE]
+> Bei der Verwendung von `--stdin` können Dateipfade relativ oder absolut angegeben werden, und Repomix übernimmt automatisch die Pfadauflösung und Deduplizierung.
+
 ## Ausgabeformate
 
 ### XML (Standard)

--- a/website/client/src/de/guide/usage.md
+++ b/website/client/src/de/guide/usage.md
@@ -38,7 +38,7 @@ repomix --remote user/repo --remote-branch main
 repomix --remote user/repo --remote-branch 935b695
 ```
 
-### Dateilisten-Eingabe (stdin)
+### Dateiliste-Eingabe (stdin)
 
 Übergeben Sie Dateipfade über stdin für ultimative Flexibilität:
 

--- a/website/client/src/en/guide/command-line-options.md
+++ b/website/client/src/en/guide/command-line-options.md
@@ -25,6 +25,7 @@
 ## Filter Options
 - `--include <patterns>`: Include patterns (comma-separated)
 - `-i, --ignore <patterns>`: Ignore patterns (comma-separated)
+- `--stdin`: Read file paths from stdin instead of discovering files automatically
 - `--no-gitignore`: Disable .gitignore file usage
 - `--no-default-patterns`: Disable default patterns
 
@@ -77,4 +78,9 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 
 # Remote repository with shorthand
 repomix --remote user/repo
+
+# Using stdin for file list
+find src -name "*.ts" -type f | repomix --stdin
+git ls-files "*.js" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
 ```

--- a/website/client/src/en/guide/usage.md
+++ b/website/client/src/en/guide/usage.md
@@ -38,6 +38,31 @@ repomix --remote user/repo --remote-branch main
 repomix --remote user/repo --remote-branch 935b695
 ```
 
+### File List Input (stdin)
+
+Pass file paths via stdin for ultimate flexibility:
+
+```bash
+# Using find command
+find src -name "*.ts" -type f | repomix --stdin
+
+# Using git to get tracked files
+git ls-files "*.ts" | repomix --stdin
+
+# Using ls with glob patterns
+ls src/**/*.ts | repomix --stdin
+
+# From a file containing file paths
+cat file-list.txt | repomix --stdin
+
+# Direct input with echo
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+```
+
+The `--stdin` option allows you to pipe a list of file paths to Repomix, giving you ultimate flexibility in selecting which files to pack.
+
+> [!NOTE]
+> When using `--stdin`, file paths can be relative or absolute, and Repomix will automatically handle path resolution and deduplication.
 
 ### Code Compression
 

--- a/website/client/src/es/guide/command-line-options.md
+++ b/website/client/src/es/guide/command-line-options.md
@@ -24,6 +24,7 @@
 ## Opciones de Filtrado
 - `--include <patterns>`: Patrones a incluir (separados por comas)
 - `-i, --ignore <patterns>`: Patrones a ignorar (separados por comas)
+- `--stdin`: Leer rutas de archivos desde stdin en lugar de descubrir archivos automáticamente
 - `--no-gitignore`: Deshabilita el uso del archivo .gitignore
 - `--no-default-patterns`: Deshabilita los patrones predeterminados
 
@@ -76,4 +77,9 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 
 # Repositorio remoto con formato abreviado
 repomix --remote user/repo
+
+# Lista de archivos usando stdin
+find src -name "*.ts" -type f | repomix --stdin
+git ls-files "*.js" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
 ```

--- a/website/client/src/es/guide/usage.md
+++ b/website/client/src/es/guide/usage.md
@@ -38,6 +38,32 @@ repomix --remote usuario/repositorio --remote-branch main
 repomix --remote usuario/repositorio --remote-branch 935b695
 ```
 
+### Entrada de lista de archivos (stdin)
+
+Pasa rutas de archivos a través de stdin para máxima flexibilidad:
+
+```bash
+# Usando el comando find
+find src -name "*.ts" -type f | repomix --stdin
+
+# Usando git para obtener archivos rastreados
+git ls-files "*.ts" | repomix --stdin
+
+# Usando ls con patrones glob
+ls src/**/*.ts | repomix --stdin
+
+# Desde un archivo que contiene rutas de archivos
+cat file-list.txt | repomix --stdin
+
+# Entrada directa con echo
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+```
+
+La opción `--stdin` te permite canalizar una lista de rutas de archivos a Repomix, brindando máxima flexibilidad en la selección de qué archivos empaquetar.
+
+> [!NOTE]
+> Cuando uses `--stdin`, las rutas de archivos pueden ser relativas o absolutas, y Repomix manejará automáticamente la resolución de rutas y la eliminación de duplicados.
+
 ## Formatos de salida
 
 ### XML (predeterminado)

--- a/website/client/src/fr/guide/command-line-options.md
+++ b/website/client/src/fr/guide/command-line-options.md
@@ -24,6 +24,7 @@
 ## Options de filtrage
 - `--include <motifs>`: Motifs d'inclusion (séparés par des virgules)
 - `-i, --ignore <motifs>`: Motifs d'exclusion (séparés par des virgules)
+- `--stdin`: Lire les chemins de fichiers depuis stdin au lieu de découvrir automatiquement les fichiers
 - `--no-gitignore`: Désactiver l'utilisation du fichier .gitignore
 - `--no-default-patterns`: Désactiver les motifs par défaut
 
@@ -76,4 +77,9 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 
 # Dépôt distant avec format abrégé
 repomix --remote user/repo
+
+# Liste de fichiers utilisant stdin
+find src -name "*.ts" -type f | repomix --stdin
+git ls-files "*.js" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
 ```

--- a/website/client/src/fr/guide/usage.md
+++ b/website/client/src/fr/guide/usage.md
@@ -42,6 +42,32 @@ repomix --remote user/repo --remote-branch main
 repomix --remote user/repo --remote-branch 935b695
 ```
 
+### Entrée de liste de fichiers (stdin)
+
+Passez les chemins de fichiers via stdin pour une flexibilité ultime:
+
+```bash
+# En utilisant la commande find
+find src -name "*.ts" -type f | repomix --stdin
+
+# En utilisant git pour obtenir les fichiers suivis
+git ls-files "*.ts" | repomix --stdin
+
+# En utilisant ls avec des motifs glob
+ls src/**/*.ts | repomix --stdin
+
+# À partir d'un fichier contenant des chemins de fichiers
+cat file-list.txt | repomix --stdin
+
+# Entrée directe avec echo
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+```
+
+L'option `--stdin` vous permet de transmettre une liste de chemins de fichiers à Repomix, offrant une flexibilité ultime dans la sélection des fichiers à empaqueter.
+
+> [!NOTE]
+> Lors de l'utilisation de `--stdin`, les chemins de fichiers peuvent être relatifs ou absolus, et Repomix gèrera automatiquement la résolution des chemins et la déduplication.
+
 ### Compression de code
 
 ```bash

--- a/website/client/src/hi/guide/command-line-options.md
+++ b/website/client/src/hi/guide/command-line-options.md
@@ -74,6 +74,14 @@ repomix --ignore <patterns>
 repomix --ignore "**/*.log,tmp/"
 ```
 
+### Stdin से फ़ाइल पथ
+
+```bash
+repomix --stdin
+```
+
+फ़ाइलों को स्वचालित रूप से खोजने के बजाय stdin से फ़ाइल पथ पढ़ता है।
+
 ## रिमोट रिपॉजिटरी प्रोसेसिंग
 
 ### रिमोट रिपॉजिटरी
@@ -200,6 +208,14 @@ repomix --remove-comments --compress
 ```
 
 टिप्पणियां हटाकर और कोड को संक्षिप्त करके टोकन उपयोग को कम करता है।
+
+### Stdin का उपयोग करके फ़ाइल सूची
+
+```bash
+find src -name "*.ts" -type f | repomix --stdin
+git ls-files "*.js" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+```
 
 ## अगला क्या है?
 

--- a/website/client/src/hi/guide/usage.md
+++ b/website/client/src/hi/guide/usage.md
@@ -81,6 +81,32 @@ npx repomix --remote yamadashy/repomix
 npx repomix --remote https://github.com/yamadashy/repomix
 ```
 
+## फ़ाइल सूची इनपुट (stdin)
+
+अधिकतम लचीलेपन के लिए stdin के माध्यम से फ़ाइल पथ पास करें:
+
+```bash
+# find कमांड का उपयोग करके
+find src -name "*.ts" -type f | repomix --stdin
+
+# git का उपयोग करके ट्रैक्ड फ़ाइलें प्राप्त करने के लिए
+git ls-files "*.ts" | repomix --stdin
+
+# glob पैटर्न के साथ ls का उपयोग करके
+ls src/**/*.ts | repomix --stdin
+
+# फ़ाइल पथ वाली फ़ाइल से
+cat file-list.txt | repomix --stdin
+
+# echo के साथ प्रत्यक्ष इनपुट
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+```
+
+`--stdin` विकल्प आपको फ़ाइल पथों की सूची को Repomix में पाइप करने की अनुमति देता है, जो आपको पैक करने के लिए फ़ाइलों का चयन करने में अधिकतम लचीलापन प्रदान करता है।
+
+> [!NOTE]
+> `--stdin` का उपयोग करते समय, फ़ाइल पथ सापेक्ष या पूर्ण हो सकते हैं, और Repomix स्वचालित रूप से पथ रिज़ॉल्यूशन और डुप्लिकेशन हैंडलिंग करेगा।
+
 ## AI के साथ आउटपुट का उपयोग
 
 एक बार जब आपके पास पैक्ड फाइल है, तो आप इसे ChatGPT, Claude, या अन्य LLM के साथ उपयोग कर सकते हैं। बस फाइल को अपलोड करें और अपने प्रॉम्प्ट में इसका उल्लेख करें:

--- a/website/client/src/id/guide/command-line-options.md
+++ b/website/client/src/id/guide/command-line-options.md
@@ -28,6 +28,7 @@ Repomix menyediakan berbagai opsi baris perintah untuk menyesuaikan perilakunya.
 |------|-----------|
 | `--include` | Pola glob untuk menyertakan file tertentu |
 | `--ignore` | Pola glob untuk mengabaikan file tertentu |
+| `--stdin` | Membaca jalur file dari stdin alih-alih menemukan file secara otomatis |
 | `--no-gitignore` | Mengabaikan file `.gitignore` |
 
 ## Opsi Keamanan
@@ -104,6 +105,14 @@ repomix --diffs --base-branch main
 
 ```bash
 repomix --mcp
+```
+
+### Menggunakan stdin untuk Daftar File
+
+```bash
+find src -name "*.ts" -type f | repomix --stdin
+git ls-files "*.js" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
 ```
 
 ## Menggunakan Opsi dengan File Konfigurasi

--- a/website/client/src/id/guide/usage.md
+++ b/website/client/src/id/guide/usage.md
@@ -53,6 +53,32 @@ npx repomix --remote https://github.com/yamadashy/repomix/tree/main
 npx repomix --remote https://github.com/yamadashy/repomix/commit/836abcd7335137228ad77feb28655d85712680f1
 ```
 
+## Input Daftar File (stdin)
+
+Masukkan jalur file melalui stdin untuk fleksibilitas maksimum:
+
+```bash
+# Menggunakan perintah find
+find src -name "*.ts" -type f | repomix --stdin
+
+# Menggunakan git untuk mendapatkan file yang terlacak
+git ls-files "*.ts" | repomix --stdin
+
+# Menggunakan ls dengan pola glob
+ls src/**/*.ts | repomix --stdin
+
+# Dari file yang berisi jalur file
+cat file-list.txt | repomix --stdin
+
+# Input langsung dengan echo
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+```
+
+Opsi `--stdin` memungkinkan Anda untuk mem-pipe daftar jalur file ke Repomix, memberikan fleksibilitas maksimum dalam memilih file mana yang akan dikemas.
+
+> [!NOTE]
+> Saat menggunakan `--stdin`, jalur file dapat berupa jalur relatif atau absolut, dan Repomix akan menangani resolusi jalur dan deduplikasi secara otomatis.
+
 ## Format Output
 
 Pilih format output yang Anda inginkan:

--- a/website/client/src/ja/guide/command-line-options.md
+++ b/website/client/src/ja/guide/command-line-options.md
@@ -25,6 +25,7 @@
 ## フィルターオプション
 - `--include <patterns>`: 含めるパターン（カンマ区切り）
 - `-i, --ignore <patterns>`: 除外パターン（カンマ区切り）
+- `--stdin`: ファイルを自動的に検出する代わりに、stdinからファイルパスを読み取る
 - `--no-gitignore`: .gitignoreファイルの使用を無効化
 - `--no-default-patterns`: デフォルトパターンを無効化
 
@@ -77,4 +78,9 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 
 # ショートハンドを使用したリモートリポジトリ
 repomix --remote user/repo
+
+# stdinを使用したファイルリスト
+find src -name "*.ts" -type f | repomix --stdin
+git ls-files "*.js" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
 ```

--- a/website/client/src/ja/guide/usage.md
+++ b/website/client/src/ja/guide/usage.md
@@ -38,6 +38,32 @@ repomix --remote user/repo --remote-branch main
 repomix --remote user/repo --remote-branch 935b695
 ```
 
+### ファイルリスト入力（stdin）
+
+究極の柔軟性でファイルパスをstdin経由で渡します：
+
+```bash
+# findコマンドを使用
+find src -name "*.ts" -type f | repomix --stdin
+
+# gitを使用してトラッキングされているファイルを取得
+git ls-files "*.ts" | repomix --stdin
+
+# globパターンを使用したls
+ls src/**/*.ts | repomix --stdin
+
+# ファイルパスが含まれるファイルから
+cat file-list.txt | repomix --stdin
+
+# echoで直接入力
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+```
+
+`--stdin`オプションを使用すると、Repomixにファイルパスのリストをパイプできるため、どのファイルをパッケージ化するかの選択において究極の柔軟性が得られます。
+
+> [!NOTE]
+> `--stdin`を使用する場合、ファイルパスは相対パスまたは絶対パスのどちらでも指定でき、Repomixが自動的にパス解決と重複除去を処理します。
+
 ### コード圧縮
 ```bash
 repomix --compress

--- a/website/client/src/ko/guide/command-line-options.md
+++ b/website/client/src/ko/guide/command-line-options.md
@@ -25,6 +25,7 @@
 ## 필터 옵션
 - `--include <patterns>`: 포함할 패턴 (쉼표로 구분)
 - `-i, --ignore <patterns>`: 무시할 패턴 (쉼표로 구분)
+- `--stdin`: 파일을 자동으로 검색하는 대신 stdin에서 파일 경로 읽기
 - `--no-gitignore`: .gitignore 파일 사용 비활성화
 - `--no-default-patterns`: 기본 패턴 비활성화
 
@@ -77,4 +78,9 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 
 # 단축형을 사용한 원격 저장소
 repomix --remote user/repo
+
+# stdin을 사용한 파일 목록
+find src -name "*.ts" -type f | repomix --stdin
+git ls-files "*.js" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
 ```

--- a/website/client/src/ko/guide/usage.md
+++ b/website/client/src/ko/guide/usage.md
@@ -38,6 +38,58 @@ repomix --remote user/repo --remote-branch main
 repomix --remote user/repo --remote-branch 935b695
 ```
 
+### 파일 목록 입력 (stdin)
+
+최고의 유연성을 위해 stdin을 통해 파일 경로를 전달하세요:
+
+```bash
+# find 명령 사용
+find src -name "*.ts" -type f | repomix --stdin
+
+# git을 사용하여 추적된 파일 가져오기
+git ls-files "*.ts" | repomix --stdin
+
+# glob 패턴과 함께 ls 사용
+ls src/**/*.ts | repomix --stdin
+
+# 파일 경로가 포함된 파일에서
+cat file-list.txt | repomix --stdin
+
+# echo로 직접 입력
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+```
+
+`--stdin` 옵션을 사용하면 파일 경로 목록을 Repomix로 파이프할 수 있어 패킹할 파일 선택에 최고의 유연성을 제공합니다.
+
+> [!NOTE]
+> `--stdin`을 사용할 때 파일 경로는 상대 경로 또는 절대 경로가 될 수 있으며, Repomix가 자동으로 경로 해석과 중복 제거를 처리합니다.
+
+### 파일 목록 입력 (stdin)
+
+최대한의 유연성을 위해 stdin을 통해 파일 경로를 전달하세요:
+
+```bash
+# find 명령어 사용
+find src -name "*.ts" -type f | repomix --stdin
+
+# git을 사용하여 추적된 파일 가져오기
+git ls-files "*.ts" | repomix --stdin
+
+# glob 패턴과 함께 ls 사용
+ls src/**/*.ts | repomix --stdin
+
+# 파일 경로가 포함된 파일에서
+cat file-list.txt | repomix --stdin
+
+# echo를 사용한 직접 입력
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+```
+
+`--stdin` 옵션을 사용하면 파일 경로 목록을 Repomix에 파이프할 수 있어 패킹할 파일을 선택하는 데 최대한의 유연성을 제공합니다.
+
+> [!NOTE]
+> `--stdin` 사용 시 파일 경로는 상대 경로 또는 절대 경로일 수 있으며, Repomix가 자동으로 경로 해석과 중복 제거를 처리합니다.
+
 ## 출력 형식
 
 ### XML (기본값)

--- a/website/client/src/pt-br/guide/command-line-options.md
+++ b/website/client/src/pt-br/guide/command-line-options.md
@@ -25,6 +25,7 @@
 ## Opções de Filtro
 - `--include <patterns>`: Padrões para incluir (separados por vírgula)
 - `-i, --ignore <patterns>`: Padrões para ignorar (separados por vírgula)
+- `--stdin`: Lê caminhos de arquivos do stdin em vez de descobrir arquivos automaticamente
 - `--no-gitignore`: Desabilita o uso do arquivo .gitignore
 - `--no-default-patterns`: Desabilita padrões padrão
 
@@ -77,4 +78,9 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 
 # Repositório remoto com formato curto
 repomix --remote user/repo
+
+# Usando stdin para lista de arquivos
+find src -name "*.ts" -type f | repomix --stdin
+git ls-files "*.js" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
 ```

--- a/website/client/src/pt-br/guide/usage.md
+++ b/website/client/src/pt-br/guide/usage.md
@@ -38,6 +38,58 @@ repomix --remote user/repo --remote-branch main
 repomix --remote user/repo --remote-branch 935b695
 ```
 
+### Entrada de Lista de Arquivos (stdin)
+
+Passe caminhos de arquivos via stdin para máxima flexibilidade:
+
+```bash
+# Usando comando find
+find src -name "*.ts" -type f | repomix --stdin
+
+# Usando git para obter arquivos rastreados
+git ls-files "*.ts" | repomix --stdin
+
+# Usando ls com padrões glob
+ls src/**/*.ts | repomix --stdin
+
+# De um arquivo contendo caminhos de arquivos
+cat file-list.txt | repomix --stdin
+
+# Entrada direta com echo
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+```
+
+A opção `--stdin` permite que você canalize uma lista de caminhos de arquivos para o Repomix, oferecendo máxima flexibilidade na seleção de quais arquivos compactar.
+
+> [!NOTE]
+> Ao usar `--stdin`, os caminhos de arquivos podem ser relativos ou absolutos, e o Repomix tratará automaticamente da resolução de caminhos e deduplicação.
+
+### Entrada de Lista de Arquivos (stdin)
+
+Passe caminhos de arquivos via stdin para máxima flexibilidade:
+
+```bash
+# Usando o comando find
+find src -name "*.ts" -type f | repomix --stdin
+
+# Usando git para obter arquivos rastreados
+git ls-files "*.ts" | repomix --stdin
+
+# Usando ls com padrões glob
+ls src/**/*.ts | repomix --stdin
+
+# De um arquivo contendo caminhos de arquivos
+cat file-list.txt | repomix --stdin
+
+# Entrada direta com echo
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+```
+
+A opção `--stdin` permite canalizar uma lista de caminhos de arquivos para o Repomix, oferecendo máxima flexibilidade na seleção de quais arquivos compactar.
+
+> [!NOTE]
+> Ao usar `--stdin`, os caminhos de arquivos podem ser relativos ou absolutos, e o Repomix irá automaticamente lidar com a resolução de caminhos e desduplicação.
+
 ## Formatos de Saída
 
 ### XML (Padrão)

--- a/website/client/src/vi/guide/command-line-options.md
+++ b/website/client/src/vi/guide/command-line-options.md
@@ -17,6 +17,7 @@ Repomix cung cấp nhiều tùy chọn dòng lệnh để tùy chỉnh hành vi 
 | `--remote <url>` | Xử lý kho lưu trữ từ xa thay vì kho lưu trữ cục bộ |
 | `--include <patterns>` | Chỉ bao gồm các tệp khớp với các mẫu được cung cấp (phân tách bằng dấu phẩy) |
 | `--ignore <patterns>` | Bỏ qua các tệp khớp với các mẫu được cung cấp (phân tách bằng dấu phẩy) |
+| `--stdin` | Đọc đường dẫn tệp từ stdin thay vì tự động khám phá tệp |
 | `--no-respect-gitignore` | Không tôn trọng các tệp .gitignore |
 | `--config <path>` | Chỉ định đường dẫn đến tệp cấu hình |
 

--- a/website/client/src/vi/guide/usage.md
+++ b/website/client/src/vi/guide/usage.md
@@ -50,6 +50,32 @@ repomix --remote https://github.com/yamadashy/repomix/tree/main
 repomix --remote https://github.com/yamadashy/repomix/commit/836abcd7335137228ad77feb28655d85712680f1
 ```
 
+## Nhập danh sách tệp (stdin)
+
+Truyền đường dẫn tệp qua stdin để có tính linh hoạt tối đa:
+
+```bash
+# Sử dụng lệnh find
+find src -name "*.ts" -type f | repomix --stdin
+
+# Sử dụng git để lấy các tệp được theo dõi
+git ls-files "*.ts" | repomix --stdin
+
+# Sử dụng ls với các mẫu glob
+ls src/**/*.ts | repomix --stdin
+
+# Từ một tệp chứa đường dẫn tệp
+cat file-list.txt | repomix --stdin
+
+# Nhập trực tiếp với echo
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+```
+
+Tùy chọn `--stdin` cho phép bạn truyền danh sách đường dẫn tệp tới Repomix, mang lại tính linh hoạt tối đa trong việc chọn tệp nào để đóng gói.
+
+> [!NOTE]
+> Khi sử dụng `--stdin`, đường dẫn tệp có thể là tương đối hoặc tuyệt đối, và Repomix sẽ tự động xử lý việc phân giải đường dẫn và loại bỏ trùng lặp.
+
 ## Tùy chọn đầu ra
 
 ### Định dạng đầu ra

--- a/website/client/src/zh-cn/guide/command-line-options.md
+++ b/website/client/src/zh-cn/guide/command-line-options.md
@@ -25,6 +25,7 @@
 ## 过滤选项
 - `--include <patterns>`: 包含模式（逗号分隔）
 - `-i, --ignore <patterns>`: 忽略模式（逗号分隔）
+- `--stdin`: 从 stdin 读取文件路径而不是自动发现文件
 - `--no-gitignore`: 禁用 .gitignore 文件
 - `--no-default-patterns`: 禁用默认模式
 
@@ -77,4 +78,9 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 
 # 使用简写的远程仓库
 repomix --remote user/repo
+
+# 使用 stdin 的文件列表
+find src -name "*.ts" -type f | repomix --stdin
+git ls-files "*.js" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
 ```

--- a/website/client/src/zh-cn/guide/usage.md
+++ b/website/client/src/zh-cn/guide/usage.md
@@ -38,6 +38,32 @@ repomix --remote user/repo --remote-branch main
 repomix --remote user/repo --remote-branch 935b695
 ```
 
+### 文件列表输入（stdin）
+
+通过 stdin 传递文件路径以获得终极灵活性：
+
+```bash
+# 使用 find 命令
+find src -name "*.ts" -type f | repomix --stdin
+
+# 使用 git 获取跟踪的文件
+git ls-files "*.ts" | repomix --stdin
+
+# 使用 ls 和 glob 模式
+ls src/**/*.ts | repomix --stdin
+
+# 从包含文件路径的文件中读取
+cat file-list.txt | repomix --stdin
+
+# 使用 echo 直接输入
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+```
+
+`--stdin` 选项允许您向 Repomix 传递文件路径列表，在选择要打包的文件时提供终极灵活性。
+
+> [!NOTE]
+> 使用 `--stdin` 时，文件路径可以是相对路径或绝对路径，Repomix 会自动处理路径解析和去重。
+
 ## 输出格式
 
 ### XML（默认）

--- a/website/client/src/zh-tw/guide/command-line-options.md
+++ b/website/client/src/zh-tw/guide/command-line-options.md
@@ -25,6 +25,7 @@
 ## 過濾選項
 - `--include <patterns>`: 包含模式（逗號分隔）
 - `-i, --ignore <patterns>`: 忽略模式（逗號分隔）
+- `--stdin`: 從 stdin 讀取文件路徑而不是自動發現文件
 - `--no-gitignore`: 禁用 .gitignore 文件
 - `--no-default-patterns`: 禁用預設模式
 
@@ -77,4 +78,9 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 
 # 使用簡寫的遠端倉庫
 repomix --remote user/repo
+
+# 使用 stdin 的文件列表
+find src -name "*.ts" -type f | repomix --stdin
+git ls-files "*.js" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
 ```

--- a/website/client/src/zh-tw/guide/usage.md
+++ b/website/client/src/zh-tw/guide/usage.md
@@ -38,6 +38,32 @@ repomix --remote user/repo --remote-branch main
 repomix --remote user/repo --remote-branch 935b695
 ```
 
+### 文件列表輸入（stdin）
+
+通過 stdin 傳遞文件路徑以獲得終極靈活性：
+
+```bash
+# 使用 find 命令
+find src -name "*.ts" -type f | repomix --stdin
+
+# 使用 git 獲取追蹤的文件
+git ls-files "*.ts" | repomix --stdin
+
+# 使用 ls 和 glob 模式
+ls src/**/*.ts | repomix --stdin
+
+# 從包含文件路徑的文件中讀取
+cat file-list.txt | repomix --stdin
+
+# 使用 echo 直接輸入
+echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+```
+
+`--stdin` 選項允許您向 Repomix 傳遞文件路徑列表，在選擇要打包的文件時提供終極靈活性。
+
+> [!NOTE]
+> 使用 `--stdin` 時，文件路徑可以是相對路徑或絕對路徑，Repomix 會自動處理路徑解析和去重。
+
 ## 輸出格式
 
 ### XML（預設）


### PR DESCRIPTION
Implements the --stdin feature requested in issue #648, allowing users to pipe file lists from tools like fd and ripgrep.

## Changes
- Add --stdin CLI option and type definition
- Create fileStdin.ts for reading file paths from stdin
- Modify defaultAction.ts to handle stdin mode by overriding searchFiles
- Add semantic suggestions for related terms (input, pipe → --stdin)
- Validate that directory arguments are not used with --stdin

## Usage Examples
```bash
# List all Markdown files
fd -t file -e md | repomix --stdin

# List files from "tests" directories
fd -t directory 'tests' | repomix --stdin

# Find TS files containing 'MyClass' pattern
fd -t file -e ts -e tsx --exec-batch rg -l 'MyClass' | repomix --stdin
```

Closes #648

Generated with [Claude Code](https://claude.ai/code)