### PR TITLE
feat: implement stdin auto-detection and remove --stdin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,29 +216,32 @@ repomix --remote https://github.com/yamadashy/repomix/commit/836abcd7335137228ad
 
 ```
 
-To pack files from a file list (via stdin):
+To pack files from a file list (pipe via stdin):
 
 ```bash
 # Using find command
-find src -name "*.ts" -type f | repomix --stdin
+find src -name "*.ts" -type f | repomix
 
 # Using git to get tracked files
-git ls-files "*.ts" | repomix --stdin
+git ls-files "*.ts" | repomix
 
 # Using ls with glob patterns
-ls src/**/*.ts | repomix --stdin
+ls src/**/*.ts | repomix
 
 # From a file containing file paths
-cat file-list.txt | repomix --stdin
+cat file-list.txt | repomix
 
 # Direct input with echo
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
+
+# Using find command with a dash (explicit stdin indicator)
+find src -name "*.ts" | repomix -
 ```
 
-The `--stdin` option allows you to pipe a list of file paths to Repomix, giving you ultimate flexibility in selecting which files to pack.
+Repomix automatically detects when file paths are piped via stdin, giving you ultimate flexibility in selecting which files to pack.
 
 > [!NOTE]
-> When using `--stdin`, file paths can be relative or absolute, and Repomix will automatically handle path resolution and deduplication.
+> When using stdin input, file paths can be relative or absolute, and Repomix will automatically handle path resolution and deduplication.
 
 To compress the output:
 
@@ -508,7 +511,6 @@ Instruction
 #### Filter Options
 - `--include <patterns>`: List of include patterns (comma-separated)
 - `-i, --ignore <patterns>`: Additional ignore patterns (comma-separated)
-- `--stdin`: Read file paths from stdin instead of discovering files automatically
 - `--no-gitignore`: Disable .gitignore file usage
 - `--no-default-patterns`: Disable default patterns
 

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -30,7 +30,7 @@ const shouldAutoDetectStdin = (directories: string[]): boolean => {
 
   // Check if default directory is used and stdin has piped data
   const isDefaultDirectory = directories.length === 1 && directories[0] === '.';
-  
+
   // Use file descriptor check as a more reliable method than process.stdin.isTTY
   // which can be undefined in some environments (like CI/CD or certain shells)
   let hasStdinInput = false;
@@ -43,7 +43,7 @@ const shouldAutoDetectStdin = (directories: string[]): boolean => {
   }
 
   // Only auto-detect stdin if we have both conditions:
-  // 1. Using the default directory  
+  // 1. Using the default directory
   // 2. Actually receiving piped input
   return isDefaultDirectory && hasStdinInput;
 };

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -42,14 +42,13 @@ const semanticSuggestionMap: Record<string, string[]> = {
   print: ['--stdout'],
   console: ['--stdout'],
   terminal: ['--stdout'],
-  pipe: ['--stdin'],
 };
 
 export const run = async () => {
   try {
     program
       .description('Repomix - Pack your repository into a single AI-friendly file')
-      .argument('[directories...]', 'list of directories to process', ['.'])
+      .argument('[directories...]', 'list of directories to process (use "-" for stdin)', ['.'])
       // Basic Options
       .optionsGroup('Basic Options')
       .option('-v, --version', 'show version information')
@@ -81,7 +80,6 @@ export const run = async () => {
       .option('-i, --ignore <patterns>', 'additional ignore patterns (comma-separated)')
       .option('--no-gitignore', 'disable .gitignore file usage')
       .option('--no-default-patterns', 'disable default patterns')
-      .option('--stdin', 'read file list from stdin')
       // Remote Repository Options
       .optionsGroup('Remote Repository Options')
       .option('--remote <url>', 'process a remote Git repository')

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -29,7 +29,6 @@ export interface CliOptions extends OptionValues {
   ignore?: string;
   gitignore?: boolean;
   defaultPatterns?: boolean;
-  stdin?: boolean;
 
   // Remote Repository Options
   remote?: string;

--- a/src/core/file/fileStdin.ts
+++ b/src/core/file/fileStdin.ts
@@ -71,7 +71,9 @@ export const readFilePathsFromStdin = async (
 
     // Check if stdin is a TTY (interactive mode)
     if (stdin.isTTY) {
-      throw new RepomixError('No data provided via stdin. Please pipe file paths to repomix when using --stdin flag.');
+      throw new RepomixError(
+        'No data provided via stdin. Please pipe file paths to repomix or specify a directory argument.',
+      );
     }
 
     // Read all lines from stdin

--- a/tests/cli/actions/stdinAutoDetect.test.ts
+++ b/tests/cli/actions/stdinAutoDetect.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runDefaultAction } from '../../../src/cli/actions/defaultAction.js';
+import type { CliOptions } from '../../../src/cli/types.js';
+import * as configLoader from '../../../src/config/configLoad.js';
+import * as fileStdin from '../../../src/core/file/fileStdin.js';
+import * as packager from '../../../src/core/packager.js';
+import type { PackResult } from '../../../src/core/packager.js';
+
+vi.mock('../../../src/core/packager');
+vi.mock('../../../src/config/configLoad');
+vi.mock('../../../src/core/file/fileStdin');
+vi.mock('../../../src/shared/logger');
+vi.mock('../../../src/cli/cliSpinner');
+vi.mock('../../../src/cli/cliPrint');
+vi.mock('../../../src/cli/actions/migrationAction');
+
+describe('stdin auto-detection', () => {
+  const mockPackResult: PackResult = {
+    totalFiles: 1,
+    totalCharacters: 100,
+    totalTokens: 25,
+    fileCharCounts: {},
+    fileTokenCounts: {},
+    suspiciousFilesResults: [],
+    suspiciousGitDiffResults: [],
+    processedFiles: [],
+    gitDiffTokenCount: 0,
+    safeFilePaths: ['test-file.txt'],
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(configLoader.loadFileConfig).mockResolvedValue({});
+    vi.mocked(configLoader.mergeConfigs).mockReturnValue({
+      cwd: process.cwd(),
+      input: { maxFileSize: 50 * 1024 * 1024 },
+      output: {
+        filePath: 'output.txt',
+        style: 'plain',
+        parsableStyle: false,
+        topFilesLength: 5,
+        showLineNumbers: false,
+        removeComments: false,
+        removeEmptyLines: false,
+        compress: false,
+        copyToClipboard: false,
+        files: true,
+        fileSummary: true,
+        directoryStructure: true,
+        includeEmptyDirectories: false,
+        stdout: false,
+        headerText: undefined,
+        instructionFilePath: undefined,
+        git: { sortByChanges: true, sortByChangesMaxCommits: 100, includeDiffs: false },
+      },
+      ignore: { useGitignore: true, useDefaultPatterns: true, customPatterns: [] },
+      include: [],
+      security: { enableSecurityCheck: true },
+      tokenCount: { encoding: 'cl100k_base' },
+    });
+    vi.mocked(packager.pack).mockResolvedValue(mockPackResult);
+    vi.mocked(fileStdin.readFilePathsFromStdin).mockResolvedValue({
+      filePaths: ['test-file.txt'],
+      emptyDirPaths: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('when stdin is piped and default directory is used', () => {
+    beforeEach(() => {
+      // Mock stdin as not TTY (piped input)
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: undefined,
+        configurable: true,
+      });
+    });
+
+    it('should auto-detect stdin input', async () => {
+      const cliOptions: CliOptions = {};
+      const directories = ['.'];
+
+      await runDefaultAction(directories, process.cwd(), cliOptions);
+
+      expect(fileStdin.readFilePathsFromStdin).toHaveBeenCalledWith(process.cwd());
+      expect(packager.pack).toHaveBeenCalledWith([process.cwd()], expect.any(Object), expect.any(Function), {}, [
+        'test-file.txt',
+      ]);
+    });
+
+    it('should not auto-detect when explicit directory is provided', async () => {
+      const cliOptions: CliOptions = {};
+      const directories = ['src'];
+
+      await runDefaultAction(directories, process.cwd(), cliOptions);
+
+      expect(fileStdin.readFilePathsFromStdin).not.toHaveBeenCalled();
+      expect(packager.pack).toHaveBeenCalledWith(
+        [expect.stringContaining('src')],
+        expect.any(Object),
+        expect.any(Function),
+      );
+    });
+
+    it('should not auto-detect when multiple directories are provided', async () => {
+      const cliOptions: CliOptions = {};
+      const directories = ['src', 'tests'];
+
+      await runDefaultAction(directories, process.cwd(), cliOptions);
+
+      expect(fileStdin.readFilePathsFromStdin).not.toHaveBeenCalled();
+      expect(packager.pack).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.stringContaining('src'), expect.stringContaining('tests')]),
+        expect.any(Object),
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('when dash argument is used', () => {
+    it('should auto-detect stdin input with dash argument', async () => {
+      const cliOptions: CliOptions = {};
+      const directories = ['-'];
+
+      await runDefaultAction(directories, process.cwd(), cliOptions);
+
+      expect(fileStdin.readFilePathsFromStdin).toHaveBeenCalledWith(process.cwd());
+      expect(packager.pack).toHaveBeenCalledWith([process.cwd()], expect.any(Object), expect.any(Function), {}, [
+        'test-file.txt',
+      ]);
+    });
+
+    it('should handle dash argument even when stdin is TTY', async () => {
+      // Mock stdin as TTY (interactive terminal)
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+
+      const cliOptions: CliOptions = {};
+      const directories = ['-'];
+
+      await runDefaultAction(directories, process.cwd(), cliOptions);
+
+      expect(fileStdin.readFilePathsFromStdin).toHaveBeenCalledWith(process.cwd());
+    });
+  });
+
+  describe('when stdin is TTY (interactive terminal)', () => {
+    beforeEach(() => {
+      // Mock stdin as TTY (interactive terminal)
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+    });
+
+    it('should not auto-detect stdin input', async () => {
+      const cliOptions: CliOptions = {};
+      const directories = ['.'];
+
+      await runDefaultAction(directories, process.cwd(), cliOptions);
+
+      expect(fileStdin.readFilePathsFromStdin).not.toHaveBeenCalled();
+      expect(packager.pack).toHaveBeenCalledWith([process.cwd()], expect.any(Object), expect.any(Function));
+    });
+  });
+
+  describe('stdin input validation', () => {
+    it('should not auto-detect stdin when multiple directories including dash', async () => {
+      const cliOptions: CliOptions = {};
+      const directories = ['-', 'src']; // Multiple directories including dash - should use normal directory processing
+
+      await runDefaultAction(directories, process.cwd(), cliOptions);
+
+      expect(fileStdin.readFilePathsFromStdin).not.toHaveBeenCalled();
+      expect(packager.pack).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.stringContaining('-'), expect.stringContaining('src')]),
+        expect.any(Object),
+        expect.any(Function),
+      );
+    });
+
+    it('should reject explicit directory with piped input', async () => {
+      // Mock stdin as not TTY (piped input)
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: undefined,
+        configurable: true,
+      });
+
+      const cliOptions: CliOptions = {};
+      const directories = ['src']; // Explicit directory should work normally (no stdin auto-detection)
+
+      await runDefaultAction(directories, process.cwd(), cliOptions);
+
+      expect(fileStdin.readFilePathsFromStdin).not.toHaveBeenCalled();
+      expect(packager.pack).toHaveBeenCalledWith(
+        [expect.stringContaining('src')],
+        expect.any(Object),
+        expect.any(Function),
+      );
+    });
+  });
+});

--- a/tests/cli/actions/stdinAutoDetect.test.ts
+++ b/tests/cli/actions/stdinAutoDetect.test.ts
@@ -33,13 +33,13 @@ describe('stdin auto-detection', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(configLoader.loadFileConfig).mockResolvedValue({});
-    
+
     // Default mock: fs.fstatSync returns character device (TTY) - no stdin auto-detection
     vi.mocked(fs.fstatSync).mockReturnValue({
       isFIFO: () => false,
       isFile: () => false,
       isCharacterDevice: () => true,
-    } as any);
+    } as fs.Stats);
     vi.mocked(configLoader.mergeConfigs).mockReturnValue({
       cwd: process.cwd(),
       input: { maxFileSize: 50 * 1024 * 1024 },
@@ -85,7 +85,7 @@ describe('stdin auto-detection', () => {
         isFIFO: () => true,
         isFile: () => false,
         isCharacterDevice: () => false,
-      } as any);
+      } as fs.Stats);
     });
 
     it('should auto-detect stdin input', async () => {
@@ -165,7 +165,7 @@ describe('stdin auto-detection', () => {
         isFIFO: () => false,
         isFile: () => false,
         isCharacterDevice: () => true,
-      } as any);
+      } as fs.Stats);
     });
 
     it('should not auto-detect stdin input', async () => {
@@ -200,7 +200,7 @@ describe('stdin auto-detection', () => {
         isFIFO: () => true,
         isFile: () => false,
         isCharacterDevice: () => false,
-      } as any);
+      } as fs.Stats);
 
       const cliOptions: CliOptions = {};
       const directories = ['src']; // Explicit directory should work normally (no stdin auto-detection)

--- a/tests/core/file/fileStdin.test.ts
+++ b/tests/core/file/fileStdin.test.ts
@@ -166,7 +166,7 @@ describe('fileStdin', () => {
 
       await expect(readFilePathsFromStdin(cwd, deps)).rejects.toThrow(RepomixError);
       await expect(readFilePathsFromStdin(cwd, deps)).rejects.toThrow(
-        'No data provided via stdin. Please pipe file paths to repomix when using --stdin flag.',
+        'No data provided via stdin. Please pipe file paths to repomix or specify a directory argument.',
       );
     });
 
@@ -282,7 +282,7 @@ describe('fileStdin', () => {
       const error = await readFilePathsFromStdin(cwd, deps).catch((e) => e);
       expect(error).toBeInstanceOf(RepomixError);
       expect(error.message).toBe(
-        'No data provided via stdin. Please pipe file paths to repomix when using --stdin flag.',
+        'No data provided via stdin. Please pipe file paths to repomix or specify a directory argument.',
       );
     });
 

--- a/website/client/src/de/guide/command-line-options.md
+++ b/website/client/src/de/guide/command-line-options.md
@@ -24,7 +24,6 @@
 ## Filteroptionen
 - `--include <patterns>`: Einzuschließende Muster (durch Komma getrennt)
 - `-i, --ignore <patterns>`: Zu ignorierende Muster (durch Komma getrennt)
-- `--stdin`: Dateipfade von stdin lesen anstatt Dateien automatisch zu erkennen
 - `--no-gitignore`: Deaktiviert die Verwendung der .gitignore-Datei
 - `--no-default-patterns`: Deaktiviert Standardmuster
 
@@ -78,8 +77,8 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 # Remote-Repository mit Kurzform
 repomix --remote user/repo
 
-# Dateiliste mit stdin
-find src -name "*.ts" -type f | repomix --stdin
-git ls-files "*.js" | repomix --stdin
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+# Dateiliste von stdin (automatische Erkennung)
+find src -name "*.ts" -type f | repomix
+git ls-files "*.js" | repomix
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
 ```

--- a/website/client/src/de/guide/usage.md
+++ b/website/client/src/de/guide/usage.md
@@ -38,31 +38,34 @@ repomix --remote user/repo --remote-branch main
 repomix --remote user/repo --remote-branch 935b695
 ```
 
-### Dateiliste-Eingabe (stdin)
+### Dateiliste-Eingabe (pipe via stdin)
 
 Übergeben Sie Dateipfade über stdin für ultimative Flexibilität:
 
 ```bash
 # Mit find-Befehl
-find src -name "*.ts" -type f | repomix --stdin
+find src -name "*.ts" -type f | repomix
 
 # Mit Git für verfolgte Dateien
-git ls-files "*.ts" | repomix --stdin
+git ls-files "*.ts" | repomix
 
 # Mit ls und Glob-Mustern
-ls src/**/*.ts | repomix --stdin
+ls src/**/*.ts | repomix
 
 # Aus einer Datei mit Dateipfaden
-cat file-list.txt | repomix --stdin
+cat file-list.txt | repomix
 
 # Direkte Eingabe mit echo
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
+
+# Mit find-Befehl und Bindestrich (expliziter stdin-Indikator)
+find src -name "*.ts" | repomix -
 ```
 
-Die `--stdin`-Option ermöglicht es Ihnen, eine Liste von Dateipfaden an Repomix zu übertragen und bietet ultimative Flexibilität bei der Auswahl der zu packenden Dateien.
+Repomix erkennt automatisch, wenn Dateipfade über stdin übertragen werden, und bietet ultimative Flexibilität bei der Auswahl der zu packenden Dateien.
 
 > [!NOTE]
-> Bei der Verwendung von `--stdin` können Dateipfade relativ oder absolut angegeben werden, und Repomix übernimmt automatisch die Pfadauflösung und Deduplizierung.
+> Bei der Verwendung von stdin-Eingabe können Dateipfade relativ oder absolut angegeben werden, und Repomix übernimmt automatisch die Pfadauflösung und Deduplizierung.
 
 ## Ausgabeformate
 

--- a/website/client/src/en/guide/command-line-options.md
+++ b/website/client/src/en/guide/command-line-options.md
@@ -25,7 +25,6 @@
 ## Filter Options
 - `--include <patterns>`: Include patterns (comma-separated)
 - `-i, --ignore <patterns>`: Ignore patterns (comma-separated)
-- `--stdin`: Read file paths from stdin instead of discovering files automatically
 - `--no-gitignore`: Disable .gitignore file usage
 - `--no-default-patterns`: Disable default patterns
 
@@ -79,8 +78,8 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 # Remote repository with shorthand
 repomix --remote user/repo
 
-# Using stdin for file list
-find src -name "*.ts" -type f | repomix --stdin
-git ls-files "*.js" | repomix --stdin
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+# Using file list via stdin (auto-detected)
+find src -name "*.ts" -type f | repomix
+git ls-files "*.js" | repomix
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
 ```

--- a/website/client/src/en/guide/usage.md
+++ b/website/client/src/en/guide/usage.md
@@ -38,31 +38,34 @@ repomix --remote user/repo --remote-branch main
 repomix --remote user/repo --remote-branch 935b695
 ```
 
-### File List Input (stdin)
+### File List Input (pipe via stdin)
 
 Pass file paths via stdin for ultimate flexibility:
 
 ```bash
 # Using find command
-find src -name "*.ts" -type f | repomix --stdin
+find src -name "*.ts" -type f | repomix
 
 # Using git to get tracked files
-git ls-files "*.ts" | repomix --stdin
+git ls-files "*.ts" | repomix
 
 # Using ls with glob patterns
-ls src/**/*.ts | repomix --stdin
+ls src/**/*.ts | repomix
 
 # From a file containing file paths
-cat file-list.txt | repomix --stdin
+cat file-list.txt | repomix
 
 # Direct input with echo
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
+
+# Using find command with a dash (explicit stdin indicator)
+find src -name "*.ts" | repomix -
 ```
 
-The `--stdin` option allows you to pipe a list of file paths to Repomix, giving you ultimate flexibility in selecting which files to pack.
+Repomix automatically detects when file paths are piped via stdin, giving you ultimate flexibility in selecting which files to pack.
 
 > [!NOTE]
-> When using `--stdin`, file paths can be relative or absolute, and Repomix will automatically handle path resolution and deduplication.
+> When using stdin input, file paths can be relative or absolute, and Repomix will automatically handle path resolution and deduplication.
 
 ### Code Compression
 

--- a/website/client/src/es/guide/command-line-options.md
+++ b/website/client/src/es/guide/command-line-options.md
@@ -24,7 +24,6 @@
 ## Opciones de Filtrado
 - `--include <patterns>`: Patrones a incluir (separados por comas)
 - `-i, --ignore <patterns>`: Patrones a ignorar (separados por comas)
-- `--stdin`: Leer rutas de archivos desde stdin en lugar de descubrir archivos automáticamente
 - `--no-gitignore`: Deshabilita el uso del archivo .gitignore
 - `--no-default-patterns`: Deshabilita los patrones predeterminados
 
@@ -78,8 +77,8 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 # Repositorio remoto con formato abreviado
 repomix --remote user/repo
 
-# Lista de archivos usando stdin
-find src -name "*.ts" -type f | repomix --stdin
-git ls-files "*.js" | repomix --stdin
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+# Lista de archivos desde stdin (detección automática)
+find src -name "*.ts" -type f | repomix
+git ls-files "*.js" | repomix
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
 ```

--- a/website/client/src/es/guide/usage.md
+++ b/website/client/src/es/guide/usage.md
@@ -38,31 +38,34 @@ repomix --remote usuario/repositorio --remote-branch main
 repomix --remote usuario/repositorio --remote-branch 935b695
 ```
 
-### Entrada de lista de archivos (stdin)
+### Entrada de lista de archivos (pipe via stdin)
 
 Pasa rutas de archivos a través de stdin para máxima flexibilidad:
 
 ```bash
 # Usando el comando find
-find src -name "*.ts" -type f | repomix --stdin
+find src -name "*.ts" -type f | repomix
 
 # Usando git para obtener archivos rastreados
-git ls-files "*.ts" | repomix --stdin
+git ls-files "*.ts" | repomix
 
 # Usando ls con patrones glob
-ls src/**/*.ts | repomix --stdin
+ls src/**/*.ts | repomix
 
 # Desde un archivo que contiene rutas de archivos
-cat file-list.txt | repomix --stdin
+cat file-list.txt | repomix
 
 # Entrada directa con echo
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
+
+# Usando el comando find con guión (indicador explícito de stdin)
+find src -name "*.ts" | repomix -
 ```
 
-La opción `--stdin` te permite canalizar una lista de rutas de archivos a Repomix, brindando máxima flexibilidad en la selección de qué archivos empaquetar.
+Repomix detecta automáticamente cuando se canalizan rutas de archivos a través de stdin, brindando máxima flexibilidad en la selección de qué archivos empaquetar.
 
 > [!NOTE]
-> Cuando uses `--stdin`, las rutas de archivos pueden ser relativas o absolutas, y Repomix manejará automáticamente la resolución de rutas y la eliminación de duplicados.
+> Cuando uses entrada de stdin, las rutas de archivos pueden ser relativas o absolutas, y Repomix manejará automáticamente la resolución de rutas y la eliminación de duplicados.
 
 ## Formatos de salida
 

--- a/website/client/src/fr/guide/command-line-options.md
+++ b/website/client/src/fr/guide/command-line-options.md
@@ -24,7 +24,6 @@
 ## Options de filtrage
 - `--include <motifs>`: Motifs d'inclusion (séparés par des virgules)
 - `-i, --ignore <motifs>`: Motifs d'exclusion (séparés par des virgules)
-- `--stdin`: Lire les chemins de fichiers depuis stdin au lieu de découvrir automatiquement les fichiers
 - `--no-gitignore`: Désactiver l'utilisation du fichier .gitignore
 - `--no-default-patterns`: Désactiver les motifs par défaut
 
@@ -78,8 +77,8 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 # Dépôt distant avec format abrégé
 repomix --remote user/repo
 
-# Liste de fichiers utilisant stdin
-find src -name "*.ts" -type f | repomix --stdin
-git ls-files "*.js" | repomix --stdin
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+# Liste de fichiers depuis stdin (détection automatique)
+find src -name "*.ts" -type f | repomix
+git ls-files "*.js" | repomix
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
 ```

--- a/website/client/src/fr/guide/usage.md
+++ b/website/client/src/fr/guide/usage.md
@@ -42,31 +42,34 @@ repomix --remote user/repo --remote-branch main
 repomix --remote user/repo --remote-branch 935b695
 ```
 
-### Entrée de liste de fichiers (stdin)
+### Entrée de liste de fichiers (pipe via stdin)
 
 Passez les chemins de fichiers via stdin pour une flexibilité ultime:
 
 ```bash
 # En utilisant la commande find
-find src -name "*.ts" -type f | repomix --stdin
+find src -name "*.ts" -type f | repomix
 
 # En utilisant git pour obtenir les fichiers suivis
-git ls-files "*.ts" | repomix --stdin
+git ls-files "*.ts" | repomix
 
 # En utilisant ls avec des motifs glob
-ls src/**/*.ts | repomix --stdin
+ls src/**/*.ts | repomix
 
 # À partir d'un fichier contenant des chemins de fichiers
-cat file-list.txt | repomix --stdin
+cat file-list.txt | repomix
 
 # Entrée directe avec echo
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
+
+# En utilisant la commande find avec tiret (indicateur stdin explicite)
+find src -name "*.ts" | repomix -
 ```
 
-L'option `--stdin` vous permet de transmettre une liste de chemins de fichiers à Repomix, offrant une flexibilité ultime dans la sélection des fichiers à empaqueter.
+Repomix détecte automatiquement lorsque les chemins de fichiers sont transmis via stdin, offrant une flexibilité ultime dans la sélection des fichiers à empaqueter.
 
 > [!NOTE]
-> Lors de l'utilisation de `--stdin`, les chemins de fichiers peuvent être relatifs ou absolus, et Repomix gèrera automatiquement la résolution des chemins et la déduplication.
+> Lors de l'utilisation d'entrée stdin, les chemins de fichiers peuvent être relatifs ou absolus, et Repomix gèrera automatiquement la résolution des chemins et la déduplication.
 
 ### Compression de code
 

--- a/website/client/src/hi/guide/command-line-options.md
+++ b/website/client/src/hi/guide/command-line-options.md
@@ -74,13 +74,15 @@ repomix --ignore <patterns>
 repomix --ignore "**/*.log,tmp/"
 ```
 
-### Stdin से फ़ाइल पथ
+### Stdin से फ़ाइल पथ (पाइप के माध्यम से)
+
+Repomix अब स्वचालित रूप से stdin से फ़ाइल पथ का पता लगाता है:
 
 ```bash
-repomix --stdin
+find src -name "*.ts" -type f | repomix
+git ls-files "*.js" | repomix
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
 ```
-
-फ़ाइलों को स्वचालित रूप से खोजने के बजाय stdin से फ़ाइल पथ पढ़ता है।
 
 ## रिमोट रिपॉजिटरी प्रोसेसिंग
 
@@ -209,12 +211,12 @@ repomix --remove-comments --compress
 
 टिप्पणियां हटाकर और कोड को संक्षिप्त करके टोकन उपयोग को कम करता है।
 
-### Stdin का उपयोग करके फ़ाइल सूची
+### Stdin का उपयोग करके फ़ाइल सूची (स्वचालित पहचान)
 
 ```bash
-find src -name "*.ts" -type f | repomix --stdin
-git ls-files "*.js" | repomix --stdin
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+find src -name "*.ts" -type f | repomix
+git ls-files "*.js" | repomix
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
 ```
 
 ## अगला क्या है?

--- a/website/client/src/hi/guide/usage.md
+++ b/website/client/src/hi/guide/usage.md
@@ -81,31 +81,31 @@ npx repomix --remote yamadashy/repomix
 npx repomix --remote https://github.com/yamadashy/repomix
 ```
 
-## फ़ाइल सूची इनपुट (stdin)
+## फ़ाइल सूची इनपुट (pipe via stdin)
 
 अधिकतम लचीलेपन के लिए stdin के माध्यम से फ़ाइल पथ पास करें:
 
 ```bash
 # find कमांड का उपयोग करके
-find src -name "*.ts" -type f | repomix --stdin
+find src -name "*.ts" -type f | repomix
 
 # git का उपयोग करके ट्रैक्ड फ़ाइलें प्राप्त करने के लिए
-git ls-files "*.ts" | repomix --stdin
+git ls-files "*.ts" | repomix
 
 # glob पैटर्न के साथ ls का उपयोग करके
-ls src/**/*.ts | repomix --stdin
+ls src/**/*.ts | repomix
 
 # फ़ाइल पथ वाली फ़ाइल से
-cat file-list.txt | repomix --stdin
+cat file-list.txt | repomix
 
 # echo के साथ प्रत्यक्ष इनपुट
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
 ```
 
-`--stdin` विकल्प आपको फ़ाइल पथों की सूची को Repomix में पाइप करने की अनुमति देता है, जो आपको पैक करने के लिए फ़ाइलों का चयन करने में अधिकतम लचीलापन प्रदान करता है।
+Repomix स्वचालित रूप से stdin के माध्यम से पाइप की गई फ़ाइल पथों का पता लगाता है, जो आपको पैक करने के लिए फ़ाइलों का चयन करने में अधिकतम लचीलापन प्रदान करता है।
 
 > [!NOTE]
-> `--stdin` का उपयोग करते समय, फ़ाइल पथ सापेक्ष या पूर्ण हो सकते हैं, और Repomix स्वचालित रूप से पथ रिज़ॉल्यूशन और डुप्लिकेशन हैंडलिंग करेगा।
+> stdin input का उपयोग करते समय, फ़ाइल पथ सापेक्ष या पूर्ण हो सकते हैं, और Repomix स्वचालित रूप से पथ रिज़ॉल्यूशन और डुप्लिकेशन हैंडलिंग करेगा।
 
 ## AI के साथ आउटपुट का उपयोग
 

--- a/website/client/src/id/guide/command-line-options.md
+++ b/website/client/src/id/guide/command-line-options.md
@@ -28,7 +28,6 @@ Repomix menyediakan berbagai opsi baris perintah untuk menyesuaikan perilakunya.
 |------|-----------|
 | `--include` | Pola glob untuk menyertakan file tertentu |
 | `--ignore` | Pola glob untuk mengabaikan file tertentu |
-| `--stdin` | Membaca jalur file dari stdin alih-alih menemukan file secara otomatis |
 | `--no-gitignore` | Mengabaikan file `.gitignore` |
 
 ## Opsi Keamanan
@@ -107,12 +106,12 @@ repomix --diffs --base-branch main
 repomix --mcp
 ```
 
-### Menggunakan stdin untuk Daftar File
+### Menggunakan Daftar File dari stdin (Deteksi Otomatis)
 
 ```bash
-find src -name "*.ts" -type f | repomix --stdin
-git ls-files "*.js" | repomix --stdin
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+find src -name "*.ts" -type f | repomix
+git ls-files "*.js" | repomix
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
 ```
 
 ## Menggunakan Opsi dengan File Konfigurasi

--- a/website/client/src/id/guide/usage.md
+++ b/website/client/src/id/guide/usage.md
@@ -53,31 +53,34 @@ npx repomix --remote https://github.com/yamadashy/repomix/tree/main
 npx repomix --remote https://github.com/yamadashy/repomix/commit/836abcd7335137228ad77feb28655d85712680f1
 ```
 
-## Input Daftar File (stdin)
+## Input Daftar File (pipe via stdin)
 
 Masukkan jalur file melalui stdin untuk fleksibilitas maksimum:
 
 ```bash
 # Menggunakan perintah find
-find src -name "*.ts" -type f | repomix --stdin
+find src -name "*.ts" -type f | repomix
 
 # Menggunakan git untuk mendapatkan file yang terlacak
-git ls-files "*.ts" | repomix --stdin
+git ls-files "*.ts" | repomix
 
 # Menggunakan ls dengan pola glob
-ls src/**/*.ts | repomix --stdin
+ls src/**/*.ts | repomix
 
 # Dari file yang berisi jalur file
-cat file-list.txt | repomix --stdin
+cat file-list.txt | repomix
 
 # Input langsung dengan echo
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
+
+# Menggunakan perintah find dengan tanda hubung (indikator stdin eksplisit)
+find src -name "*.ts" | repomix -
 ```
 
-Opsi `--stdin` memungkinkan Anda untuk mem-pipe daftar jalur file ke Repomix, memberikan fleksibilitas maksimum dalam memilih file mana yang akan dikemas.
+Repomix secara otomatis mendeteksi ketika jalur file di-pipe melalui stdin, memberikan fleksibilitas maksimum dalam memilih file mana yang akan dikemas.
 
 > [!NOTE]
-> Saat menggunakan `--stdin`, jalur file dapat berupa jalur relatif atau absolut, dan Repomix akan menangani resolusi jalur dan deduplikasi secara otomatis.
+> Saat menggunakan input stdin, jalur file dapat berupa jalur relatif atau absolut, dan Repomix akan menangani resolusi jalur dan deduplikasi secara otomatis.
 
 ## Format Output
 

--- a/website/client/src/ja/guide/command-line-options.md
+++ b/website/client/src/ja/guide/command-line-options.md
@@ -25,7 +25,6 @@
 ## フィルターオプション
 - `--include <patterns>`: 含めるパターン（カンマ区切り）
 - `-i, --ignore <patterns>`: 除外パターン（カンマ区切り）
-- `--stdin`: ファイルを自動的に検出する代わりに、stdinからファイルパスを読み取る
 - `--no-gitignore`: .gitignoreファイルの使用を無効化
 - `--no-default-patterns`: デフォルトパターンを無効化
 
@@ -79,8 +78,8 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 # ショートハンドを使用したリモートリポジトリ
 repomix --remote user/repo
 
-# stdinを使用したファイルリスト
-find src -name "*.ts" -type f | repomix --stdin
-git ls-files "*.js" | repomix --stdin
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+# stdinからのファイルリスト（自動検出）
+find src -name "*.ts" -type f | repomix
+git ls-files "*.js" | repomix
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
 ```

--- a/website/client/src/ja/guide/usage.md
+++ b/website/client/src/ja/guide/usage.md
@@ -38,31 +38,34 @@ repomix --remote user/repo --remote-branch main
 repomix --remote user/repo --remote-branch 935b695
 ```
 
-### ファイルリスト入力（stdin）
+### ファイルリスト入力（pipe via stdin）
 
 究極の柔軟性でファイルパスをstdin経由で渡します：
 
 ```bash
 # findコマンドを使用
-find src -name "*.ts" -type f | repomix --stdin
+find src -name "*.ts" -type f | repomix
 
 # gitを使用してトラッキングされているファイルを取得
-git ls-files "*.ts" | repomix --stdin
+git ls-files "*.ts" | repomix
 
 # globパターンを使用したls
-ls src/**/*.ts | repomix --stdin
+ls src/**/*.ts | repomix
 
 # ファイルパスが含まれるファイルから
-cat file-list.txt | repomix --stdin
+cat file-list.txt | repomix
 
 # echoで直接入力
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
+
+# ダッシュを使用したfindコマンド（明示的なstdin指標）
+find src -name "*.ts" | repomix -
 ```
 
-`--stdin`オプションを使用すると、Repomixにファイルパスのリストをパイプできるため、どのファイルをパッケージ化するかの選択において究極の柔軟性が得られます。
+Repomixは、ファイルパスがstdin経由でパイプされるのを自動的に検出するため、どのファイルをパッケージ化するかの選択において究極の柔軟性が得られます。
 
 > [!NOTE]
-> `--stdin`を使用する場合、ファイルパスは相対パスまたは絶対パスのどちらでも指定でき、Repomixが自動的にパス解決と重複除去を処理します。
+> stdin入力を使用する場合、ファイルパスは相対パスまたは絶対パスのどちらでも指定でき、Repomixが自動的にパス解決と重複除去を処理します。
 
 ### コード圧縮
 ```bash

--- a/website/client/src/ko/guide/command-line-options.md
+++ b/website/client/src/ko/guide/command-line-options.md
@@ -25,7 +25,6 @@
 ## 필터 옵션
 - `--include <patterns>`: 포함할 패턴 (쉼표로 구분)
 - `-i, --ignore <patterns>`: 무시할 패턴 (쉼표로 구분)
-- `--stdin`: 파일을 자동으로 검색하는 대신 stdin에서 파일 경로 읽기
 - `--no-gitignore`: .gitignore 파일 사용 비활성화
 - `--no-default-patterns`: 기본 패턴 비활성화
 
@@ -79,8 +78,8 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 # 단축형을 사용한 원격 저장소
 repomix --remote user/repo
 
-# stdin을 사용한 파일 목록
-find src -name "*.ts" -type f | repomix --stdin
-git ls-files "*.js" | repomix --stdin
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+# stdin에서 파일 목록 (자동 감지)
+find src -name "*.ts" -type f | repomix
+git ls-files "*.js" | repomix
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
 ```

--- a/website/client/src/ko/guide/usage.md
+++ b/website/client/src/ko/guide/usage.md
@@ -38,57 +38,60 @@ repomix --remote user/repo --remote-branch main
 repomix --remote user/repo --remote-branch 935b695
 ```
 
-### 파일 목록 입력 (stdin)
+### 파일 목록 입력 (pipe via stdin)
 
 최고의 유연성을 위해 stdin을 통해 파일 경로를 전달하세요:
 
 ```bash
 # find 명령 사용
-find src -name "*.ts" -type f | repomix --stdin
+find src -name "*.ts" -type f | repomix
 
 # git을 사용하여 추적된 파일 가져오기
-git ls-files "*.ts" | repomix --stdin
+git ls-files "*.ts" | repomix
 
 # glob 패턴과 함께 ls 사용
-ls src/**/*.ts | repomix --stdin
+ls src/**/*.ts | repomix
 
 # 파일 경로가 포함된 파일에서
-cat file-list.txt | repomix --stdin
+cat file-list.txt | repomix
 
 # echo로 직접 입력
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
+
+# 대시를 사용한 find 명령 (명시적 stdin 지시자)
+find src -name "*.ts" | repomix -
 ```
 
-`--stdin` 옵션을 사용하면 파일 경로 목록을 Repomix로 파이프할 수 있어 패킹할 파일 선택에 최고의 유연성을 제공합니다.
+Repomix는 파일 경로가 stdin을 통해 파이프될 때 자동으로 감지하여 패킹할 파일 선택에 최고의 유연성을 제공합니다.
 
 > [!NOTE]
-> `--stdin`을 사용할 때 파일 경로는 상대 경로 또는 절대 경로가 될 수 있으며, Repomix가 자동으로 경로 해석과 중복 제거를 처리합니다.
+> stdin 입력을 사용할 때 파일 경로는 상대 경로 또는 절대 경로가 될 수 있으며, Repomix가 자동으로 경로 해석과 중복 제거를 처리합니다.
 
-### 파일 목록 입력 (stdin)
+### 파일 목록 입력 (pipe via stdin)
 
 최대한의 유연성을 위해 stdin을 통해 파일 경로를 전달하세요:
 
 ```bash
 # find 명령어 사용
-find src -name "*.ts" -type f | repomix --stdin
+find src -name "*.ts" -type f | repomix
 
 # git을 사용하여 추적된 파일 가져오기
-git ls-files "*.ts" | repomix --stdin
+git ls-files "*.ts" | repomix
 
 # glob 패턴과 함께 ls 사용
-ls src/**/*.ts | repomix --stdin
+ls src/**/*.ts | repomix
 
 # 파일 경로가 포함된 파일에서
-cat file-list.txt | repomix --stdin
+cat file-list.txt | repomix
 
 # echo를 사용한 직접 입력
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
 ```
 
-`--stdin` 옵션을 사용하면 파일 경로 목록을 Repomix에 파이프할 수 있어 패킹할 파일을 선택하는 데 최대한의 유연성을 제공합니다.
+Repomix는 stdin을 통해 파이프된 파일 경로를 자동으로 감지하여 패킹할 파일을 선택하는 데 최대한의 유연성을 제공합니다.
 
 > [!NOTE]
-> `--stdin` 사용 시 파일 경로는 상대 경로 또는 절대 경로일 수 있으며, Repomix가 자동으로 경로 해석과 중복 제거를 처리합니다.
+> stdin 입력 사용 시 파일 경로는 상대 경로 또는 절대 경로일 수 있으며, Repomix가 자동으로 경로 해석과 중복 제거를 처리합니다.
 
 ## 출력 형식
 

--- a/website/client/src/pt-br/guide/command-line-options.md
+++ b/website/client/src/pt-br/guide/command-line-options.md
@@ -25,7 +25,6 @@
 ## Opções de Filtro
 - `--include <patterns>`: Padrões para incluir (separados por vírgula)
 - `-i, --ignore <patterns>`: Padrões para ignorar (separados por vírgula)
-- `--stdin`: Lê caminhos de arquivos do stdin em vez de descobrir arquivos automaticamente
 - `--no-gitignore`: Desabilita o uso do arquivo .gitignore
 - `--no-default-patterns`: Desabilita padrões padrão
 
@@ -79,8 +78,8 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 # Repositório remoto com formato curto
 repomix --remote user/repo
 
-# Usando stdin para lista de arquivos
-find src -name "*.ts" -type f | repomix --stdin
-git ls-files "*.js" | repomix --stdin
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+# Usando stdin para lista de arquivos (detecção automática)
+find src -name "*.ts" -type f | repomix
+git ls-files "*.js" | repomix
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
 ```

--- a/website/client/src/pt-br/guide/usage.md
+++ b/website/client/src/pt-br/guide/usage.md
@@ -38,57 +38,32 @@ repomix --remote user/repo --remote-branch main
 repomix --remote user/repo --remote-branch 935b695
 ```
 
-### Entrada de Lista de Arquivos (stdin)
+### Entrada de Lista de Arquivos (pipe via stdin)
 
 Passe caminhos de arquivos via stdin para máxima flexibilidade:
 
 ```bash
 # Usando comando find
-find src -name "*.ts" -type f | repomix --stdin
+find src -name "*.ts" -type f | repomix
 
 # Usando git para obter arquivos rastreados
-git ls-files "*.ts" | repomix --stdin
+git ls-files "*.ts" | repomix
 
 # Usando ls com padrões glob
-ls src/**/*.ts | repomix --stdin
+ls src/**/*.ts | repomix
 
 # De um arquivo contendo caminhos de arquivos
-cat file-list.txt | repomix --stdin
+cat file-list.txt | repomix
 
 # Entrada direta com echo
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
 ```
 
-A opção `--stdin` permite que você canalize uma lista de caminhos de arquivos para o Repomix, oferecendo máxima flexibilidade na seleção de quais arquivos compactar.
+
+Repomix detecta automaticamente quando caminhos de arquivos são canalizados via stdin, oferecendo máxima flexibilidade na seleção de quais arquivos compactar.
 
 > [!NOTE]
-> Ao usar `--stdin`, os caminhos de arquivos podem ser relativos ou absolutos, e o Repomix tratará automaticamente da resolução de caminhos e deduplicação.
-
-### Entrada de Lista de Arquivos (stdin)
-
-Passe caminhos de arquivos via stdin para máxima flexibilidade:
-
-```bash
-# Usando o comando find
-find src -name "*.ts" -type f | repomix --stdin
-
-# Usando git para obter arquivos rastreados
-git ls-files "*.ts" | repomix --stdin
-
-# Usando ls com padrões glob
-ls src/**/*.ts | repomix --stdin
-
-# De um arquivo contendo caminhos de arquivos
-cat file-list.txt | repomix --stdin
-
-# Entrada direta com echo
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
-```
-
-A opção `--stdin` permite canalizar uma lista de caminhos de arquivos para o Repomix, oferecendo máxima flexibilidade na seleção de quais arquivos compactar.
-
-> [!NOTE]
-> Ao usar `--stdin`, os caminhos de arquivos podem ser relativos ou absolutos, e o Repomix irá automaticamente lidar com a resolução de caminhos e desduplicação.
+> Ao usar entrada stdin, os caminhos de arquivos podem ser relativos ou absolutos, e o Repomix irá automaticamente lidar com a resolução de caminhos e desduplicação.
 
 ## Formatos de Saída
 

--- a/website/client/src/vi/guide/command-line-options.md
+++ b/website/client/src/vi/guide/command-line-options.md
@@ -17,7 +17,6 @@ Repomix cung cấp nhiều tùy chọn dòng lệnh để tùy chỉnh hành vi 
 | `--remote <url>` | Xử lý kho lưu trữ từ xa thay vì kho lưu trữ cục bộ |
 | `--include <patterns>` | Chỉ bao gồm các tệp khớp với các mẫu được cung cấp (phân tách bằng dấu phẩy) |
 | `--ignore <patterns>` | Bỏ qua các tệp khớp với các mẫu được cung cấp (phân tách bằng dấu phẩy) |
-| `--stdin` | Đọc đường dẫn tệp từ stdin thay vì tự động khám phá tệp |
 | `--no-respect-gitignore` | Không tôn trọng các tệp .gitignore |
 | `--config <path>` | Chỉ định đường dẫn đến tệp cấu hình |
 

--- a/website/client/src/vi/guide/usage.md
+++ b/website/client/src/vi/guide/usage.md
@@ -50,31 +50,31 @@ repomix --remote https://github.com/yamadashy/repomix/tree/main
 repomix --remote https://github.com/yamadashy/repomix/commit/836abcd7335137228ad77feb28655d85712680f1
 ```
 
-## Nhập danh sách tệp (stdin)
+## Nhập danh sách tệp (pipe via stdin)
 
 Truyền đường dẫn tệp qua stdin để có tính linh hoạt tối đa:
 
 ```bash
 # Sử dụng lệnh find
-find src -name "*.ts" -type f | repomix --stdin
+find src -name "*.ts" -type f | repomix
 
 # Sử dụng git để lấy các tệp được theo dõi
-git ls-files "*.ts" | repomix --stdin
+git ls-files "*.ts" | repomix
 
 # Sử dụng ls với các mẫu glob
-ls src/**/*.ts | repomix --stdin
+ls src/**/*.ts | repomix
 
 # Từ một tệp chứa đường dẫn tệp
-cat file-list.txt | repomix --stdin
+cat file-list.txt | repomix
 
 # Nhập trực tiếp với echo
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
 ```
 
-Tùy chọn `--stdin` cho phép bạn truyền danh sách đường dẫn tệp tới Repomix, mang lại tính linh hoạt tối đa trong việc chọn tệp nào để đóng gói.
+Repomix tự động phát hiện khi đường dẫn tệp được truyền qua stdin, mang lại tính linh hoạt tối đa trong việc chọn tệp nào để đóng gói.
 
 > [!NOTE]
-> Khi sử dụng `--stdin`, đường dẫn tệp có thể là tương đối hoặc tuyệt đối, và Repomix sẽ tự động xử lý việc phân giải đường dẫn và loại bỏ trùng lặp.
+> Khi sử dụng stdin input, đường dẫn tệp có thể là tương đối hoặc tuyệt đối, và Repomix sẽ tự động xử lý việc phân giải đường dẫn và loại bỏ trùng lặp.
 
 ## Tùy chọn đầu ra
 

--- a/website/client/src/zh-cn/guide/command-line-options.md
+++ b/website/client/src/zh-cn/guide/command-line-options.md
@@ -25,7 +25,6 @@
 ## 过滤选项
 - `--include <patterns>`: 包含模式（逗号分隔）
 - `-i, --ignore <patterns>`: 忽略模式（逗号分隔）
-- `--stdin`: 从 stdin 读取文件路径而不是自动发现文件
 - `--no-gitignore`: 禁用 .gitignore 文件
 - `--no-default-patterns`: 禁用默认模式
 
@@ -79,8 +78,8 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 # 使用简写的远程仓库
 repomix --remote user/repo
 
-# 使用 stdin 的文件列表
-find src -name "*.ts" -type f | repomix --stdin
-git ls-files "*.js" | repomix --stdin
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+# 从 stdin 获取文件列表（自动检测）
+find src -name "*.ts" -type f | repomix
+git ls-files "*.js" | repomix
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
 ```

--- a/website/client/src/zh-cn/guide/usage.md
+++ b/website/client/src/zh-cn/guide/usage.md
@@ -38,31 +38,31 @@ repomix --remote user/repo --remote-branch main
 repomix --remote user/repo --remote-branch 935b695
 ```
 
-### 文件列表输入（stdin）
+### 文件列表输入（pipe via stdin）
 
 通过 stdin 传递文件路径以获得终极灵活性：
 
 ```bash
 # 使用 find 命令
-find src -name "*.ts" -type f | repomix --stdin
+find src -name "*.ts" -type f | repomix
 
 # 使用 git 获取跟踪的文件
-git ls-files "*.ts" | repomix --stdin
+git ls-files "*.ts" | repomix
 
 # 使用 ls 和 glob 模式
-ls src/**/*.ts | repomix --stdin
+ls src/**/*.ts | repomix
 
 # 从包含文件路径的文件中读取
-cat file-list.txt | repomix --stdin
+cat file-list.txt | repomix
 
 # 使用 echo 直接输入
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
 ```
 
-`--stdin` 选项允许您向 Repomix 传递文件路径列表，在选择要打包的文件时提供终极灵活性。
+Repomix 自动检测通过 stdin 传递的文件路径，在选择要打包的文件时提供终极灵活性。
 
 > [!NOTE]
-> 使用 `--stdin` 时，文件路径可以是相对路径或绝对路径，Repomix 会自动处理路径解析和去重。
+> 使用 stdin 输入时，文件路径可以是相对路径或绝对路径，Repomix 会自动处理路径解析和去重。
 
 ## 输出格式
 

--- a/website/client/src/zh-tw/guide/command-line-options.md
+++ b/website/client/src/zh-tw/guide/command-line-options.md
@@ -25,7 +25,6 @@
 ## 過濾選項
 - `--include <patterns>`: 包含模式（逗號分隔）
 - `-i, --ignore <patterns>`: 忽略模式（逗號分隔）
-- `--stdin`: 從 stdin 讀取文件路徑而不是自動發現文件
 - `--no-gitignore`: 禁用 .gitignore 文件
 - `--no-default-patterns`: 禁用預設模式
 
@@ -79,8 +78,8 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 # 使用簡寫的遠端倉庫
 repomix --remote user/repo
 
-# 使用 stdin 的文件列表
-find src -name "*.ts" -type f | repomix --stdin
-git ls-files "*.js" | repomix --stdin
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+# 從 stdin 獲取文件列表（自動檢測）
+find src -name "*.ts" -type f | repomix
+git ls-files "*.js" | repomix
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
 ```

--- a/website/client/src/zh-tw/guide/usage.md
+++ b/website/client/src/zh-tw/guide/usage.md
@@ -38,31 +38,31 @@ repomix --remote user/repo --remote-branch main
 repomix --remote user/repo --remote-branch 935b695
 ```
 
-### 文件列表輸入（stdin）
+### 文件列表輸入（pipe via stdin）
 
 通過 stdin 傳遞文件路徑以獲得終極靈活性：
 
 ```bash
 # 使用 find 命令
-find src -name "*.ts" -type f | repomix --stdin
+find src -name "*.ts" -type f | repomix
 
 # 使用 git 獲取追蹤的文件
-git ls-files "*.ts" | repomix --stdin
+git ls-files "*.ts" | repomix
 
 # 使用 ls 和 glob 模式
-ls src/**/*.ts | repomix --stdin
+ls src/**/*.ts | repomix
 
 # 從包含文件路徑的文件中讀取
-cat file-list.txt | repomix --stdin
+cat file-list.txt | repomix
 
 # 使用 echo 直接輸入
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+echo -e "src/index.ts\nsrc/utils.ts" | repomix
 ```
 
-`--stdin` 選項允許您向 Repomix 傳遞文件路徑列表，在選擇要打包的文件時提供終極靈活性。
+Repomix 自動檢測通過 stdin 傳遞的文件路徑，在選擇要打包的文件時提供終極靈活性。
 
 > [!NOTE]
-> 使用 `--stdin` 時，文件路徑可以是相對路徑或絕對路徑，Repomix 會自動處理路徑解析和去重。
+> 使用 stdin 輸入時，文件路徑可以是相對路徑或絕對路徑，Repomix 會自動處理路徑解析和去重。
 
 ## 輸出格式
 


### PR DESCRIPTION
## Summary

This PR implements automatic stdin detection for Repomix, eliminating the need for the `--stdin` flag when piping input. The system now intelligently detects when file paths are provided via stdin and processes them accordingly.

- #648

### Key Changes

- **Auto-detection logic**: Uses `process.stdin.isTTY` to detect piped input
- **Unix convention support**: Supports `-` as explicit stdin indicator  
- **Removed `--stdin` option**: No longer needed with auto-detection
- **Backward compatibility**: Maintains existing stdin processing logic
- **Comprehensive testing**: Added extensive test coverage for auto-detection scenarios
- **Documentation updates**: Updated all documentation across 12+ languages

### Technical Implementation

- Added `shouldAutoDetectStdin()` function in `src/cli/actions/defaultAction.ts`
- Removed `--stdin` option from CLI definition and types
- Updated error messages to reflect new behavior
- Enhanced validation logic for stdin processing

### Breaking Changes

- Removed `--stdin` CLI option (functionality replaced by auto-detection)
- Changed CLI argument description to mention `-` for stdin

## Test Plan

- [x] All existing tests pass
- [x] New auto-detection tests added and passing
- [x] Manual testing with various stdin scenarios
- [x] Documentation updated across all languages

🤖 Generated with [Claude Code](https://claude.ai/code)