### PR TITLE
fix: prevent file copy in stdout mode for remote repositories

### DIFF
--- a/src/cli/actions/remoteAction.ts
+++ b/src/cli/actions/remoteAction.ts
@@ -90,7 +90,13 @@ export const runRemoteAction = async (
 
     // Run the default action on the downloaded/cloned repository
     result = await deps.runDefaultAction([tempDirPath], tempDirPath, cliOptions);
-    await copyOutputToCurrentDirectory(tempDirPath, process.cwd(), result.config.output.filePath);
+
+    // Copy output file only when not in stdout mode
+    // In stdout mode, output is written directly to stdout without creating a file,
+    // so attempting to copy a non-existent file would cause an error and exit code 1
+    if (!cliOptions.stdout) {
+      await copyOutputToCurrentDirectory(tempDirPath, process.cwd(), result.config.output.filePath);
+    }
 
     logger.trace(`Repository obtained via ${downloadMethod} method`);
   } finally {


### PR DESCRIPTION
## Summary

Fixes #673 - False positive error with `--stdout` and `--remote` flags

When using `--remote` with `--stdout` flags together, the command was failing with exit code 1 due to attempting to copy a non-existent output file. In stdout mode, output is written directly to stdout without creating a file, so the copy operation should be skipped.

## Changes

- Skip `copyOutputToCurrentDirectory` when `--stdout` flag is enabled in `remoteAction.ts`
- This prevents the false positive exit code 1 when using `--remote` and `--stdout` together

## Test plan

- [x] Run `npm run test` - All tests pass
- [x] Run `npm run lint` - No lint errors
- [x] Test the specific command from the issue: `npx repomix --stdout --remote https://github.com/JedWatson/classnames`
- [x] Verify exit code is 0 (success) instead of 1 (failure)

🤖 Generated with [Claude Code](https://claude.ai/code)