### PR TITLE
feat(website): Configure US region deployment for website server

### DIFF
--- a/website/server/cloudbuild.yaml
+++ b/website/server/cloudbuild.yaml
@@ -67,8 +67,8 @@ steps:
       - '$_REGION-docker.pkg.dev/$PROJECT_ID/repomix/server:latest'
 
 substitutions:
-  _REGION: asia-northeast1
-  _SERVICE_NAME: repomix-server
+  _REGION: us-central1
+  _SERVICE_NAME: repomix-server-us
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
This PR updates the Cloud Build configuration to enable deployment of the website server to the US Central region for improved performance for US-based users.

## Changes
- Update Cloud Build region from `asia-northeast1` to `us-central1`
- Update service name from `repomix-server` to `repomix-server-us`

## Motivation
This change allows deploying the Repomix website server to a US region, which will provide better latency and performance for users accessing the service from the United States.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`