### PR TITLE
feat(website): Update Warp sponsorship assets and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
    <sup>Special thanks to:</sup>
    <br>
    <br>
-   <a href="https://www.warp.dev/repomix">
-      <img alt="Warp sponsorship" width="400" src="website/client/src/public/images/sponsors/warp/Terminal-Image.png">
+   <a href="https://go.warp.dev/repomix">
+      <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
    </a>
 
-### [Warp, the agent terminal for developers](https://www.warp.dev/repomix)
-[Available for MacOS, Linux, & Windows](https://www.warp.dev/repomix)<br>
+### [Warp, built for coding with multiple AI agents](https://go.warp.dev/repomix)
+[Available for MacOS, Linux, & Windows](https://go.warp.dev/repomix)<br>
 
 </div>
 

--- a/website/client/components/Home/TryItResult.vue
+++ b/website/client/components/Home/TryItResult.vue
@@ -19,16 +19,16 @@ defineProps<{
 
       <div class="sponsor-section">
         <p class="sponsor-header">Special thanks to:</p>
-        <a href="https://www.warp.dev/repomix" target="_blank" rel="noopener noreferrer">
-          <img alt="Warp sponsorship" width="400" src="/images/sponsors/warp/Terminal-Image.png">
+        <a href="https://go.warp.dev/repomix" target="_blank" rel="noopener noreferrer">
+          <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
         </a>
         <p class="sponsor-title">
-          <a href="https://www.warp.dev/repomix" target="_blank" rel="noopener noreferrer">
-            Warp, the AI terminal for developers
+          <a href="https://go.warp.dev/repomix" target="_blank" rel="noopener noreferrer">
+            Warp, built for coding with multiple AI agents
           </a>
         </p>
         <p class="sponsor-subtitle">
-          <a href="https://www.warp.dev/repomix" target="_blank" rel="noopener noreferrer">
+          <a href="https://go.warp.dev/repomix" target="_blank" rel="noopener noreferrer">
             Available for MacOS, Linux, & Windows
           </a>
         </p>

--- a/website/client/src/de/guide/sponsors.md
+++ b/website/client/src/de/guide/sponsors.md
@@ -26,12 +26,12 @@ Ihr Sponsoring hilft uns dabei:
 <div align="center">
    <sup>Besonderen Dank an:</sup>
 
-   <a href="https://www.warp.dev/repomix" target="_blank">
-      <img alt="Warp sponsorship" width="400" src="/images/sponsors/warp/Terminal-Image.png">
+   <a href="https://go.warp.dev/repomix" target="_blank">
+      <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
    </a>
 
-  [Warp, das Agent-Terminal für Entwickler](https://www.warp.dev/repomix)  
-  [Verfügbar für MacOS, Linux und Windows](https://www.warp.dev/repomix)
+  [Warp, entwickelt für das Programmieren mit mehreren KI-Agenten](https://go.warp.dev/repomix)  
+  [Verfügbar für MacOS, Linux und Windows](https://go.warp.dev/repomix)
 </div>
 
 [![Sponsors](https://cdn.jsdelivr.net/gh/yamadashy/sponsor-list/sponsors/sponsors.png)](https://github.com/sponsors/yamadashy)

--- a/website/client/src/en/guide/sponsors.md
+++ b/website/client/src/en/guide/sponsors.md
@@ -26,12 +26,12 @@ Your sponsorship helps us:
 <div align="center">
    <sup>Special thanks to:</sup>
 
-   <a href="https://www.warp.dev/repomix" target="_blank">
-      <img alt="Warp sponsorship" width="400" src="/images/sponsors/warp/Terminal-Image.png">
+   <a href="https://go.warp.dev/repomix" target="_blank">
+      <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
    </a>
 
-  [Warp, the agent terminal for developers](https://www.warp.dev/repomix)  
-  [Available for MacOS, Linux, & Windows](https://www.warp.dev/repomix)
+  [Warp, built for coding with multiple AI agents](https://go.warp.dev/repomix)  
+  [Available for MacOS, Linux, & Windows](https://go.warp.dev/repomix)
 </div>
 
 [![Sponsors](https://cdn.jsdelivr.net/gh/yamadashy/sponsor-list/sponsors/sponsors.png)](https://github.com/sponsors/yamadashy)

--- a/website/client/src/es/guide/sponsors.md
+++ b/website/client/src/es/guide/sponsors.md
@@ -26,12 +26,12 @@ Tu patrocinio nos ayuda a:
 <div align="center">
    <sup>Agradecimientos especiales a:</sup>
 
-   <a href="https://www.warp.dev/repomix" target="_blank">
-      <img alt="Warp sponsorship" width="400" src="/images/sponsors/warp/Terminal-Image.png">
+   <a href="https://go.warp.dev/repomix" target="_blank">
+      <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
    </a>
 
-  [Warp, la terminal inteligente para desarrolladores](https://www.warp.dev/repomix)  
-  [Disponible para MacOS, Linux y Windows](https://www.warp.dev/repomix)
+  [Warp, construido para programar con múltiples agentes de IA](https://go.warp.dev/repomix)  
+  [Disponible para MacOS, Linux y Windows](https://go.warp.dev/repomix)
 </div>
 
 [![Sponsors](https://cdn.jsdelivr.net/gh/yamadashy/sponsor-list/sponsors/sponsors.png)](https://github.com/sponsors/yamadashy)

--- a/website/client/src/fr/guide/sponsors.md
+++ b/website/client/src/fr/guide/sponsors.md
@@ -26,12 +26,12 @@ Votre parrainage nous aide à :
 <div align="center">
    <sup>Remerciements spéciaux à :</sup>
 
-   <a href="https://www.warp.dev/repomix" target="_blank">
-      <img alt="Warp sponsorship" width="400" src="/images/sponsors/warp/Terminal-Image.png">
+   <a href="https://go.warp.dev/repomix" target="_blank">
+      <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
    </a>
 
-  [Warp, le terminal agent pour les développeurs](https://www.warp.dev/repomix)  
-  [Disponible pour MacOS, Linux et Windows](https://www.warp.dev/repomix)
+  [Warp, conçu pour programmer avec plusieurs agents IA](https://go.warp.dev/repomix)  
+  [Disponible pour MacOS, Linux et Windows](https://go.warp.dev/repomix)
 </div>
 
 [![Sponsors](https://cdn.jsdelivr.net/gh/yamadashy/sponsor-list/sponsors/sponsors.png)](https://github.com/sponsors/yamadashy)

--- a/website/client/src/hi/guide/sponsors.md
+++ b/website/client/src/hi/guide/sponsors.md
@@ -26,12 +26,12 @@ editLink: false
 <div align="center">
    <sup>विशेष धन्यवाद:</sup>
 
-   <a href="https://www.warp.dev/repomix" target="_blank">
-      <img alt="Warp sponsorship" width="400" src="/images/sponsors/warp/Terminal-Image.png">
+   <a href="https://go.warp.dev/repomix" target="_blank">
+      <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
    </a>
 
-  [Warp, डेवलपर्स के लिए एजेंट टर्मिनल](https://www.warp.dev/repomix)  
-  [MacOS, Linux और Windows के लिए उपलब्ध](https://www.warp.dev/repomix)
+  [Warp, कई AI एजेंट्स के साथ कोडिंग के लिए बनाया गया](https://go.warp.dev/repomix)  
+  [MacOS, Linux और Windows के लिए उपलब्ध](https://go.warp.dev/repomix)
 </div>
 
 [![Sponsors](https://cdn.jsdelivr.net/gh/yamadashy/sponsor-list/sponsors/sponsors.png)](https://github.com/sponsors/yamadashy)

--- a/website/client/src/id/guide/sponsors.md
+++ b/website/client/src/id/guide/sponsors.md
@@ -26,12 +26,12 @@ Sponsorship Anda membantu kami:
 <div align="center">
    <sup>Terima kasih khusus kepada:</sup>
 
-   <a href="https://www.warp.dev/repomix" target="_blank">
-      <img alt="Warp sponsorship" width="400" src="/images/sponsors/warp/Terminal-Image.png">
+   <a href="https://go.warp.dev/repomix" target="_blank">
+      <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
    </a>
 
-  [Warp, terminal agen untuk pengembang](https://www.warp.dev/repomix)  
-  [Tersedia untuk MacOS, Linux, & Windows](https://www.warp.dev/repomix)
+  [Warp, dibuat untuk coding dengan beberapa agen AI](https://go.warp.dev/repomix)  
+  [Tersedia untuk MacOS, Linux, & Windows](https://go.warp.dev/repomix)
 </div>
 
 [![Sponsors](https://cdn.jsdelivr.net/gh/yamadashy/sponsor-list/sponsors/sponsors.png)](https://github.com/sponsors/yamadashy)

--- a/website/client/src/ja/guide/sponsors.md
+++ b/website/client/src/ja/guide/sponsors.md
@@ -26,12 +26,12 @@ Repomixをサポートしてくださる素晴らしい個人・組織の皆様�
 <div align="center">
    <sup>Special thanks to:</sup>
 
-   <a href="https://www.warp.dev/repomix" target="_blank">
-      <img alt="Warp sponsorship" width="400" src="/images/sponsors/warp/Terminal-Image.png">
+   <a href="https://go.warp.dev/repomix" target="_blank">
+      <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
    </a>
 
-  [Warp, the agent terminal for developers](https://www.warp.dev/repomix)  
-  [Available for MacOS, Linux, & Windows](https://www.warp.dev/repomix)
+  [Warp, built for coding with multiple AI agents](https://go.warp.dev/repomix)  
+  [Available for MacOS, Linux, & Windows](https://go.warp.dev/repomix)
 </div>
 
 [![Sponsors](https://cdn.jsdelivr.net/gh/yamadashy/sponsor-list/sponsors/sponsors.png)](https://github.com/sponsors/yamadashy)

--- a/website/client/src/ko/guide/sponsors.md
+++ b/website/client/src/ko/guide/sponsors.md
@@ -26,12 +26,12 @@ Repomix를 지원해주시는 모든 훌륭한 개인과 조직에게 감사드�
 <div align="center">
    <sup>특별히 감사드립니다:</sup>
 
-   <a href="https://www.warp.dev/repomix" target="_blank">
-      <img alt="Warp sponsorship" width="400" src="/images/sponsors/warp/Terminal-Image.png">
+   <a href="https://go.warp.dev/repomix" target="_blank">
+      <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
    </a>
 
-  [Warp, 개발자를 위한 에이전트 터미널](https://www.warp.dev/repomix)  
-  [MacOS, Linux, Windows에서 사용 가능](https://www.warp.dev/repomix)
+  [Warp, 여러 AI 에이전트와 함께 코딩하기 위해 제작됨](https://go.warp.dev/repomix)  
+  [MacOS, Linux, Windows에서 사용 가능](https://go.warp.dev/repomix)
 </div>
 
 [![Sponsors](https://cdn.jsdelivr.net/gh/yamadashy/sponsor-list/sponsors/sponsors.png)](https://github.com/sponsors/yamadashy)

--- a/website/client/src/pt-br/guide/sponsors.md
+++ b/website/client/src/pt-br/guide/sponsors.md
@@ -26,12 +26,12 @@ Seu patrocínio nos ajuda a:
 <div align="center">
    <sup>Agradecimentos especiais para:</sup>
 
-   <a href="https://www.warp.dev/repomix" target="_blank">
-      <img alt="Warp sponsorship" width="400" src="/images/sponsors/warp/Terminal-Image.png">
+   <a href="https://go.warp.dev/repomix" target="_blank">
+      <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
    </a>
 
-  [Warp, o terminal inteligente para desenvolvedores](https://www.warp.dev/repomix)  
-  [Disponível para MacOS, Linux e Windows](https://www.warp.dev/repomix)
+  [Warp, feito para programar com múltiplos agentes de IA](https://go.warp.dev/repomix)  
+  [Disponível para MacOS, Linux e Windows](https://go.warp.dev/repomix)
 </div>
 
 [![Sponsors](https://cdn.jsdelivr.net/gh/yamadashy/sponsor-list/sponsors/sponsors.png)](https://github.com/sponsors/yamadashy)

--- a/website/client/src/vi/guide/sponsors.md
+++ b/website/client/src/vi/guide/sponsors.md
@@ -26,12 +26,12 @@ Sự tài trợ của bạn giúp chúng tôi:
 <div align="center">
    <sup>Đặc biệt cảm ơn:</sup>
 
-   <a href="https://www.warp.dev/repomix" target="_blank">
-      <img alt="Warp sponsorship" width="400" src="/images/sponsors/warp/Terminal-Image.png">
+   <a href="https://go.warp.dev/repomix" target="_blank">
+      <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
    </a>
 
-  [Warp, terminal thông minh cho nhà phát triển](https://www.warp.dev/repomix)  
-  [Có sẵn cho MacOS, Linux và Windows](https://www.warp.dev/repomix)
+  [Warp, được xây dựng cho việc lập trình với nhiều AI agent](https://go.warp.dev/repomix)  
+  [Có sẵn cho MacOS, Linux và Windows](https://go.warp.dev/repomix)
 </div>
 
 [![Sponsors](https://cdn.jsdelivr.net/gh/yamadashy/sponsor-list/sponsors/sponsors.png)](https://github.com/sponsors/yamadashy)

--- a/website/client/src/zh-cn/guide/sponsors.md
+++ b/website/client/src/zh-cn/guide/sponsors.md
@@ -26,12 +26,12 @@ editLink: false
 <div align="center">
    <sup>特别感谢：</sup>
 
-   <a href="https://www.warp.dev/repomix" target="_blank">
-      <img alt="Warp sponsorship" width="400" src="/images/sponsors/warp/Terminal-Image.png">
+   <a href="https://go.warp.dev/repomix" target="_blank">
+      <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
    </a>
 
-  [Warp，开发者的智能终端](https://www.warp.dev/repomix)  
-  [支持 MacOS、Linux 和 Windows](https://www.warp.dev/repomix)
+  [Warp，专为多个AI代理编程而构建](https://go.warp.dev/repomix)  
+  [支持 MacOS、Linux 和 Windows](https://go.warp.dev/repomix)
 </div>
 
 [![Sponsors](https://cdn.jsdelivr.net/gh/yamadashy/sponsor-list/sponsors/sponsors.png)](https://github.com/sponsors/yamadashy)

--- a/website/client/src/zh-tw/guide/sponsors.md
+++ b/website/client/src/zh-tw/guide/sponsors.md
@@ -26,12 +26,12 @@ editLink: false
 <div align="center">
    <sup>特別感謝：</sup>
 
-   <a href="https://www.warp.dev/repomix" target="_blank">
-      <img alt="Warp sponsorship" width="400" src="/images/sponsors/warp/Terminal-Image.png">
+   <a href="https://go.warp.dev/repomix" target="_blank">
+      <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
    </a>
 
-  [Warp，開發者的智慧終端](https://www.warp.dev/repomix)  
-  [支援 MacOS、Linux 和 Windows](https://www.warp.dev/repomix)
+  [Warp，專為多個AI代理編程而構建](https://go.warp.dev/repomix)  
+  [支援 MacOS、Linux 和 Windows](https://go.warp.dev/repomix)
 </div>
 
 [![Sponsors](https://cdn.jsdelivr.net/gh/yamadashy/sponsor-list/sponsors/sponsors.png)](https://github.com/sponsors/yamadashy)


### PR DESCRIPTION
This PR updates the Warp sponsorship content across all website files and README as requested by Warp for their partnership renewal.

## Summary
- **Updated sponsor image**: Switched from local image to official Warp brand assets from GitHub (`Warp-Github-LG-01.png`)
- **Updated all links**: Changed from `www.warp.dev/repomix` to `go.warp.dev/repomix` for performance tracking
- **Updated tagline**: Changed to "Warp, built for coding with multiple AI agents" as requested
- **Applied across all languages**: Updated 12 language versions with appropriate translations

## Files changed
- `README.md`
- `website/client/components/Home/TryItResult.vue`
- All 12 language versions in `website/client/src/*/guide/sponsors.md`

## Context
Warp is renewing their 3-month sponsorship at $600/month and requested these updates to align with their latest branding and enable performance tracking through the new URL structure.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`