### PR TITLE
feat(website): Add real-time URL parameter updates for better UX

### DIFF
--- a/website/client/components/Home/TryIt.vue
+++ b/website/client/components/Home/TryIt.vue
@@ -101,7 +101,7 @@
 
 <script setup lang="ts">
 import { FolderArchive, FolderOpen, Link2, RotateCcw } from 'lucide-vue-next';
-import { computed, nextTick, onMounted, ref } from 'vue';
+import { computed, nextTick, onMounted, ref, watch } from 'vue';
 import { usePackRequest } from '../../composables/usePackRequest';
 import { hasNonDefaultValues, parseUrlParameters, updateUrlParameters } from '../../utils/urlParams';
 import { isValidRemoteValue } from '../utils/validation';
@@ -142,11 +142,6 @@ const {
 
 // Check if reset button should be shown
 const shouldShowReset = computed(() => {
-  // Don't show if pack hasn't been executed yet
-  if (!hasExecuted.value) {
-    return false;
-  }
-
   // Use utility function to check for non-default values
   return hasNonDefaultValues(
     inputUrl.value,
@@ -155,8 +150,8 @@ const shouldShowReset = computed(() => {
   );
 });
 
-async function handleSubmit() {
-  // Update URL parameters before submitting
+// Function to update URL parameters based on current state
+function updateUrlFromCurrentState() {
   const urlParamsToUpdate: Record<string, unknown> = {};
 
   // Add repository URL if it exists and is valid
@@ -178,7 +173,9 @@ async function handleSubmit() {
   }
 
   updateUrlParameters(urlParamsToUpdate);
+}
 
+async function handleSubmit() {
   await submitRequest();
 }
 
@@ -195,6 +192,11 @@ function handleReset() {
   // Clear URL parameters
   updateUrlParameters({});
 }
+
+// Watch for changes in packOptions and inputUrl to update URL in real-time
+watch([packOptions, inputUrl], () => {
+  updateUrlFromCurrentState();
+}, { deep: true });
 
 // Handle URL parameters when component mounts
 onMounted(() => {

--- a/website/client/components/Home/TryIt.vue
+++ b/website/client/components/Home/TryIt.vue
@@ -194,9 +194,13 @@ function handleReset() {
 }
 
 // Watch for changes in packOptions and inputUrl to update URL in real-time
-watch([packOptions, inputUrl], () => {
-  updateUrlFromCurrentState();
-}, { deep: true });
+watch(
+  [packOptions, inputUrl],
+  () => {
+    updateUrlFromCurrentState();
+  },
+  { deep: true },
+);
 
 // Handle URL parameters when component mounts
 onMounted(() => {


### PR DESCRIPTION
This PR enhances the website's URL parameter functionality by adding real-time updates when users modify any option, providing immediate feedback and making URL sharing more intuitive.

## Problem

Previously, URL parameters were only updated when the Pack button was pressed. This meant users had to execute packing to get a shareable URL with their current configuration, which was not ideal for quick sharing or bookmarking.

## Solution

Implemented real-time URL parameter updates that trigger immediately when users change any option:

- **Real-time monitoring**: Added `watch` for `packOptions` and `inputUrl` with deep watching
- **Immediate feedback**: URL updates instantly when format buttons, checkboxes, or text inputs change
- **Better reset UX**: Reset button now appears immediately when values differ from defaults
- **Clean architecture**: Extracted URL update logic to reusable `updateUrlFromCurrentState()` function

## Changes

- `website/client/components/Home/TryIt.vue`:
  - Add `watch([packOptions, inputUrl], ...)` for real-time URL updates
  - Extract `updateUrlFromCurrentState()` function for reusable URL update logic
  - Remove URL update from `handleSubmit()` (now handled automatically by watch)
  - Simplify reset button logic to show immediately when values differ from defaults
  - Import `watch` from Vue for reactive monitoring

## User Experience Improvements

- ✅ **Instant URL updates**: Any option change immediately reflects in the URL
- ✅ **Better sharing**: Users can copy URLs at any time with current configuration
- ✅ **Immediate reset button**: Shows as soon as user changes any option from defaults
- ✅ **Maintained functionality**: All existing features (auto-execution, validation) preserved

## Testing

This change improves UX while maintaining all existing functionality:
- URL parameters work correctly in both development and production
- Real-time updates work for all option types (format, checkboxes, text inputs)
- Reset functionality works immediately
- Auto-execution from URL parameters still works correctly

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`