### PR TITLE
fix(website): Fix URL parameter initialization timing for production builds

### DIFF
--- a/website/client/components/Home/TryIt.vue
+++ b/website/client/components/Home/TryIt.vue
@@ -101,7 +101,7 @@
 
 <script setup lang="ts">
 import { FolderArchive, FolderOpen, Link2, RotateCcw } from 'lucide-vue-next';
-import { computed, nextTick, onMounted, ref, watch } from 'vue';
+import { computed, nextTick, onMounted, ref } from 'vue';
 import { usePackRequest } from '../../composables/usePackRequest';
 import { hasNonDefaultValues, parseUrlParameters, updateUrlParameters } from '../../utils/urlParams';
 import { isValidRemoteValue } from '../utils/validation';

--- a/website/client/composables/usePackOptions.ts
+++ b/website/client/composables/usePackOptions.ts
@@ -1,4 +1,4 @@
-import { computed, reactive } from 'vue';
+import { computed, onMounted, reactive } from 'vue';
 import { parseUrlParameters } from '../utils/urlParams';
 
 export interface PackOptions {
@@ -28,19 +28,21 @@ const DEFAULT_PACK_OPTIONS: PackOptions = {
 };
 
 export function usePackOptions() {
-  // Initialize with URL parameters if available
-  const urlParams = parseUrlParameters();
-  const initialOptions = { ...DEFAULT_PACK_OPTIONS };
+  // Initialize with default options only
+  const packOptions = reactive<PackOptions>({ ...DEFAULT_PACK_OPTIONS });
 
-  // Apply URL parameters to initial options
-  for (const key of Object.keys(initialOptions) as Array<keyof PackOptions>) {
-    if (key in urlParams && urlParams[key] !== undefined) {
-      // Type-safe assignment: only assign if the key is a valid PackOptions key
-      initialOptions[key] = urlParams[key] as PackOptions[typeof key];
+  // Apply URL parameters after component mounts
+  onMounted(() => {
+    const urlParams = parseUrlParameters();
+
+    // Apply URL parameters to pack options
+    for (const key of Object.keys(packOptions) as Array<keyof PackOptions>) {
+      if (key in urlParams && urlParams[key] !== undefined) {
+        // Type-safe assignment: only assign if the key is a valid PackOptions key
+        packOptions[key] = urlParams[key] as PackOptions[typeof key];
+      }
     }
-  }
-
-  const packOptions = reactive<PackOptions>(initialOptions);
+  });
 
   const getPackRequestOptions = computed(() => ({
     removeComments: packOptions.removeComments,

--- a/website/client/composables/usePackRequest.ts
+++ b/website/client/composables/usePackRequest.ts
@@ -1,4 +1,4 @@
-import { computed, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import type { PackResult } from '../components/api/client';
 import { handlePackRequest } from '../components/utils/requestHandlers';
 import { isValidRemoteValue } from '../components/utils/validation';
@@ -11,11 +11,8 @@ export function usePackRequest() {
   const packOptionsComposable = usePackOptions();
   const { packOptions, getPackRequestOptions, resetOptions, DEFAULT_PACK_OPTIONS } = packOptionsComposable;
 
-  // Initialize with URL parameters if available
-  const urlParams = parseUrlParameters();
-
   // Input states
-  const inputUrl = ref(urlParams.repo || '');
+  const inputUrl = ref('');
   const inputRepositoryUrl = ref('');
   const mode = ref<InputMode>('url');
   const uploadedFile = ref<File | null>(null);
@@ -108,6 +105,14 @@ export function usePackRequest() {
     }
     loading.value = false;
   }
+
+  // Apply URL parameters after component mounts
+  onMounted(() => {
+    const urlParams = parseUrlParameters();
+    if (urlParams.repo) {
+      inputUrl.value = urlParams.repo;
+    }
+  });
 
   return {
     // Pack options (re-exported for convenience)


### PR DESCRIPTION
This PR fixes a critical issue where URL parameters (like `?format=markdown`) were not being applied in production builds, despite working correctly in development environment.

## Problem

URL parameters were working for text inputs (includePatterns, ignorePatterns) but not for format selection buttons and checkboxes in production builds. The root cause was a timing issue with SSR/hydration where `window.location.search` was not available during the initial component setup in production builds.

## Solution

Moved URL parameter initialization from component setup to the `onMounted` lifecycle hook to ensure proper timing:

- **usePackOptions**: Move URL parameter parsing to `onMounted` 
- **usePackRequest**: Move repo parameter application to `onMounted`
- Remove debug console logs
- Fix import statements for `onMounted`

## Changes

- `website/client/composables/usePackOptions.ts`: Initialize with defaults, apply URL params in onMounted
- `website/client/composables/usePackRequest.ts`: Apply repo parameter in onMounted  
- `website/client/components/Home/TryIt.vue`: Remove unused watch import

## Testing

This change ensures that URL parameters like `?format=markdown&repo=yamadashy/repomix` work correctly in both development and production environments.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`