### PR TITLE
feat(output): Make summary purpose conditional based on file selection

### DIFF
--- a/src/core/output/outputGenerate.ts
+++ b/src/core/output/outputGenerate.ts
@@ -31,7 +31,7 @@ const calculateMarkdownDelimiter = (files: ReadonlyArray<ProcessedFile>): string
 const createRenderContext = (outputGeneratorContext: OutputGeneratorContext): RenderContext => {
   return {
     generationHeader: generateHeader(outputGeneratorContext.config, outputGeneratorContext.generationDate),
-    summaryPurpose: generateSummaryPurpose(),
+    summaryPurpose: generateSummaryPurpose(outputGeneratorContext.config),
     summaryFileFormat: generateSummaryFileFormat(),
     summaryUsageGuidelines: generateSummaryUsageGuidelines(
       outputGeneratorContext.config,

--- a/src/core/output/outputStyleDecorate.ts
+++ b/src/core/output/outputStyleDecorate.ts
@@ -89,9 +89,15 @@ export const generateHeader = (config: RepomixConfigMerged, generationDate: stri
   return `${description}, combined into a single document by Repomix.\n${processingInfo}`.trim();
 };
 
-export const generateSummaryPurpose = (): string => {
+export const generateSummaryPurpose = (config: RepomixConfigMerged): string => {
+  const info = analyzeContent(config);
+
+  const contentDescription = info.selection.isEntireCodebase
+    ? "the entire repository's contents"
+    : "a subset of the repository's contents that is considered the most important context";
+
   return `
-This file contains a packed representation of the entire repository's contents.
+This file contains a packed representation of ${contentDescription}.
 It is designed to be easily consumable by AI systems for analysis, code review,
 or other automated processes.
 `.trim();

--- a/tests/core/output/outputStyleDecorate.test.ts
+++ b/tests/core/output/outputStyleDecorate.test.ts
@@ -86,10 +86,26 @@ describe('generateHeader', () => {
 
 describe('generateSummaryPurpose', () => {
   it('should generate consistent purpose text', () => {
-    const purpose = generateSummaryPurpose();
+    const purpose = generateSummaryPurpose(createMockConfig());
     expect(purpose).toContain('packed representation');
     expect(purpose).toContain('AI systems');
     expect(purpose).toContain('code review');
+  });
+
+  it('should indicate entire repository when using default settings', () => {
+    const config = createMockConfig();
+    const purpose = generateSummaryPurpose(config);
+    expect(purpose).toContain("entire repository's contents");
+    expect(purpose).not.toContain('subset');
+  });
+
+  it('should indicate subset when using include patterns', () => {
+    const config = createMockConfig({
+      include: ['src/**/*.ts'],
+    });
+    const purpose = generateSummaryPurpose(config);
+    expect(purpose).toContain("subset of the repository's contents that is considered the most important context");
+    expect(purpose).not.toContain('entire repository');
   });
 });
 


### PR DESCRIPTION
## What
- Update generateSummaryPurpose function to accept RepomixConfigMerged parameter
- Add logic to differentiate between entire codebase vs subset in purpose description
- Update function call in outputGenerate.ts to pass config parameter
- Add comprehensive tests for both entire codebase and subset scenarios

## Why
Previously, the summary purpose section always claimed the file contained "the entire repository's contents", even when repomix was configured to process only a subset of files (e.g., with include patterns). This created inconsistency with other parts of the output that correctly indicated when only a subset was processed.

This change ensures the purpose section accurately describes the content as either "the entire repository's contents" or "a subset of the repository's contents that is considered the most important context" based on the actual file selection configuration.

Let me know what you think! I think this removes a potential "contradiction" for the LLMs parsing this file, and thanks for an awesome repo.

## Checklist

- [ x] Run `npm run test`
- [ x] Run `npm run lint`
