### PR TITLE
fix(website): Reduce Cloud Run memory allocation to 1024Mi

### DIFF
--- a/website/server/cloudbuild.yaml
+++ b/website/server/cloudbuild.yaml
@@ -36,7 +36,7 @@ steps:
       - '--port'
       - '8080'
       - '--memory'
-      - '2048Mi'
+      - '1024Mi'
       - '--cpu'
       - '2'
       - '--min-instances'


### PR DESCRIPTION
This PR reduces the memory allocation for the website server Cloud Run deployment from 2048Mi to 1024Mi to optimize resource usage and reduce costs.

The website server should work efficiently with 1024Mi of memory, and this change will help reduce infrastructure costs without affecting performance.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`