### PR TITLE
Replace tsc with tsgo for type checking in subprojects

### DIFF
--- a/browser/package-lock.json
+++ b/browser/package-lock.json
@@ -10,6 +10,7 @@
         "@types/chrome": "^0.1.1",
         "@types/node": "^24.0.14",
         "@types/webextension-polyfill": "^0.12.3",
+        "@typescript/native-preview": "^7.0.0-dev.20250824.1",
         "@webextension-toolbox/webextension-toolbox": "^7.1.1",
         "jsdom": "^26.1.0",
         "sharp": "^0.34.3",
@@ -3497,6 +3498,147 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript/native-preview": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-UtCoYEH0vehSgt05eP7GJO530AkdisBOIuxQ6vuDP4FXg5EMiszkimU2Ry7heHOwvSVu1Np1nYlvDE7oxLYRig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsgo": "bin/tsgo.js"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "optionalDependencies": {
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20250824.1"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-arm64": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-B0owFv9kBjhNWbYyZwXtBHSPocXID6CJzrVQRATfaGm9cGl1luB9kNiPZjsXnCZU5qjIwRGu37wrxXzRP6OFIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-x64": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-vNDL0AAEv7ht4+YMWOsWV8c/rN5uwwzhWPDM5LnV9+MrrjL9kos6zMtegQAcKzKWUQlZADHwECP4sNXiyeflJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-arm": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-SitIkTIJ4yTGxR/hhzhfK62i776YE2eAsJeVj+ege1S91TOd04h7V1stHRAQgSjLXZYPDHJnfXHq8NEZTYL6sA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-arm64": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-QqEeiLsOO+3KzUSAjZSwWvX9T2IuHv+L1pb3GrM6Kr+ZnpxRfRoy448ds7dTJwU423ZegaCktIHZZkxmJkgUVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-x64": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-s79rwaYI6xf/bljggcbhmuJ+PtGdxcv07JFhw0KMEWTfDvSlR+hUJyGR7S/djvX6a3/TXIDezrhikT5aQcqHOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-win32-arm64": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-gl3wVMxFjNAzGdoSzLMsioMGcZGeHNivqbHyehzwuEBUX6iGTIOSbtp8lDQcfZrXY3SOSVPq9DJX6epYWtw5BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-win32-x64": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-NBT0fKR7K09NnAHznN0Mp8YRHiSx/hmy9R2G/LAMz+HoQRImPK+CZktWPdeefT4W6QN91xXprTLmq5z+hWR73A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
       }
     },
     "node_modules/@vitest/expect": {

--- a/browser/package.json
+++ b/browser/package.json
@@ -8,7 +8,7 @@
     "build-all": "npm run build chrome && npm run build firefox && npm run build edge",
     "generate-icons": "tsx scripts/generate-icons.ts",
     "lint": "npm run lint-tsc",
-    "lint-tsc": "tsc --noEmit",
+    "lint-tsc": "tsgo --noEmit",
     "test": "vitest",
     "archive": "git archive HEAD -o storage/source.zip"
   },
@@ -27,6 +27,7 @@
     "@types/chrome": "^0.1.1",
     "@types/node": "^24.0.14",
     "@types/webextension-polyfill": "^0.12.3",
+    "@typescript/native-preview": "^7.0.0-dev.20250708.1",
     "@webextension-toolbox/webextension-toolbox": "^7.1.1",
     "jsdom": "^26.1.0",
     "sharp": "^0.34.3",

--- a/browser/package.json
+++ b/browser/package.json
@@ -27,7 +27,7 @@
     "@types/chrome": "^0.1.1",
     "@types/node": "^24.0.14",
     "@types/webextension-polyfill": "^0.12.3",
-    "@typescript/native-preview": "^7.0.0-dev.20250708.1",
+    "@typescript/native-preview": "^7.0.0-dev.20250824.1",
     "@webextension-toolbox/webextension-toolbox": "^7.1.1",
     "jsdom": "^26.1.0",
     "sharp": "^0.34.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@secretlint/types": "^9.3.4",
         "@types/node": "^22.14.1",
         "@types/strip-comments": "^2.0.4",
-        "@typescript/native-preview": "^7.0.0-dev.20250708.1",
+        "@typescript/native-preview": "^7.0.0-dev.20250824.1",
         "@vitest/coverage-v8": "^3.1.1",
         "git-up": "^8.1.1",
         "oxlint": "^1.12.0",
@@ -1858,9 +1858,9 @@
       "dev": true
     },
     "node_modules/@typescript/native-preview": {
-      "version": "7.0.0-dev.20250708.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20250708.1.tgz",
-      "integrity": "sha512-DtzOqUrg7S5fAZ2/SFa2YnOqLu+WeOaKkpg2xQEkROHugnGFWVrTIHLb4abKpDELXASb97vFhFDZbrjcn3QLyw==",
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-UtCoYEH0vehSgt05eP7GJO530AkdisBOIuxQ6vuDP4FXg5EMiszkimU2Ry7heHOwvSVu1Np1nYlvDE7oxLYRig==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1870,19 +1870,19 @@
         "node": ">=20.6.0"
       },
       "optionalDependencies": {
-        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20250708.1",
-        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20250708.1",
-        "@typescript/native-preview-linux-arm": "7.0.0-dev.20250708.1",
-        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20250708.1",
-        "@typescript/native-preview-linux-x64": "7.0.0-dev.20250708.1",
-        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20250708.1",
-        "@typescript/native-preview-win32-x64": "7.0.0-dev.20250708.1"
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20250824.1"
       }
     },
     "node_modules/@typescript/native-preview-darwin-arm64": {
-      "version": "7.0.0-dev.20250708.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20250708.1.tgz",
-      "integrity": "sha512-GCjHpuLsxMDO6eCGFfK8p5HrUGhZf9mD03Nd8gqfUVOuzu85DMbYS4dN+UbsprZKEktpVAJo+4ngft/Ri8bbFw==",
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-B0owFv9kBjhNWbYyZwXtBHSPocXID6CJzrVQRATfaGm9cGl1luB9kNiPZjsXnCZU5qjIwRGu37wrxXzRP6OFIQ==",
       "cpu": [
         "arm64"
       ],
@@ -1897,9 +1897,9 @@
       }
     },
     "node_modules/@typescript/native-preview-darwin-x64": {
-      "version": "7.0.0-dev.20250708.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20250708.1.tgz",
-      "integrity": "sha512-WFXh84S5vUWKhG9nok35cICVM2VbQnQ2qetb09B/i7jVx7D8dz/7eiSqie/y4/g/TfQ3Gbc1r1vHSfpCWvVgjg==",
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-vNDL0AAEv7ht4+YMWOsWV8c/rN5uwwzhWPDM5LnV9+MrrjL9kos6zMtegQAcKzKWUQlZADHwECP4sNXiyeflJQ==",
       "cpu": [
         "x64"
       ],
@@ -1914,9 +1914,9 @@
       }
     },
     "node_modules/@typescript/native-preview-linux-arm": {
-      "version": "7.0.0-dev.20250708.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20250708.1.tgz",
-      "integrity": "sha512-E5Pd1Xlzi8tI4oSC+KuXu1sAgHIApp0lgvBqeP0h9tDbyz3+cre95zt0yhy+W0C3YCV3KtoiVCbS6G6+TqzjbA==",
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-SitIkTIJ4yTGxR/hhzhfK62i776YE2eAsJeVj+ege1S91TOd04h7V1stHRAQgSjLXZYPDHJnfXHq8NEZTYL6sA==",
       "cpu": [
         "arm"
       ],
@@ -1931,9 +1931,9 @@
       }
     },
     "node_modules/@typescript/native-preview-linux-arm64": {
-      "version": "7.0.0-dev.20250708.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20250708.1.tgz",
-      "integrity": "sha512-1jdWz50O/Y+jJZKAIejshlD4i/tJeY2ZqAFWlvhZXqBFjJTjjyZuLIbOoy7aRX2rQaRF90FFukiA4ICKFs+DEA==",
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-QqEeiLsOO+3KzUSAjZSwWvX9T2IuHv+L1pb3GrM6Kr+ZnpxRfRoy448ds7dTJwU423ZegaCktIHZZkxmJkgUVQ==",
       "cpu": [
         "arm64"
       ],
@@ -1948,9 +1948,9 @@
       }
     },
     "node_modules/@typescript/native-preview-linux-x64": {
-      "version": "7.0.0-dev.20250708.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20250708.1.tgz",
-      "integrity": "sha512-9Uoktwwa9XSsbsIil+oxU1qiz+6uown82V8QLGI1CCbAjJ7WJEdYJ3VbL5gttMtU++pfY4UFBWVp2Tm61k5Q0A==",
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-s79rwaYI6xf/bljggcbhmuJ+PtGdxcv07JFhw0KMEWTfDvSlR+hUJyGR7S/djvX6a3/TXIDezrhikT5aQcqHOQ==",
       "cpu": [
         "x64"
       ],
@@ -1965,9 +1965,9 @@
       }
     },
     "node_modules/@typescript/native-preview-win32-arm64": {
-      "version": "7.0.0-dev.20250708.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20250708.1.tgz",
-      "integrity": "sha512-Tqo+1RK/Uz7xZlCQ+XJ+1ny2Wo8IaMBdJnakZoReIeAYN+Cylo31Vyg8kAxybKpI63joMbRGfAPfuyvCfIXmpg==",
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-gl3wVMxFjNAzGdoSzLMsioMGcZGeHNivqbHyehzwuEBUX6iGTIOSbtp8lDQcfZrXY3SOSVPq9DJX6epYWtw5BA==",
       "cpu": [
         "arm64"
       ],
@@ -1982,9 +1982,9 @@
       }
     },
     "node_modules/@typescript/native-preview-win32-x64": {
-      "version": "7.0.0-dev.20250708.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20250708.1.tgz",
-      "integrity": "sha512-72wD8/AbzC8pA5phiv8X543RIcAlsfrterDaPC8m2598/8yaPl3uL6FYrKLOTJSTPoOUbfVEJczm9e9UYFd8Nw==",
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-NBT0fKR7K09NnAHznN0Mp8YRHiSx/hmy9R2G/LAMz+HoQRImPK+CZktWPdeefT4W6QN91xXprTLmq5z+hWR73A==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@secretlint/types": "^9.3.4",
     "@types/node": "^22.14.1",
     "@types/strip-comments": "^2.0.4",
-    "@typescript/native-preview": "^7.0.0-dev.20250708.1",
+    "@typescript/native-preview": "^7.0.0-dev.20250824.1",
     "@vitest/coverage-v8": "^3.1.1",
     "git-up": "^8.1.1",
     "oxlint": "^1.12.0",

--- a/website/client/package-lock.json
+++ b/website/client/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@types/gtag.js": "^0.0.20",
+        "@types/node": "^24.0.14",
         "@typescript/native-preview": "^7.0.0-dev.20250824.1",
         "rollup-plugin-visualizer": "^6.0.3",
         "vite-plugin-pwa": "^1.0.1",
@@ -2812,6 +2813,16 @@
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -6738,6 +6749,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/website/client/package-lock.json
+++ b/website/client/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@types/gtag.js": "^0.0.20",
+        "@typescript/native-preview": "^7.0.0-dev.20250824.1",
         "rollup-plugin-visualizer": "^6.0.3",
         "vite-plugin-pwa": "^1.0.1",
         "vitepress": "^1.6.3"
@@ -2839,6 +2840,147 @@
       "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript/native-preview": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-UtCoYEH0vehSgt05eP7GJO530AkdisBOIuxQ6vuDP4FXg5EMiszkimU2Ry7heHOwvSVu1Np1nYlvDE7oxLYRig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsgo": "bin/tsgo.js"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "optionalDependencies": {
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20250824.1"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-arm64": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-B0owFv9kBjhNWbYyZwXtBHSPocXID6CJzrVQRATfaGm9cGl1luB9kNiPZjsXnCZU5qjIwRGu37wrxXzRP6OFIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-x64": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-vNDL0AAEv7ht4+YMWOsWV8c/rN5uwwzhWPDM5LnV9+MrrjL9kos6zMtegQAcKzKWUQlZADHwECP4sNXiyeflJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-arm": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-SitIkTIJ4yTGxR/hhzhfK62i776YE2eAsJeVj+ege1S91TOd04h7V1stHRAQgSjLXZYPDHJnfXHq8NEZTYL6sA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-arm64": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-QqEeiLsOO+3KzUSAjZSwWvX9T2IuHv+L1pb3GrM6Kr+ZnpxRfRoy448ds7dTJwU423ZegaCktIHZZkxmJkgUVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-x64": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-s79rwaYI6xf/bljggcbhmuJ+PtGdxcv07JFhw0KMEWTfDvSlR+hUJyGR7S/djvX6a3/TXIDezrhikT5aQcqHOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-win32-arm64": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-gl3wVMxFjNAzGdoSzLMsioMGcZGeHNivqbHyehzwuEBUX6iGTIOSbtp8lDQcfZrXY3SOSVPq9DJX6epYWtw5BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-win32-x64": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-NBT0fKR7K09NnAHznN0Mp8YRHiSx/hmy9R2G/LAMz+HoQRImPK+CZktWPdeefT4W6QN91xXprTLmq5z+hWR73A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.1",

--- a/website/client/package.json
+++ b/website/client/package.json
@@ -7,7 +7,7 @@
     "docs:build": "vitepress build",
     "docs:preview": "vitepress preview",
     "lint": "npm run lint-tsc",
-    "lint-tsc": "tsc --noEmit"
+    "lint-tsc": "tsgo --noEmit"
   },
   "dependencies": {
     "fflate": "^0.8.2",
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@types/gtag.js": "^0.0.20",
+    "@typescript/native-preview": "^7.0.0-dev.20250708.1",
     "rollup-plugin-visualizer": "^6.0.3",
     "vite-plugin-pwa": "^1.0.1",
     "vitepress": "^1.6.3"

--- a/website/client/package.json
+++ b/website/client/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@types/gtag.js": "^0.0.20",
-    "@typescript/native-preview": "^7.0.0-dev.20250708.1",
+    "@typescript/native-preview": "^7.0.0-dev.20250824.1",
     "rollup-plugin-visualizer": "^6.0.3",
     "vite-plugin-pwa": "^1.0.1",
     "vitepress": "^1.6.3"

--- a/website/client/package.json
+++ b/website/client/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@types/gtag.js": "^0.0.20",
+    "@types/node": "^24.0.14",
     "@typescript/native-preview": "^7.0.0-dev.20250824.1",
     "rollup-plugin-visualizer": "^6.0.3",
     "vite-plugin-pwa": "^1.0.1",

--- a/website/client/tsconfig.json
+++ b/website/client/tsconfig.json
@@ -13,7 +13,7 @@
     "lib": ["ESNext", "DOM"],
     "skipLibCheck": true,
     "noEmit": true,
-    "baseUrl": ".",
+    "paths": {"*": ["./*"]},
     "types": ["vite/client", "vitepress/client"]
   },
   "include": [

--- a/website/server/package-lock.json
+++ b/website/server/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@types/node": "^24.0.14",
+        "@typescript/native-preview": "^7.0.0-dev.20250824.1",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.3",
         "typescript": "^5.8.3"
@@ -913,6 +914,147 @@
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "license": "MIT"
+    },
+    "node_modules/@typescript/native-preview": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-UtCoYEH0vehSgt05eP7GJO530AkdisBOIuxQ6vuDP4FXg5EMiszkimU2Ry7heHOwvSVu1Np1nYlvDE7oxLYRig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsgo": "bin/tsgo.js"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "optionalDependencies": {
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20250824.1",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20250824.1"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-arm64": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-B0owFv9kBjhNWbYyZwXtBHSPocXID6CJzrVQRATfaGm9cGl1luB9kNiPZjsXnCZU5qjIwRGu37wrxXzRP6OFIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-x64": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-vNDL0AAEv7ht4+YMWOsWV8c/rN5uwwzhWPDM5LnV9+MrrjL9kos6zMtegQAcKzKWUQlZADHwECP4sNXiyeflJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-arm": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-SitIkTIJ4yTGxR/hhzhfK62i776YE2eAsJeVj+ege1S91TOd04h7V1stHRAQgSjLXZYPDHJnfXHq8NEZTYL6sA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-arm64": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-QqEeiLsOO+3KzUSAjZSwWvX9T2IuHv+L1pb3GrM6Kr+ZnpxRfRoy448ds7dTJwU423ZegaCktIHZZkxmJkgUVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-x64": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-s79rwaYI6xf/bljggcbhmuJ+PtGdxcv07JFhw0KMEWTfDvSlR+hUJyGR7S/djvX6a3/TXIDezrhikT5aQcqHOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-win32-arm64": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-gl3wVMxFjNAzGdoSzLMsioMGcZGeHNivqbHyehzwuEBUX6iGTIOSbtp8lDQcfZrXY3SOSVPq9DJX6epYWtw5BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-win32-x64": {
+      "version": "7.0.0-dev.20250824.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20250824.1.tgz",
+      "integrity": "sha512-NBT0fKR7K09NnAHznN0Mp8YRHiSx/hmy9R2G/LAMz+HoQRImPK+CZktWPdeefT4W6QN91xXprTLmq5z+hWR73A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",

--- a/website/server/package.json
+++ b/website/server/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.0.14",
-    "@typescript/native-preview": "^7.0.0-dev.20250708.1",
+    "@typescript/native-preview": "^7.0.0-dev.20250824.1",
     "rimraf": "^6.0.1",
     "tsx": "^4.20.3",
     "typescript": "^5.8.3"

--- a/website/server/package.json
+++ b/website/server/package.json
@@ -6,7 +6,7 @@
     "dev": "PORT=8080 tsx watch src/index.ts",
     "build": "tsc",
     "lint": "npm run lint-tsc",
-    "lint-tsc": "tsc --noEmit",
+    "lint-tsc": "tsgo --noEmit",
     "start": "node dist/index.js",
     "clean": "rimraf dist",
     "cloud-deploy": "gcloud builds submit --config=cloudbuild.yaml ."
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.0.14",
+    "@typescript/native-preview": "^7.0.0-dev.20250708.1",
     "rimraf": "^6.0.1",
     "tsx": "^4.20.3",
     "typescript": "^5.8.3"


### PR DESCRIPTION
This PR replaces `tsc` with `tsgo` for TypeScript type checking in all subprojects to align with the main package.json configuration and improve type checking performance.

## Changes

- **browser/package.json**: Updated `lint-tsc` script from `tsc --noEmit` to `tsgo --noEmit`
- **website/client/package.json**: Updated `lint-tsc` script from `tsc --noEmit` to `tsgo --noEmit`  
- **website/server/package.json**: Updated `lint-tsc` script from `tsc --noEmit` to `tsgo --noEmit`
- **All subprojects**: Added `@typescript/native-preview` dependency required for tsgo compatibility

## Benefits

- Consistent tooling across all packages in the monorepo
- Faster TypeScript type checking with tsgo's native performance improvements
- Reduced maintenance overhead by using the same type checking approach everywhere

## Checklist

- [ ] Run `npm run test`
- [ ] Run `npm run lint`