### PR TITLE
chore: Add .private/ to .gitignore and improve CI comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
+      # Run tests directly instead of using npm scripts with node --run which is not supported in older Node versions
       - run: ./node_modules/.bin/vitest --reporter=verbose
         env:
           CI_OS: ${{ runner.os }}
@@ -187,6 +188,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
+      # Run build directly instead of using npm scripts with node --run which is not supported in older Node versions
       - run: ./node_modules/.bin/rimraf lib && ./node_modules/.bin/tsc -p tsconfig.build.json --sourceMap --declaration
       - name: Install only production dependencies
         run: npm ci --omit=dev

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ repomix-output.md
 .cursor/rules/
 .github/todo.md
 .mcp.json
+.private/


### PR DESCRIPTION
This PR adds the `.private/` directory to `.gitignore` and includes explanatory comments in the CI workflow.

## Summary
- Added `.private/` directory to `.gitignore` to exclude private working files
- Added comments in CI workflow explaining why we run commands directly instead of using npm scripts (for compatibility with older Node.js versions)

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.ai/code)