### PR TITLE
feat(git): Use HEAD instead of hardcoded main branch for GitHub archives

### DIFF
--- a/src/core/git/gitHubArchiveApi.ts
+++ b/src/core/git/gitHubArchiveApi.ts
@@ -12,8 +12,8 @@ export const buildGitHubArchiveUrl = (repoInfo: GitHubRepoInfo): string => {
   const baseUrl = `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/archive`;
 
   if (!ref) {
-    // Default to main branch - fallback to master will be handled by the caller
-    return `${baseUrl}/refs/heads/main.zip`;
+    // Default to HEAD (repository's default branch)
+    return `${baseUrl}/HEAD.zip`;
   }
 
   // Check if ref looks like a commit SHA (40 hex chars or shorter)
@@ -57,7 +57,7 @@ export const buildGitHubTagArchiveUrl = (repoInfo: GitHubRepoInfo): string | nul
  */
 export const getArchiveFilename = (repoInfo: GitHubRepoInfo): string => {
   const { repo, ref } = repoInfo;
-  const refPart = ref || 'main';
+  const refPart = ref || 'HEAD';
 
   // GitHub uses the last part of the ref for the filename
   const refName = refPart.includes('/') ? refPart.split('/').pop() : refPart;

--- a/tests/core/git/gitHubArchive.test.ts
+++ b/tests/core/git/gitHubArchive.test.ts
@@ -242,9 +242,9 @@ describe('gitHubArchive', () => {
         createWriteStream: mockCreateWriteStream,
       });
 
-      // Should try main branch first, then master branch
+      // Should try HEAD first, then master branch
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://github.com/yamadashy/repomix/archive/refs/heads/main.zip',
+        'https://github.com/yamadashy/repomix/archive/HEAD.zip',
         expect.any(Object),
       );
       expect(mockFetch).toHaveBeenCalledWith(

--- a/tests/core/git/gitHubArchiveApi.test.ts
+++ b/tests/core/git/gitHubArchiveApi.test.ts
@@ -11,10 +11,10 @@ import { RepomixError } from '../../../src/shared/errorHandle.js';
 
 describe('GitHub Archive API', () => {
   describe('buildGitHubArchiveUrl', () => {
-    test('should build URL for default branch', () => {
+    test('should build URL for default branch (HEAD)', () => {
       const repoInfo = { owner: 'user', repo: 'repo' };
       const url = buildGitHubArchiveUrl(repoInfo);
-      expect(url).toBe('https://github.com/user/repo/archive/refs/heads/main.zip');
+      expect(url).toBe('https://github.com/user/repo/archive/HEAD.zip');
     });
 
     test('should build URL for specific branch', () => {
@@ -71,10 +71,10 @@ describe('GitHub Archive API', () => {
   });
 
   describe('getArchiveFilename', () => {
-    test('should generate filename for default branch', () => {
+    test('should generate filename for default branch (HEAD)', () => {
       const repoInfo = { owner: 'user', repo: 'myrepo' };
       const filename = getArchiveFilename(repoInfo);
-      expect(filename).toBe('myrepo-main.zip');
+      expect(filename).toBe('myrepo-HEAD.zip');
     });
 
     test('should generate filename for specific branch', () => {


### PR DESCRIPTION
This PR replaces hardcoded 'main' branch references with 'HEAD' in GitHub archive functionality, making the system automatically use the repository's default branch regardless of whether it's 'main', 'master', or a custom branch name.

## Summary

- Replace hardcoded 'main' branch with 'HEAD' in `buildGitHubArchiveUrl` function
- Update `getArchiveFilename` to default to 'HEAD' instead of 'main'  
- Update corresponding tests to reflect the new behavior
- Eliminates compatibility issues with repositories using different default branch names

## Benefits

- **Better compatibility**: Works with repositories using 'master', 'main', or custom default branches
- **Future-proof**: No need to update code when GitHub or repositories change default branch naming conventions
- **Simplified logic**: Relies on GitHub's native HEAD resolution instead of guessing branch names

## Test Plan

- [x] Run `npm run test` - All 743 tests pass
- [x] Run `npm run lint` - No linting issues
- [x] Updated unit tests for `buildGitHubArchiveUrl` and `getArchiveFilename` 
- [x] Updated integration tests in `gitHubArchive.test.ts`
- [x] Verified fallback behavior still works (HEAD → master fallback)

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`