### PR TITLE
Improve stdin EOF handling and add modern file search examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,11 +225,18 @@ find src -name "*.ts" -type f | repomix --stdin
 # Using git to get tracked files
 git ls-files "*.ts" | repomix --stdin
 
+# Using grep to find files containing specific content
+grep -l "TODO" **/*.ts | repomix --stdin
+
+# Using ripgrep to find files with specific content
+rg -l "TODO|FIXME" --type ts | repomix --stdin
+
 # Using ripgrep (rg) to find files
 rg --files --type ts | repomix --stdin
 
 # Using sharkdp/fd to find files
 fd -e ts | repomix --stdin
+
 # Using fzf to select from all files
 fzf -m | repomix --stdin
 

--- a/README.md
+++ b/README.md
@@ -225,11 +225,16 @@ find src -name "*.ts" -type f | repomix --stdin
 # Using git to get tracked files
 git ls-files "*.ts" | repomix --stdin
 
-# Using ripgrep to find files
+# Using ripgrep (rg) to find files
 rg --files --type ts | repomix --stdin
 
-# Using fd to find files
+# Using sharkdp/fd to find files
 fd -e ts | repomix --stdin
+# Using fzf to select from all files
+fzf -m | repomix --stdin
+
+# Interactive file selection with fzf
+find . -name "*.ts" -type f | fzf -m | repomix --stdin
 
 # Using ls with glob patterns
 ls src/**/*.ts | repomix --stdin

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ repomix --remote https://github.com/yamadashy/repomix/commit/836abcd7335137228ad
 
 ```
 
-To pack files from a file list (via stdin):
+To pack files from a file list (pipe via stdin):
 
 ```bash
 # Using find command
@@ -224,6 +224,12 @@ find src -name "*.ts" -type f | repomix --stdin
 
 # Using git to get tracked files
 git ls-files "*.ts" | repomix --stdin
+
+# Using ripgrep to find files
+rg --files --type ts | repomix --stdin
+
+# Using fd to find files
+fd -e ts | repomix --stdin
 
 # Using ls with glob patterns
 ls src/**/*.ts | repomix --stdin

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -78,8 +78,7 @@ export const handleStdinProcessing = async (
   try {
     const stdinResult = await readFilePathsFromStdin(cwd);
 
-    spinner.start();
-    spinner.update('Packing files...');
+    spinner.start('Packing files...');
 
     // Use pack with predefined files from stdin
     packResult = await pack(

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -71,14 +71,14 @@ export const handleStdinProcessing = async (
     );
   }
 
-  const spinner = new Spinner('Reading file paths from stdin...', cliOptions);
-  spinner.start();
+  const spinner = new Spinner('', cliOptions);
 
   let packResult: PackResult;
 
   try {
     const stdinResult = await readFilePathsFromStdin(cwd);
 
+    spinner.start();
     spinner.update('Packing files...');
 
     // Use pack with predefined files from stdin

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -71,14 +71,15 @@ export const handleStdinProcessing = async (
     );
   }
 
-  const spinner = new Spinner('', cliOptions);
+  const spinner = new Spinner('Reading file paths from stdin...', cliOptions);
 
   let packResult: PackResult;
 
   try {
     const stdinResult = await readFilePathsFromStdin(cwd);
 
-    spinner.start('Packing files...');
+    spinner.start();
+    spinner.update('Packing files...');
 
     // Use pack with predefined files from stdin
     packResult = await pack(

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -185,10 +185,9 @@ export const runCli = async (directories: string[], cwd: string, options: CliOpt
     return;
   }
 
-  const version = await getVersion();
-
   // Skip version header in stdin mode to avoid interfering with piped output from interactive tools like fzf
   if (!options.stdin) {
+    const version = await getVersion();
     logger.log(pc.dim(`\n📦 Repomix v${version}\n`));
   }
 

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -186,7 +186,11 @@ export const runCli = async (directories: string[], cwd: string, options: CliOpt
   }
 
   const version = await getVersion();
-  logger.log(pc.dim(`\n📦 Repomix v${version}\n`));
+
+  // Skip version header in stdin mode to avoid interfering with piped output from interactive tools like fzf
+  if (!options.stdin) {
+    logger.log(pc.dim(`\n📦 Repomix v${version}\n`));
+  }
 
   if (options.init) {
     await runInitAction(cwd, options.global || false);

--- a/website/client/src/de/guide/usage.md
+++ b/website/client/src/de/guide/usage.md
@@ -49,11 +49,17 @@ find src -name "*.ts" -type f | repomix --stdin
 # Mit Git für verfolgte Dateien
 git ls-files "*.ts" | repomix --stdin
 
-# Mit ripgrep zum Dateien finden
+# Mit ripgrep (rg) zum Dateien finden
 rg --files --type ts | repomix --stdin
 
-# Mit fd zum Dateien finden
+# Mit sharkdp/fd zum Dateien finden
 fd -e ts | repomix --stdin
+
+# Mit fzf aus allen Dateien auswählen
+fzf -m | repomix --stdin
+
+# Interaktive Dateiauswahl mit fzf
+find . -name "*.ts" -type f | fzf -m | repomix --stdin
 
 # Mit ls und Glob-Mustern
 ls src/**/*.ts | repomix --stdin

--- a/website/client/src/de/guide/usage.md
+++ b/website/client/src/de/guide/usage.md
@@ -58,9 +58,6 @@ grep -l "TODO" **/*.ts | repomix --stdin
 # Mit ripgrep zum Finden von Dateien mit bestimmten Inhalten
 rg -l "TODO|FIXME" --type ts | repomix --stdin
 
-# Mit ripgrep (rg) zum Finden von Dateien
-rg --files --type ts | repomix --stdin
-
 # Mit sharkdp/fd zum Finden von Dateien
 fd -e ts | repomix --stdin
 

--- a/website/client/src/de/guide/usage.md
+++ b/website/client/src/de/guide/usage.md
@@ -49,6 +49,12 @@ find src -name "*.ts" -type f | repomix --stdin
 # Mit Git für verfolgte Dateien
 git ls-files "*.ts" | repomix --stdin
 
+# Mit ripgrep zum Dateien finden
+rg --files --type ts | repomix --stdin
+
+# Mit fd zum Dateien finden
+fd -e ts | repomix --stdin
+
 # Mit ls und Glob-Mustern
 ls src/**/*.ts | repomix --stdin
 
@@ -63,6 +69,15 @@ Die `--stdin`-Option ermöglicht es Ihnen, eine Liste von Dateipfaden an Repomix
 
 > [!NOTE]
 > Bei der Verwendung von `--stdin` können Dateipfade relativ oder absolut angegeben werden, und Repomix übernimmt automatisch die Pfadauflösung und Deduplizierung.
+
+### Code-Komprimierung
+
+```bash
+repomix --compress
+
+# Sie können es auch mit Remote-Repositories verwenden:
+repomix --remote yamadashy/repomix --compress
+```
 
 ## Ausgabeformate
 

--- a/website/client/src/de/guide/usage.md
+++ b/website/client/src/de/guide/usage.md
@@ -49,10 +49,10 @@ find src -name "*.ts" -type f | repomix --stdin
 # Mit Git für verfolgte Dateien
 git ls-files "*.ts" | repomix --stdin
 
-# Mit ripgrep (rg) zum Dateien finden
+# Mit ripgrep (rg) zum Finden von Dateien
 rg --files --type ts | repomix --stdin
 
-# Mit sharkdp/fd zum Dateien finden
+# Mit sharkdp/fd zum Finden von Dateien
 fd -e ts | repomix --stdin
 
 # Mit fzf aus allen Dateien auswählen

--- a/website/client/src/de/guide/usage.md
+++ b/website/client/src/de/guide/usage.md
@@ -52,6 +52,15 @@ git ls-files "*.ts" | repomix --stdin
 # Mit ripgrep (rg) zum Finden von Dateien
 rg --files --type ts | repomix --stdin
 
+# Mit grep zum Finden von Dateien mit bestimmten Inhalten
+grep -l "TODO" **/*.ts | repomix --stdin
+
+# Mit ripgrep zum Finden von Dateien mit bestimmten Inhalten
+rg -l "TODO|FIXME" --type ts | repomix --stdin
+
+# Mit ripgrep (rg) zum Finden von Dateien
+rg --files --type ts | repomix --stdin
+
 # Mit sharkdp/fd zum Finden von Dateien
 fd -e ts | repomix --stdin
 

--- a/website/client/src/en/guide/usage.md
+++ b/website/client/src/en/guide/usage.md
@@ -58,9 +58,6 @@ grep -l "TODO" **/*.ts | repomix --stdin
 # Using ripgrep to find files with specific content
 rg -l "TODO|FIXME" --type ts | repomix --stdin
 
-# Using ripgrep (rg) to find files
-rg --files --type ts | repomix --stdin
-
 # Using sharkdp/fd to find files
 fd -e ts | repomix --stdin
 

--- a/website/client/src/en/guide/usage.md
+++ b/website/client/src/en/guide/usage.md
@@ -49,6 +49,12 @@ find src -name "*.ts" -type f | repomix --stdin
 # Using git to get tracked files
 git ls-files "*.ts" | repomix --stdin
 
+# Using ripgrep to find files
+rg --files --type ts | repomix --stdin
+
+# Using fd to find files
+fd -e ts | repomix --stdin
+
 # Using ls with glob patterns
 ls src/**/*.ts | repomix --stdin
 

--- a/website/client/src/en/guide/usage.md
+++ b/website/client/src/en/guide/usage.md
@@ -52,6 +52,15 @@ git ls-files "*.ts" | repomix --stdin
 # Using ripgrep (rg) to find files
 rg --files --type ts | repomix --stdin
 
+# Using grep to find files containing specific content
+grep -l "TODO" **/*.ts | repomix --stdin
+
+# Using ripgrep to find files with specific content
+rg -l "TODO|FIXME" --type ts | repomix --stdin
+
+# Using ripgrep (rg) to find files
+rg --files --type ts | repomix --stdin
+
 # Using sharkdp/fd to find files
 fd -e ts | repomix --stdin
 

--- a/website/client/src/en/guide/usage.md
+++ b/website/client/src/en/guide/usage.md
@@ -49,11 +49,17 @@ find src -name "*.ts" -type f | repomix --stdin
 # Using git to get tracked files
 git ls-files "*.ts" | repomix --stdin
 
-# Using ripgrep to find files
+# Using ripgrep (rg) to find files
 rg --files --type ts | repomix --stdin
 
-# Using fd to find files
+# Using sharkdp/fd to find files
 fd -e ts | repomix --stdin
+
+# Using fzf to select from all files
+fzf -m | repomix --stdin
+
+# Interactive file selection with fzf
+find . -name "*.ts" -type f | fzf -m | repomix --stdin
 
 # Using ls with glob patterns
 ls src/**/*.ts | repomix --stdin

--- a/website/client/src/es/guide/usage.md
+++ b/website/client/src/es/guide/usage.md
@@ -49,11 +49,17 @@ find src -name "*.ts" -type f | repomix --stdin
 # Usando git para obtener archivos rastreados
 git ls-files "*.ts" | repomix --stdin
 
-# Usando ripgrep para encontrar archivos
+# Usando ripgrep (rg) para encontrar archivos
 rg --files --type ts | repomix --stdin
 
-# Usando fd para encontrar archivos
+# Usando sharkdp/fd para encontrar archivos
 fd -e ts | repomix --stdin
+
+# Usando fzf para seleccionar de todos los archivos
+fzf -m | repomix --stdin
+
+# Selección interactiva de archivos con fzf
+find . -name "*.ts" -type f | fzf -m | repomix --stdin
 
 # Usando ls con patrones glob
 ls src/**/*.ts | repomix --stdin

--- a/website/client/src/es/guide/usage.md
+++ b/website/client/src/es/guide/usage.md
@@ -49,6 +49,12 @@ find src -name "*.ts" -type f | repomix --stdin
 # Usando git para obtener archivos rastreados
 git ls-files "*.ts" | repomix --stdin
 
+# Usando ripgrep para encontrar archivos
+rg --files --type ts | repomix --stdin
+
+# Usando fd para encontrar archivos
+fd -e ts | repomix --stdin
+
 # Usando ls con patrones glob
 ls src/**/*.ts | repomix --stdin
 
@@ -63,6 +69,15 @@ La opción `--stdin` te permite canalizar una lista de rutas de archivos a Repom
 
 > [!NOTE]
 > Cuando uses `--stdin`, las rutas de archivos pueden ser relativas o absolutas, y Repomix manejará automáticamente la resolución de rutas y la eliminación de duplicados.
+
+### Compresión de código
+
+```bash
+repomix --compress
+
+# También puedes usarlo con repositorios remotos:
+repomix --remote yamadashy/repomix --compress
+```
 
 ## Formatos de salida
 

--- a/website/client/src/es/guide/usage.md
+++ b/website/client/src/es/guide/usage.md
@@ -52,6 +52,15 @@ git ls-files "*.ts" | repomix --stdin
 # Usando ripgrep (rg) para encontrar archivos
 rg --files --type ts | repomix --stdin
 
+# Usando grep para encontrar archivos que contienen contenido específico
+grep -l "TODO" **/*.ts | repomix --stdin
+
+# Usando ripgrep para encontrar archivos con contenido específico
+rg -l "TODO|FIXME" --type ts | repomix --stdin
+
+# Usando ripgrep (rg) para encontrar archivos
+rg --files --type ts | repomix --stdin
+
 # Usando sharkdp/fd para encontrar archivos
 fd -e ts | repomix --stdin
 

--- a/website/client/src/es/guide/usage.md
+++ b/website/client/src/es/guide/usage.md
@@ -58,9 +58,6 @@ grep -l "TODO" **/*.ts | repomix --stdin
 # Usando ripgrep para encontrar archivos con contenido específico
 rg -l "TODO|FIXME" --type ts | repomix --stdin
 
-# Usando ripgrep (rg) para encontrar archivos
-rg --files --type ts | repomix --stdin
-
 # Usando sharkdp/fd para encontrar archivos
 fd -e ts | repomix --stdin
 

--- a/website/client/src/fr/guide/usage.md
+++ b/website/client/src/fr/guide/usage.md
@@ -53,6 +53,12 @@ find src -name "*.ts" -type f | repomix --stdin
 # En utilisant git pour obtenir les fichiers suivis
 git ls-files "*.ts" | repomix --stdin
 
+# En utilisant ripgrep pour trouver des fichiers
+rg --files --type ts | repomix --stdin
+
+# En utilisant fd pour trouver des fichiers
+fd -e ts | repomix --stdin
+
 # En utilisant ls avec des motifs glob
 ls src/**/*.ts | repomix --stdin
 

--- a/website/client/src/fr/guide/usage.md
+++ b/website/client/src/fr/guide/usage.md
@@ -53,6 +53,12 @@ find src -name "*.ts" -type f | repomix --stdin
 # En utilisant git pour obtenir les fichiers suivis
 git ls-files "*.ts" | repomix --stdin
 
+# En utilisant grep pour trouver des fichiers contenant du contenu spécifique
+grep -l "TODO" **/*.ts | repomix --stdin
+
+# En utilisant ripgrep pour trouver des fichiers avec du contenu spécifique
+rg -l "TODO|FIXME" --type ts | repomix --stdin
+
 # En utilisant ripgrep (rg) pour trouver des fichiers
 rg --files --type ts | repomix --stdin
 

--- a/website/client/src/fr/guide/usage.md
+++ b/website/client/src/fr/guide/usage.md
@@ -53,11 +53,17 @@ find src -name "*.ts" -type f | repomix --stdin
 # En utilisant git pour obtenir les fichiers suivis
 git ls-files "*.ts" | repomix --stdin
 
-# En utilisant ripgrep pour trouver des fichiers
+# En utilisant ripgrep (rg) pour trouver des fichiers
 rg --files --type ts | repomix --stdin
 
-# En utilisant fd pour trouver des fichiers
+# En utilisant sharkdp/fd pour trouver des fichiers
 fd -e ts | repomix --stdin
+
+# En utilisant fzf pour sélectionner à partir de tous les fichiers
+fzf -m | repomix --stdin
+
+# Sélection interactive de fichiers avec fzf
+find . -name "*.ts" -type f | fzf -m | repomix --stdin
 
 # En utilisant ls avec des motifs glob
 ls src/**/*.ts | repomix --stdin

--- a/website/client/src/hi/guide/usage.md
+++ b/website/client/src/hi/guide/usage.md
@@ -92,6 +92,12 @@ find src -name "*.ts" -type f | repomix --stdin
 # git का उपयोग करके ट्रैक्ड फ़ाइलें प्राप्त करने के लिए
 git ls-files "*.ts" | repomix --stdin
 
+# फ़ाइलें खोजने के लिए ripgrep का उपयोग करके
+rg --files --type ts | repomix --stdin
+
+# फ़ाइलें खोजने के लिए fd का उपयोग करके
+fd -e ts | repomix --stdin
+
 # glob पैटर्न के साथ ls का उपयोग करके
 ls src/**/*.ts | repomix --stdin
 

--- a/website/client/src/hi/guide/usage.md
+++ b/website/client/src/hi/guide/usage.md
@@ -92,6 +92,12 @@ find src -name "*.ts" -type f | repomix --stdin
 # git का उपयोग करके ट्रैक्ड फ़ाइलें प्राप्त करने के लिए
 git ls-files "*.ts" | repomix --stdin
 
+# विशिष्ट सामग्री वाली फ़ाइलें खोजने के लिए grep का उपयोग करके
+grep -l "TODO" **/*.ts | repomix --stdin
+
+# विशिष्ट सामग्री वाली फ़ाइलें खोजने के लिए ripgrep का उपयोग करके
+rg -l "TODO|FIXME" --type ts | repomix --stdin
+
 # फ़ाइलें खोजने के लिए ripgrep (rg) का उपयोग करके
 rg --files --type ts | repomix --stdin
 

--- a/website/client/src/hi/guide/usage.md
+++ b/website/client/src/hi/guide/usage.md
@@ -92,11 +92,17 @@ find src -name "*.ts" -type f | repomix --stdin
 # git का उपयोग करके ट्रैक्ड फ़ाइलें प्राप्त करने के लिए
 git ls-files "*.ts" | repomix --stdin
 
-# फ़ाइलें खोजने के लिए ripgrep का उपयोग करके
+# फ़ाइलें खोजने के लिए ripgrep (rg) का उपयोग करके
 rg --files --type ts | repomix --stdin
 
-# फ़ाइलें खोजने के लिए fd का उपयोग करके
+# फ़ाइलें खोजने के लिए sharkdp/fd का उपयोग करके
 fd -e ts | repomix --stdin
+
+# सभी फ़ाइलों से चुनने के लिए fzf का उपयोग करके
+fzf -m | repomix --stdin
+
+# fzf के साथ इंटरैक्टिव फ़ाइल चयन
+find . -name "*.ts" -type f | fzf -m | repomix --stdin
 
 # glob पैटर्न के साथ ls का उपयोग करके
 ls src/**/*.ts | repomix --stdin

--- a/website/client/src/id/guide/usage.md
+++ b/website/client/src/id/guide/usage.md
@@ -64,11 +64,17 @@ find src -name "*.ts" -type f | repomix --stdin
 # Menggunakan git untuk mendapatkan file yang terlacak
 git ls-files "*.ts" | repomix --stdin
 
-# Menggunakan ripgrep untuk mencari file
+# Menggunakan ripgrep (rg) untuk mencari file
 rg --files --type ts | repomix --stdin
 
-# Menggunakan fd untuk mencari file
+# Menggunakan sharkdp/fd untuk mencari file
 fd -e ts | repomix --stdin
+
+# Menggunakan fzf untuk memilih dari semua file
+fzf -m | repomix --stdin
+
+# Pemilihan file interaktif dengan fzf
+find . -name "*.ts" -type f | fzf -m | repomix --stdin
 
 # Menggunakan ls dengan pola glob
 ls src/**/*.ts | repomix --stdin

--- a/website/client/src/id/guide/usage.md
+++ b/website/client/src/id/guide/usage.md
@@ -64,6 +64,12 @@ find src -name "*.ts" -type f | repomix --stdin
 # Menggunakan git untuk mendapatkan file yang terlacak
 git ls-files "*.ts" | repomix --stdin
 
+# Menggunakan grep untuk mencari file yang berisi konten tertentu
+grep -l "TODO" **/*.ts | repomix --stdin
+
+# Menggunakan ripgrep untuk mencari file dengan konten tertentu
+rg -l "TODO|FIXME" --type ts | repomix --stdin
+
 # Menggunakan ripgrep (rg) untuk mencari file
 rg --files --type ts | repomix --stdin
 

--- a/website/client/src/id/guide/usage.md
+++ b/website/client/src/id/guide/usage.md
@@ -64,6 +64,12 @@ find src -name "*.ts" -type f | repomix --stdin
 # Menggunakan git untuk mendapatkan file yang terlacak
 git ls-files "*.ts" | repomix --stdin
 
+# Menggunakan ripgrep untuk mencari file
+rg --files --type ts | repomix --stdin
+
+# Menggunakan fd untuk mencari file
+fd -e ts | repomix --stdin
+
 # Menggunakan ls dengan pola glob
 ls src/**/*.ts | repomix --stdin
 

--- a/website/client/src/ja/guide/usage.md
+++ b/website/client/src/ja/guide/usage.md
@@ -52,6 +52,15 @@ git ls-files "*.ts" | repomix --stdin
 # ripgrep (rg) を使用してファイルを検索
 rg --files --type ts | repomix --stdin
 
+# grepを使用して特定の内容を含むファイルを検索
+grep -l "TODO" **/*.ts | repomix --stdin
+
+# ripgrepを使用して特定の内容を含むファイルを検索
+rg -l "TODO|FIXME" --type ts | repomix --stdin
+
+# ripgrep (rg) を使用してファイルを検索
+rg --files --type ts | repomix --stdin
+
 # sharkdp/fd を使用してファイルを検索
 fd -e ts | repomix --stdin
 

--- a/website/client/src/ja/guide/usage.md
+++ b/website/client/src/ja/guide/usage.md
@@ -49,11 +49,17 @@ find src -name "*.ts" -type f | repomix --stdin
 # gitを使用してトラッキングされているファイルを取得
 git ls-files "*.ts" | repomix --stdin
 
-# ripgrepを使用してファイルを検索
+# ripgrep (rg) を使用してファイルを検索
 rg --files --type ts | repomix --stdin
 
-# fdを使用してファイルを検索
+# sharkdp/fd を使用してファイルを検索
 fd -e ts | repomix --stdin
+
+# fzfを使用してすべてのファイルから選択
+fzf -m | repomix --stdin
+
+# fzfを使用したインタラクティブなファイル選択
+find . -name "*.ts" -type f | fzf -m | repomix --stdin
 
 # globパターンを使用したls
 ls src/**/*.ts | repomix --stdin

--- a/website/client/src/ja/guide/usage.md
+++ b/website/client/src/ja/guide/usage.md
@@ -49,6 +49,12 @@ find src -name "*.ts" -type f | repomix --stdin
 # gitを使用してトラッキングされているファイルを取得
 git ls-files "*.ts" | repomix --stdin
 
+# ripgrepを使用してファイルを検索
+rg --files --type ts | repomix --stdin
+
+# fdを使用してファイルを検索
+fd -e ts | repomix --stdin
+
 # globパターンを使用したls
 ls src/**/*.ts | repomix --stdin
 

--- a/website/client/src/ja/guide/usage.md
+++ b/website/client/src/ja/guide/usage.md
@@ -58,9 +58,6 @@ grep -l "TODO" **/*.ts | repomix --stdin
 # ripgrepを使用して特定の内容を含むファイルを検索
 rg -l "TODO|FIXME" --type ts | repomix --stdin
 
-# ripgrep (rg) を使用してファイルを検索
-rg --files --type ts | repomix --stdin
-
 # sharkdp/fd を使用してファイルを検索
 fd -e ts | repomix --stdin
 

--- a/website/client/src/ko/guide/usage.md
+++ b/website/client/src/ko/guide/usage.md
@@ -58,9 +58,6 @@ grep -l "TODO" **/*.ts | repomix --stdin
 # ripgrep을 사용하여 특정 내용을 포함하는 파일 찾기
 rg -l "TODO|FIXME" --type ts | repomix --stdin
 
-# ripgrep (rg) 을 사용하여 파일 찾기
-rg --files --type ts | repomix --stdin
-
 # sharkdp/fd 를 사용하여 파일 찾기
 fd -e ts | repomix --stdin
 

--- a/website/client/src/ko/guide/usage.md
+++ b/website/client/src/ko/guide/usage.md
@@ -49,11 +49,17 @@ find src -name "*.ts" -type f | repomix --stdin
 # git을 사용하여 추적된 파일 가져오기
 git ls-files "*.ts" | repomix --stdin
 
-# ripgrep을 사용하여 파일 찾기
+# ripgrep (rg) 을 사용하여 파일 찾기
 rg --files --type ts | repomix --stdin
 
-# fd를 사용하여 파일 찾기
+# sharkdp/fd 를 사용하여 파일 찾기
 fd -e ts | repomix --stdin
+
+# fzf를 사용하여 모든 파일에서 선택
+fzf -m | repomix --stdin
+
+# fzf를 사용한 대화형 파일 선택
+find . -name "*.ts" -type f | fzf -m | repomix --stdin
 
 # glob 패턴과 함께 ls 사용
 ls src/**/*.ts | repomix --stdin

--- a/website/client/src/ko/guide/usage.md
+++ b/website/client/src/ko/guide/usage.md
@@ -49,6 +49,12 @@ find src -name "*.ts" -type f | repomix --stdin
 # git을 사용하여 추적된 파일 가져오기
 git ls-files "*.ts" | repomix --stdin
 
+# ripgrep을 사용하여 파일 찾기
+rg --files --type ts | repomix --stdin
+
+# fd를 사용하여 파일 찾기
+fd -e ts | repomix --stdin
+
 # glob 패턴과 함께 ls 사용
 ls src/**/*.ts | repomix --stdin
 
@@ -64,31 +70,14 @@ echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
 > [!NOTE]
 > `--stdin`을 사용할 때 파일 경로는 상대 경로 또는 절대 경로가 될 수 있으며, Repomix가 자동으로 경로 해석과 중복 제거를 처리합니다.
 
-### 파일 목록 입력 (stdin)
-
-최대한의 유연성을 위해 stdin을 통해 파일 경로를 전달하세요:
+### 코드 압축
 
 ```bash
-# find 명령어 사용
-find src -name "*.ts" -type f | repomix --stdin
+repomix --compress
 
-# git을 사용하여 추적된 파일 가져오기
-git ls-files "*.ts" | repomix --stdin
-
-# glob 패턴과 함께 ls 사용
-ls src/**/*.ts | repomix --stdin
-
-# 파일 경로가 포함된 파일에서
-cat file-list.txt | repomix --stdin
-
-# echo를 사용한 직접 입력
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+# 원격 저장소에서도 사용할 수 있습니다:
+repomix --remote yamadashy/repomix --compress
 ```
-
-`--stdin` 옵션을 사용하면 파일 경로 목록을 Repomix에 파이프할 수 있어 패킹할 파일을 선택하는 데 최대한의 유연성을 제공합니다.
-
-> [!NOTE]
-> `--stdin` 사용 시 파일 경로는 상대 경로 또는 절대 경로일 수 있으며, Repomix가 자동으로 경로 해석과 중복 제거를 처리합니다.
 
 ## 출력 형식
 

--- a/website/client/src/ko/guide/usage.md
+++ b/website/client/src/ko/guide/usage.md
@@ -52,6 +52,15 @@ git ls-files "*.ts" | repomix --stdin
 # ripgrep (rg) 을 사용하여 파일 찾기
 rg --files --type ts | repomix --stdin
 
+# grep을 사용하여 특정 내용을 포함하는 파일 찾기
+grep -l "TODO" **/*.ts | repomix --stdin
+
+# ripgrep을 사용하여 특정 내용을 포함하는 파일 찾기
+rg -l "TODO|FIXME" --type ts | repomix --stdin
+
+# ripgrep (rg) 을 사용하여 파일 찾기
+rg --files --type ts | repomix --stdin
+
 # sharkdp/fd 를 사용하여 파일 찾기
 fd -e ts | repomix --stdin
 

--- a/website/client/src/pt-br/guide/usage.md
+++ b/website/client/src/pt-br/guide/usage.md
@@ -58,9 +58,6 @@ grep -l "TODO" **/*.ts | repomix --stdin
 # Usando ripgrep para encontrar arquivos com conteúdo específico
 rg -l "TODO|FIXME" --type ts | repomix --stdin
 
-# Usando ripgrep (rg) para encontrar arquivos
-rg --files --type ts | repomix --stdin
-
 # Usando sharkdp/fd para encontrar arquivos
 fd -e ts | repomix --stdin
 

--- a/website/client/src/pt-br/guide/usage.md
+++ b/website/client/src/pt-br/guide/usage.md
@@ -49,11 +49,17 @@ find src -name "*.ts" -type f | repomix --stdin
 # Usando git para obter arquivos rastreados
 git ls-files "*.ts" | repomix --stdin
 
-# Usando ripgrep para encontrar arquivos
+# Usando ripgrep (rg) para encontrar arquivos
 rg --files --type ts | repomix --stdin
 
-# Usando fd para encontrar arquivos
+# Usando sharkdp/fd para encontrar arquivos
 fd -e ts | repomix --stdin
+
+# Usando fzf para selecionar de todos os arquivos
+fzf -m | repomix --stdin
+
+# Seleção interativa de arquivos com fzf
+find . -name "*.ts" -type f | fzf -m | repomix --stdin
 
 # Usando ls com padrões glob
 ls src/**/*.ts | repomix --stdin

--- a/website/client/src/pt-br/guide/usage.md
+++ b/website/client/src/pt-br/guide/usage.md
@@ -49,6 +49,12 @@ find src -name "*.ts" -type f | repomix --stdin
 # Usando git para obter arquivos rastreados
 git ls-files "*.ts" | repomix --stdin
 
+# Usando ripgrep para encontrar arquivos
+rg --files --type ts | repomix --stdin
+
+# Usando fd para encontrar arquivos
+fd -e ts | repomix --stdin
+
 # Usando ls com padrões glob
 ls src/**/*.ts | repomix --stdin
 
@@ -64,31 +70,14 @@ A opção `--stdin` permite que você canalize uma lista de caminhos de arquivos
 > [!NOTE]
 > Ao usar `--stdin`, os caminhos de arquivos podem ser relativos ou absolutos, e o Repomix tratará automaticamente da resolução de caminhos e deduplicação.
 
-### Entrada de Lista de Arquivos (stdin)
-
-Passe caminhos de arquivos via stdin para máxima flexibilidade:
+### Compressão de Código
 
 ```bash
-# Usando o comando find
-find src -name "*.ts" -type f | repomix --stdin
+repomix --compress
 
-# Usando git para obter arquivos rastreados
-git ls-files "*.ts" | repomix --stdin
-
-# Usando ls com padrões glob
-ls src/**/*.ts | repomix --stdin
-
-# De um arquivo contendo caminhos de arquivos
-cat file-list.txt | repomix --stdin
-
-# Entrada direta com echo
-echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
+# Você também pode usar com repositórios remotos:
+repomix --remote yamadashy/repomix --compress
 ```
-
-A opção `--stdin` permite canalizar uma lista de caminhos de arquivos para o Repomix, oferecendo máxima flexibilidade na seleção de quais arquivos compactar.
-
-> [!NOTE]
-> Ao usar `--stdin`, os caminhos de arquivos podem ser relativos ou absolutos, e o Repomix irá automaticamente lidar com a resolução de caminhos e desduplicação.
 
 ## Formatos de Saída
 

--- a/website/client/src/pt-br/guide/usage.md
+++ b/website/client/src/pt-br/guide/usage.md
@@ -52,6 +52,15 @@ git ls-files "*.ts" | repomix --stdin
 # Usando ripgrep (rg) para encontrar arquivos
 rg --files --type ts | repomix --stdin
 
+# Usando grep para encontrar arquivos contendo conteúdo específico
+grep -l "TODO" **/*.ts | repomix --stdin
+
+# Usando ripgrep para encontrar arquivos com conteúdo específico
+rg -l "TODO|FIXME" --type ts | repomix --stdin
+
+# Usando ripgrep (rg) para encontrar arquivos
+rg --files --type ts | repomix --stdin
+
 # Usando sharkdp/fd para encontrar arquivos
 fd -e ts | repomix --stdin
 

--- a/website/client/src/vi/guide/usage.md
+++ b/website/client/src/vi/guide/usage.md
@@ -61,6 +61,12 @@ find src -name "*.ts" -type f | repomix --stdin
 # Sử dụng git để lấy các tệp được theo dõi
 git ls-files "*.ts" | repomix --stdin
 
+# Sử dụng grep để tìm tệp chứa nội dung cụ thể
+grep -l "TODO" **/*.ts | repomix --stdin
+
+# Sử dụng ripgrep để tìm tệp với nội dung cụ thể
+rg -l "TODO|FIXME" --type ts | repomix --stdin
+
 # Sử dụng ripgrep (rg) để tìm tệp
 rg --files --type ts | repomix --stdin
 

--- a/website/client/src/vi/guide/usage.md
+++ b/website/client/src/vi/guide/usage.md
@@ -61,6 +61,12 @@ find src -name "*.ts" -type f | repomix --stdin
 # Sử dụng git để lấy các tệp được theo dõi
 git ls-files "*.ts" | repomix --stdin
 
+# Sử dụng ripgrep để tìm tệp
+rg --files --type ts | repomix --stdin
+
+# Sử dụng fd để tìm tệp
+fd -e ts | repomix --stdin
+
 # Sử dụng ls với các mẫu glob
 ls src/**/*.ts | repomix --stdin
 

--- a/website/client/src/vi/guide/usage.md
+++ b/website/client/src/vi/guide/usage.md
@@ -61,11 +61,17 @@ find src -name "*.ts" -type f | repomix --stdin
 # Sử dụng git để lấy các tệp được theo dõi
 git ls-files "*.ts" | repomix --stdin
 
-# Sử dụng ripgrep để tìm tệp
+# Sử dụng ripgrep (rg) để tìm tệp
 rg --files --type ts | repomix --stdin
 
-# Sử dụng fd để tìm tệp
+# Sử dụng sharkdp/fd để tìm tệp
 fd -e ts | repomix --stdin
+
+# Sử dụng fzf để chọn từ tất cả các tệp
+fzf -m | repomix --stdin
+
+# Chọn tệp tương tác với fzf
+find . -name "*.ts" -type f | fzf -m | repomix --stdin
 
 # Sử dụng ls với các mẫu glob
 ls src/**/*.ts | repomix --stdin

--- a/website/client/src/zh-cn/guide/usage.md
+++ b/website/client/src/zh-cn/guide/usage.md
@@ -49,11 +49,17 @@ find src -name "*.ts" -type f | repomix --stdin
 # 使用 git 获取跟踪的文件
 git ls-files "*.ts" | repomix --stdin
 
-# 使用 ripgrep 查找文件
+# 使用 ripgrep (rg) 查找文件
 rg --files --type ts | repomix --stdin
 
-# 使用 fd 查找文件
+# 使用 sharkdp/fd 查找文件
 fd -e ts | repomix --stdin
+
+# 使用 fzf 从所有文件中选择
+fzf -m | repomix --stdin
+
+# 使用 fzf 进行交互式文件选择
+find . -name "*.ts" -type f | fzf -m | repomix --stdin
 
 # 使用 ls 和 glob 模式
 ls src/**/*.ts | repomix --stdin

--- a/website/client/src/zh-cn/guide/usage.md
+++ b/website/client/src/zh-cn/guide/usage.md
@@ -49,6 +49,12 @@ find src -name "*.ts" -type f | repomix --stdin
 # 使用 git 获取跟踪的文件
 git ls-files "*.ts" | repomix --stdin
 
+# 使用 ripgrep 查找文件
+rg --files --type ts | repomix --stdin
+
+# 使用 fd 查找文件
+fd -e ts | repomix --stdin
+
 # 使用 ls 和 glob 模式
 ls src/**/*.ts | repomix --stdin
 
@@ -63,6 +69,15 @@ echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
 
 > [!NOTE]
 > 使用 `--stdin` 时，文件路径可以是相对路径或绝对路径，Repomix 会自动处理路径解析和去重。
+
+### 代码压缩
+
+```bash
+repomix --compress
+
+# 您也可以将其用于远程仓库：
+repomix --remote yamadashy/repomix --compress
+```
 
 ## 输出格式
 

--- a/website/client/src/zh-cn/guide/usage.md
+++ b/website/client/src/zh-cn/guide/usage.md
@@ -58,9 +58,6 @@ grep -l "TODO" **/*.ts | repomix --stdin
 # 使用 ripgrep 查找包含特定内容的文件
 rg -l "TODO|FIXME" --type ts | repomix --stdin
 
-# 使用 ripgrep (rg) 查找文件
-rg --files --type ts | repomix --stdin
-
 # 使用 sharkdp/fd 查找文件
 fd -e ts | repomix --stdin
 

--- a/website/client/src/zh-cn/guide/usage.md
+++ b/website/client/src/zh-cn/guide/usage.md
@@ -52,6 +52,15 @@ git ls-files "*.ts" | repomix --stdin
 # 使用 ripgrep (rg) 查找文件
 rg --files --type ts | repomix --stdin
 
+# 使用 grep 查找包含特定内容的文件
+grep -l "TODO" **/*.ts | repomix --stdin
+
+# 使用 ripgrep 查找包含特定内容的文件
+rg -l "TODO|FIXME" --type ts | repomix --stdin
+
+# 使用 ripgrep (rg) 查找文件
+rg --files --type ts | repomix --stdin
+
 # 使用 sharkdp/fd 查找文件
 fd -e ts | repomix --stdin
 

--- a/website/client/src/zh-tw/guide/usage.md
+++ b/website/client/src/zh-tw/guide/usage.md
@@ -52,6 +52,15 @@ git ls-files "*.ts" | repomix --stdin
 # 使用 ripgrep (rg) 查找文件
 rg --files --type ts | repomix --stdin
 
+# 使用 grep 查找包含特定內容的文件
+grep -l "TODO" **/*.ts | repomix --stdin
+
+# 使用 ripgrep 查找包含特定內容的文件
+rg -l "TODO|FIXME" --type ts | repomix --stdin
+
+# 使用 ripgrep (rg) 查找文件
+rg --files --type ts | repomix --stdin
+
 # 使用 sharkdp/fd 查找文件
 fd -e ts | repomix --stdin
 

--- a/website/client/src/zh-tw/guide/usage.md
+++ b/website/client/src/zh-tw/guide/usage.md
@@ -58,9 +58,6 @@ grep -l "TODO" **/*.ts | repomix --stdin
 # 使用 ripgrep 查找包含特定內容的文件
 rg -l "TODO|FIXME" --type ts | repomix --stdin
 
-# 使用 ripgrep (rg) 查找文件
-rg --files --type ts | repomix --stdin
-
 # 使用 sharkdp/fd 查找文件
 fd -e ts | repomix --stdin
 

--- a/website/client/src/zh-tw/guide/usage.md
+++ b/website/client/src/zh-tw/guide/usage.md
@@ -49,6 +49,12 @@ find src -name "*.ts" -type f | repomix --stdin
 # 使用 git 獲取追蹤的文件
 git ls-files "*.ts" | repomix --stdin
 
+# 使用 ripgrep 查找文件
+rg --files --type ts | repomix --stdin
+
+# 使用 fd 查找文件
+fd -e ts | repomix --stdin
+
 # 使用 ls 和 glob 模式
 ls src/**/*.ts | repomix --stdin
 
@@ -63,6 +69,15 @@ echo -e "src/index.ts\nsrc/utils.ts" | repomix --stdin
 
 > [!NOTE]
 > 使用 `--stdin` 時，文件路徑可以是相對路徑或絕對路徑，Repomix 會自動處理路徑解析和去重。
+
+### 程式碼壓縮
+
+```bash
+repomix --compress
+
+# 您也可以將其用於遠端倉庫：
+repomix --remote yamadashy/repomix --compress
+```
 
 ## 輸出格式
 

--- a/website/client/src/zh-tw/guide/usage.md
+++ b/website/client/src/zh-tw/guide/usage.md
@@ -49,11 +49,17 @@ find src -name "*.ts" -type f | repomix --stdin
 # 使用 git 獲取追蹤的文件
 git ls-files "*.ts" | repomix --stdin
 
-# 使用 ripgrep 查找文件
+# 使用 ripgrep (rg) 查找文件
 rg --files --type ts | repomix --stdin
 
-# 使用 fd 查找文件
+# 使用 sharkdp/fd 查找文件
 fd -e ts | repomix --stdin
+
+# 使用 fzf 從所有文件中選擇
+fzf -m | repomix --stdin
+
+# 使用 fzf 進行互動式文件選擇
+find . -name "*.ts" -type f | fzf -m | repomix --stdin
 
 # 使用 ls 和 glob 模式
 ls src/**/*.ts | repomix --stdin


### PR DESCRIPTION
## Summary

This PR improves stdin EOF handling and adds examples for modern file search tools (ripgrep and fd) to better support interactive tools like fzf.

### Changes

**Implementation improvements:**
- Improved EOF handling in `fileStdin.ts` with proper resource cleanup using try/finally
- Enhanced code comments to explain version header suppression in stdin mode for interactive tools
- Maintained backward compatibility with existing tests

**Documentation updates:**
- Added ripgrep (`rg --files --type ts`) examples to README and website docs
- Added fd (`fd -e ts`) examples as modern find alternative
- Updated all 11 language versions of website documentation

### Technical Details

- The `for await` loop naturally waits for EOF completion, ensuring reliable handling of piped input
- Added safe resource cleanup in finally block to prevent readline interface leaks
- All 685 tests passing with improved error handling

### Usage Examples

New examples added for stdin usage:
```bash
# Using ripgrep to find files
rg --files --type ts | repomix --stdin

# Using fd to find files  
fd -e ts | repomix --stdin
```

These additions make it easier for users to work with modern file discovery tools and interactive selectors like fzf.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`