### PR TITLE
refactor(core): remove unused calculateAllFileMetrics function and rename file

### DIFF
--- a/src/core/metrics/calculateMetrics.ts
+++ b/src/core/metrics/calculateMetrics.ts
@@ -2,8 +2,9 @@ import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
 import type { ProcessedFile } from '../file/fileTypes.js';
 import type { GitDiffResult } from '../git/gitDiffHandle.js';
-import { calculateAllFileMetrics, calculateSelectiveFileMetrics } from './calculateAllFileMetrics.js';
+import { calculateGitDiffMetrics } from './calculateGitDiffMetrics.js';
 import { calculateOutputMetrics } from './calculateOutputMetrics.js';
+import { calculateSelectiveFileMetrics } from './calculateSelectiveFileMetrics.js';
 
 export interface CalculateMetricsResult {
   totalFiles: number;
@@ -14,8 +15,6 @@ export interface CalculateMetricsResult {
   gitDiffTokenCount: number;
 }
 
-import { calculateGitDiffMetrics } from './calculateGitDiffMetrics.js';
-
 export const calculateMetrics = async (
   processedFiles: ProcessedFile[],
   output: string,
@@ -23,7 +22,6 @@ export const calculateMetrics = async (
   config: RepomixConfigMerged,
   gitDiffResult: GitDiffResult | undefined,
   deps = {
-    calculateAllFileMetrics,
     calculateSelectiveFileMetrics,
     calculateOutputMetrics,
     calculateGitDiffMetrics,

--- a/src/core/metrics/calculateSelectiveFileMetrics.ts
+++ b/src/core/metrics/calculateSelectiveFileMetrics.ts
@@ -7,58 +7,6 @@ import type { ProcessedFile } from '../file/fileTypes.js';
 import type { FileMetricsTask } from './workers/fileMetricsWorker.js';
 import type { FileMetrics } from './workers/types.js';
 
-export const calculateAllFileMetrics = async (
-  processedFiles: ProcessedFile[],
-  tokenCounterEncoding: TiktokenEncoding,
-  progressCallback: RepomixProgressCallback,
-  deps = {
-    initTaskRunner,
-  },
-): Promise<FileMetrics[]> => {
-  const taskRunner = deps.initTaskRunner<FileMetricsTask, FileMetrics>(
-    processedFiles.length,
-    new URL('./workers/fileMetricsWorker.js', import.meta.url).href,
-  );
-  const tasks = processedFiles.map(
-    (file, index) =>
-      ({
-        file,
-        index,
-        totalFiles: processedFiles.length,
-        encoding: tokenCounterEncoding,
-      }) satisfies FileMetricsTask,
-  );
-
-  try {
-    const startTime = process.hrtime.bigint();
-    logger.trace(`Starting metrics calculation for ${processedFiles.length} files using worker pool`);
-
-    let completedTasks = 0;
-    const results = await Promise.all(
-      tasks.map((task) =>
-        taskRunner.run(task).then((result) => {
-          completedTasks++;
-          progressCallback(`Calculating metrics... (${completedTasks}/${task.totalFiles}) ${pc.dim(task.file.path)}`);
-          logger.trace(`Calculating metrics... (${completedTasks}/${task.totalFiles}) ${task.file.path}`);
-          return result;
-        }),
-      ),
-    );
-
-    const endTime = process.hrtime.bigint();
-    const duration = Number(endTime - startTime) / 1e6;
-    logger.trace(`Metrics calculation completed in ${duration.toFixed(2)}ms`);
-
-    return results;
-  } catch (error) {
-    logger.error('Error during metrics calculation:', error);
-    throw error;
-  } finally {
-    // Always cleanup worker pool
-    await taskRunner.cleanup();
-  }
-};
-
 export const calculateSelectiveFileMetrics = async (
   processedFiles: ProcessedFile[],
   targetFilePaths: string[],

--- a/tests/core/metrics/calculateMetrics.test.ts
+++ b/tests/core/metrics/calculateMetrics.test.ts
@@ -2,11 +2,8 @@ import { type Mock, describe, expect, it, vi } from 'vitest';
 import type { ProcessedFile } from '../../../src/core/file/fileTypes.js';
 import type { GitDiffResult } from '../../../src/core/git/gitDiffHandle.js';
 import { TokenCounter } from '../../../src/core/metrics/TokenCounter.js';
-import {
-  calculateAllFileMetrics,
-  calculateSelectiveFileMetrics,
-} from '../../../src/core/metrics/calculateAllFileMetrics.js';
 import { calculateMetrics } from '../../../src/core/metrics/calculateMetrics.js';
+import { calculateSelectiveFileMetrics } from '../../../src/core/metrics/calculateSelectiveFileMetrics.js';
 import type { RepomixProgressCallback } from '../../../src/shared/types.js';
 import { createMockConfig } from '../../testing/testUtils.js';
 
@@ -19,8 +16,7 @@ vi.mock('../../../src/core/metrics/TokenCounter.js', () => {
   };
 });
 vi.mock('../../../src/core/metrics/aggregateMetrics.js');
-vi.mock('../../../src/core/metrics/calculateAllFileMetrics.js', () => ({
-  calculateAllFileMetrics: vi.fn(),
+vi.mock('../../../src/core/metrics/calculateSelectiveFileMetrics.js', () => ({
   calculateSelectiveFileMetrics: vi.fn(),
 }));
 
@@ -59,7 +55,6 @@ describe('calculateMetrics', () => {
     const gitDiffResult: GitDiffResult | undefined = undefined;
 
     const result = await calculateMetrics(processedFiles, output, progressCallback, config, gitDiffResult, {
-      calculateAllFileMetrics,
       calculateSelectiveFileMetrics,
       calculateOutputMetrics: () => Promise.resolve(30),
       calculateGitDiffMetrics: () => Promise.resolve(0),

--- a/tests/core/metrics/calculateSelectiveFileMetrics.test.ts
+++ b/tests/core/metrics/calculateSelectiveFileMetrics.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { ProcessedFile } from '../../../src/core/file/fileTypes.js';
-import {
-  calculateAllFileMetrics,
-  calculateSelectiveFileMetrics,
-} from '../../../src/core/metrics/calculateAllFileMetrics.js';
+import { calculateSelectiveFileMetrics } from '../../../src/core/metrics/calculateSelectiveFileMetrics.js';
 import type { FileMetricsTask } from '../../../src/core/metrics/workers/fileMetricsWorker.js';
 import fileMetricsWorker from '../../../src/core/metrics/workers/fileMetricsWorker.js';
 import type { RepomixProgressCallback } from '../../../src/shared/types.js';
@@ -23,24 +20,7 @@ const mockInitTaskRunner = <T, R>(numOfTasks: number, workerPath: string) => {
   };
 };
 
-describe('calculateAllFileMetrics', () => {
-  it('should calculate metrics for all files', async () => {
-    const processedFiles: ProcessedFile[] = [
-      { path: 'file1.txt', content: 'a'.repeat(100) },
-      { path: 'file2.txt', content: 'b'.repeat(200) },
-    ];
-    const progressCallback: RepomixProgressCallback = vi.fn();
-
-    const result = await calculateAllFileMetrics(processedFiles, 'o200k_base', progressCallback, {
-      initTaskRunner: mockInitTaskRunner,
-    });
-
-    expect(result).toEqual([
-      { path: 'file1.txt', charCount: 100, tokenCount: 13 },
-      { path: 'file2.txt', charCount: 200, tokenCount: 50 },
-    ]);
-  });
-
+describe('calculateSelectiveFileMetrics', () => {
   it('should calculate metrics for selective files only', async () => {
     const processedFiles: ProcessedFile[] = [
       { path: 'file1.txt', content: 'a'.repeat(100) },

--- a/tests/core/metrics/diffTokenCount.test.ts
+++ b/tests/core/metrics/diffTokenCount.test.ts
@@ -88,13 +88,6 @@ index 123..456 100644
     });
 
     // Mock dependency functions
-    const mockCalculateAllFileMetrics = vi.fn().mockResolvedValue([
-      {
-        path: 'test.js',
-        charCount: 20,
-        tokenCount: 5,
-      },
-    ]);
 
     const mockCalculateOutputMetrics = vi.fn().mockResolvedValue(15);
 
@@ -108,7 +101,6 @@ index 123..456 100644
         stagedDiffContent: '',
       },
       {
-        calculateAllFileMetrics: mockCalculateAllFileMetrics,
         calculateSelectiveFileMetrics: vi.fn().mockResolvedValue([]),
         calculateOutputMetrics: mockCalculateOutputMetrics,
         calculateGitDiffMetrics: vi.fn().mockResolvedValue(25),
@@ -172,13 +164,6 @@ index 123..456 100644
     });
 
     // Mock dependency functions
-    const mockCalculateAllFileMetrics = vi.fn().mockResolvedValue([
-      {
-        path: 'test.js',
-        charCount: 20,
-        tokenCount: 5,
-      },
-    ]);
 
     const mockCalculateOutputMetrics = vi.fn().mockResolvedValue(15);
 
@@ -189,7 +174,6 @@ index 123..456 100644
       config,
       undefined, // No diff content
       {
-        calculateAllFileMetrics: mockCalculateAllFileMetrics,
         calculateSelectiveFileMetrics: vi.fn().mockResolvedValue([]),
         calculateOutputMetrics: mockCalculateOutputMetrics,
         calculateGitDiffMetrics: vi.fn().mockResolvedValue(0),
@@ -251,13 +235,6 @@ index 123..456 100644
     });
 
     // Mock dependency functions
-    const mockCalculateAllFileMetrics = vi.fn().mockResolvedValue([
-      {
-        path: 'test.js',
-        charCount: 20,
-        tokenCount: 5,
-      },
-    ]);
 
     const mockCalculateOutputMetrics = vi.fn().mockResolvedValue(15);
 
@@ -268,7 +245,6 @@ index 123..456 100644
       config,
       undefined, // No diff content
       {
-        calculateAllFileMetrics: mockCalculateAllFileMetrics,
         calculateSelectiveFileMetrics: vi.fn().mockResolvedValue([]),
         calculateOutputMetrics: mockCalculateOutputMetrics,
         calculateGitDiffMetrics: vi.fn().mockResolvedValue(0),


### PR DESCRIPTION
## Summary

This PR removes the unused `calculateAllFileMetrics` function and renames the file to `calculateSelectiveFileMetrics.ts` to better reflect its purpose.

### Changes made:
- Removed `calculateAllFileMetrics` function that was only used in tests
- Renamed `calculateAllFileMetrics.ts` → `calculateSelectiveFileMetrics.ts`
- Updated all imports and references across the codebase
- Removed corresponding tests for the deleted function
- Updated test file names and imports accordingly

The `calculateAllFileMetrics` function was redundant as only `calculateSelectiveFileMetrics` is used in production code. This simplifies the metrics calculation API and makes the codebase more maintainable.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.ai/code)