### PR TITLE
refactor: remove cli-spinners dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@modelcontextprotocol/sdk": "^1.11.0",
         "@secretlint/core": "^9.3.1",
         "@secretlint/secretlint-rule-preset-recommend": "^9.3.1",
-        "cli-spinners": "^2.9.2",
         "clipboardy": "^4.0.0",
         "commander": "^14.0.0",
         "fast-xml-parser": "^5.2.0",
@@ -2111,18 +2110,6 @@
       },
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@modelcontextprotocol/sdk": "^1.11.0",
     "@secretlint/core": "^9.3.1",
     "@secretlint/secretlint-rule-preset-recommend": "^9.3.1",
-    "cli-spinners": "^2.9.2",
     "clipboardy": "^4.0.0",
     "commander": "^14.0.0",
     "fast-xml-parser": "^5.2.0",

--- a/src/cli/cliSpinner.ts
+++ b/src/cli/cliSpinner.ts
@@ -1,10 +1,12 @@
-import cliSpinners from 'cli-spinners';
 import logUpdate from 'log-update';
 import pc from 'picocolors';
 import type { CliOptions } from './types.js';
 
+// Replicate cli-spinners dots animation
+const dotsFrames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+const dotsInterval = 80;
+
 export class Spinner {
-  private spinner = cliSpinners.dots;
   private message: string;
   private currentFrame = 0;
   private interval: ReturnType<typeof setInterval> | null = null;
@@ -21,13 +23,12 @@ export class Spinner {
       return;
     }
 
-    const frames = this.spinner.frames;
-    const framesLength = frames.length;
+    const framesLength = dotsFrames.length;
     this.interval = setInterval(() => {
       this.currentFrame++;
-      const frame = frames[this.currentFrame % framesLength];
+      const frame = dotsFrames[this.currentFrame % framesLength];
       logUpdate(`${pc.cyan(frame)} ${this.message}`);
-    }, this.spinner.interval);
+    }, dotsInterval);
   }
 
   update(message: string): void {


### PR DESCRIPTION
Remove cli-spinners dependency to reduce bundle size by embedding the animation frames directly in the code.

## Summary

- Remove `cli-spinners` dependency 
- Embed dots animation frames directly in the code
- Keep the exact same spinner behavior and appearance
- No changes to the public API

## Changes

- **package.json**: Removed `cli-spinners` dependency
- **src/cli/cliSpinner.ts**: Added dots animation frames as a constant array
- The spinner still shows the same 10-frame braille pattern animation: `⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`

## Benefits

- Reduced dependencies (one less package to maintain)
- Smaller bundle size
- Same visual behavior as before
- No breaking changes

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.ai/code)