### PR TITLE
chore(config): add .serena/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ repomix-output.md
 .mcp.json
 .agents/local/
 
+# serena
+.serena/
+
 # private files
 .private/
 .env


### PR DESCRIPTION
Add Serena project configuration directory to gitignore to prevent tracking of local development environment settings and memories.

This change ensures that Serena's local configuration files (project settings, memories, etc.) are not accidentally committed to the repository, maintaining a clean git history and avoiding conflicts between different development environments.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.ai/code)