### PR TITLE
feat(website): Reduce Cloud Run CPU allocation from 2 to 1

### DIFF
--- a/website/server/cloudbuild.yaml
+++ b/website/server/cloudbuild.yaml
@@ -38,7 +38,7 @@ steps:
       - '--memory'
       - '1024Mi'
       - '--cpu'
-      - '2'
+      - '1'
       - '--min-instances'
       - '0'
       - '--max-instances'


### PR DESCRIPTION
This PR reduces the CPU allocation from 2 to 1 in the Cloud Run deployment configuration for the website server. This optimization helps reduce operational costs while maintaining adequate performance for the website.

## Changes
- Updated `website/server/cloudbuild.yaml` to change CPU allocation from `2` to `1`

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`