### PR TITLE
chore(config): consolidate AI assistant rules configuration

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -1,3 +1,0 @@
-# Important
-- Follow all AI instructions in the `.github/instructions/` directory
-- The base instructions are located in `.github/instructions/base.instructions.md`

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-Please make sure to check the rules written in `.agents/rules/base.md` as they contain important project-specific guidelines and instructions.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../.agents/rules/base.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,1 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-# Rules
-**IMPORTANT**
-Before starting any work, you MUST first read and understand the rules in `.agents/rules/base.md`.
-These rules contain critical project-specific guidelines and instructions that must be followed for all work in this repository.
-Do NOT proceed with any work without reading these rules first.
+.agents/rules/base.md


### PR DESCRIPTION
Consolidate AI assistant rules configuration by centralizing all rules in `.agents/rules/base.md` and removing legacy rule files.

## Changes

- **Removed legacy rule files**: Deleted `.clinerules` and `.cursorrules` files that contained outdated or redundant configurations
- **Updated CLAUDE.md**: Converted from a regular file to a symlink pointing to `.agents/rules/base.md` for centralized rule management
- **Added GitHub Copilot integration**: Created `.github/copilot-instructions.md` as a symlink to the centralized rules file

This change improves maintainability by having a single source of truth for AI assistant rules while ensuring compatibility with different AI tools (Claude Code, GitHub Copilot, Cursor, etc.).

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`