### PR TITLE
chore(website): Update repomix dependency to v1.4.1

### DIFF
--- a/website/server/package-lock.json
+++ b/website/server/package-lock.json
@@ -10,7 +10,7 @@
         "@hono/node-server": "^1.16.0",
         "fflate": "^0.8.2",
         "hono": "^4.8.5",
-        "repomix": "^1.4.0",
+        "repomix": "^1.4.1",
         "winston": "^3.17.0",
         "zod": "^3.24.1"
       },
@@ -3522,9 +3522,9 @@
       }
     },
     "node_modules/repomix": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/repomix/-/repomix-1.4.0.tgz",
-      "integrity": "sha512-n3Yzmbh4AonDIJ6eRjySIJ5fnUD5LxmgAMqB6B2UWsfhzuZbNS8/LwhcgUtMEREmJlUjifQWTPJ+6x27lMorJQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/repomix/-/repomix-1.4.1.tgz",
+      "integrity": "sha512-ORx7d1HiyW+yki47sr06thMOPeXRQhInimBB9RlrAwQeDampyvXS+9DLOuJoMsC6K0GyedKnx/4yFrF4aAOiaQ==",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.10.1",

--- a/website/server/package.json
+++ b/website/server/package.json
@@ -16,7 +16,7 @@
     "@hono/node-server": "^1.16.0",
     "fflate": "^0.8.2",
     "hono": "^4.8.5",
-    "repomix": "^1.4.0",
+    "repomix": "^1.4.1",
     "winston": "^3.17.0",
     "zod": "^3.24.1"
   },


### PR DESCRIPTION
This PR updates the repomix dependency in the website server from v1.4.0 to v1.4.1 to incorporate the latest bug fixes and improvements.

## Changes
- Updated `repomix` dependency from `^1.4.0` to `^1.4.1` in website/server/package.json
- Updated corresponding package-lock.json with new version and integrity hash

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`