### PR TITLE
refactor(core): Consolidate worker pool arguments into WorkerOptions interface

### DIFF
--- a/benchmarks/memory/src/memory-test.ts
+++ b/benchmarks/memory/src/memory-test.ts
@@ -26,7 +26,7 @@ const flags = {
 
 // Extract numeric arguments
 const numericArgs = args.filter((arg) => !arg.startsWith('-') && !Number.isNaN(Number(arg)));
-const iterations = Number(numericArgs[0]) || (flags.full ? 200 : 50);
+const iterations = Number(numericArgs[0]) || (flags.full ? 200 : 100);
 const delay = Number(numericArgs[1]) || (flags.full ? 100 : 50);
 
 // Configuration

--- a/src/core/file/fileCollect.ts
+++ b/src/core/file/fileCollect.ts
@@ -23,11 +23,11 @@ export const collectFiles = async (
     initTaskRunner,
   },
 ): Promise<FileCollectResults> => {
-  const taskRunner = deps.initTaskRunner<FileCollectTask, FileCollectResult>(
-    filePaths.length,
-    new URL('./workers/fileCollectWorker.js', import.meta.url).href,
-    'worker_threads',
-  );
+  const taskRunner = deps.initTaskRunner<FileCollectTask, FileCollectResult>({
+    numOfTasks: filePaths.length,
+    workerPath: new URL('./workers/fileCollectWorker.js', import.meta.url).href,
+    runtime: 'worker_threads',
+  });
   const tasks = filePaths.map(
     (filePath) =>
       ({

--- a/src/core/file/fileCollect.ts
+++ b/src/core/file/fileCollect.ts
@@ -26,6 +26,7 @@ export const collectFiles = async (
   const taskRunner = deps.initTaskRunner<FileCollectTask, FileCollectResult>(
     filePaths.length,
     new URL('./workers/fileCollectWorker.js', import.meta.url).href,
+    'worker_threads',
   );
   const tasks = filePaths.map(
     (filePath) =>

--- a/src/core/file/fileProcess.ts
+++ b/src/core/file/fileProcess.ts
@@ -21,10 +21,10 @@ export const processFiles = async (
     getFileManipulator,
   },
 ): Promise<ProcessedFile[]> => {
-  const taskRunner = deps.initTaskRunner<FileProcessTask, ProcessedFile>(
-    rawFiles.length,
-    new URL('./workers/fileProcessWorker.js', import.meta.url).href,
-  );
+  const taskRunner = deps.initTaskRunner<FileProcessTask, ProcessedFile>({
+    numOfTasks: rawFiles.length,
+    workerPath: new URL('./workers/fileProcessWorker.js', import.meta.url).href,
+  });
   const tasks = rawFiles.map(
     (rawFile, _index) =>
       ({

--- a/src/core/file/globbyExecute.ts
+++ b/src/core/file/globbyExecute.ts
@@ -13,10 +13,10 @@ export const executeGlobbyInWorker = async (
     initTaskRunner,
   },
 ): Promise<string[]> => {
-  const taskRunner = deps.initTaskRunner<GlobbyTask, string[]>(
-    1,
-    new URL('./workers/globbyWorker.js', import.meta.url).href,
-  );
+  const taskRunner = deps.initTaskRunner<GlobbyTask, string[]>({
+    numOfTasks: 1,
+    workerPath: new URL('./workers/globbyWorker.js', import.meta.url).href,
+  });
 
   try {
     logger.trace('Starting globby in worker for memory isolation');

--- a/src/core/metrics/calculateGitDiffMetrics.ts
+++ b/src/core/metrics/calculateGitDiffMetrics.ts
@@ -23,10 +23,10 @@ export const calculateGitDiffMetrics = async (
     return 0;
   }
 
-  const taskRunner = deps.initTaskRunner<GitDiffMetricsTask, number>(
-    1, // Single task for git diff calculation
-    new URL('./workers/gitDiffMetricsWorker.js', import.meta.url).href,
-  );
+  const taskRunner = deps.initTaskRunner<GitDiffMetricsTask, number>({
+    numOfTasks: 1, // Single task for git diff calculation
+    workerPath: new URL('./workers/gitDiffMetricsWorker.js', import.meta.url).href,
+  });
 
   try {
     const startTime = process.hrtime.bigint();

--- a/src/core/metrics/calculateGitLogMetrics.ts
+++ b/src/core/metrics/calculateGitLogMetrics.ts
@@ -28,10 +28,10 @@ export const calculateGitLogMetrics = async (
     };
   }
 
-  const taskRunner = deps.initTaskRunner<GitLogMetricsTask, number>(
-    1, // Single task for git log calculation
-    new URL('./workers/gitLogMetricsWorker.js', import.meta.url).href,
-  );
+  const taskRunner = deps.initTaskRunner<GitLogMetricsTask, number>({
+    numOfTasks: 1, // Single task for git log calculation
+    workerPath: new URL('./workers/gitLogMetricsWorker.js', import.meta.url).href,
+  });
 
   try {
     const startTime = process.hrtime.bigint();

--- a/src/core/metrics/calculateOutputMetrics.ts
+++ b/src/core/metrics/calculateOutputMetrics.ts
@@ -16,10 +16,10 @@ export const calculateOutputMetrics = async (
 ): Promise<number> => {
   const shouldRunInParallel = content.length > MIN_CONTENT_LENGTH_FOR_PARALLEL;
   const numOfTasks = shouldRunInParallel ? CHUNK_SIZE : 1;
-  const taskRunner = deps.initTaskRunner<OutputMetricsTask, number>(
+  const taskRunner = deps.initTaskRunner<OutputMetricsTask, number>({
     numOfTasks,
-    new URL('./workers/outputMetricsWorker.js', import.meta.url).href,
-  );
+    workerPath: new URL('./workers/outputMetricsWorker.js', import.meta.url).href,
+  });
 
   try {
     logger.trace(`Starting output token count for ${path || 'output'}`);

--- a/src/core/metrics/calculateSelectiveFileMetrics.ts
+++ b/src/core/metrics/calculateSelectiveFileMetrics.ts
@@ -23,10 +23,10 @@ export const calculateSelectiveFileMetrics = async (
     return [];
   }
 
-  const taskRunner = deps.initTaskRunner<FileMetricsTask, FileMetrics>(
-    filesToProcess.length,
-    new URL('./workers/fileMetricsWorker.js', import.meta.url).href,
-  );
+  const taskRunner = deps.initTaskRunner<FileMetricsTask, FileMetrics>({
+    numOfTasks: filesToProcess.length,
+    workerPath: new URL('./workers/fileMetricsWorker.js', import.meta.url).href,
+  });
   const tasks = filesToProcess.map(
     (file, index) =>
       ({

--- a/src/core/security/securityCheck.ts
+++ b/src/core/security/securityCheck.ts
@@ -55,10 +55,10 @@ export const runSecurityCheck = async (
     }
   }
 
-  const taskRunner = deps.initTaskRunner<SecurityCheckTask, SuspiciousFileResult | null>(
-    rawFiles.length + gitDiffTasks.length + gitLogTasks.length,
-    new URL('./workers/securityCheckWorker.js', import.meta.url).href,
-  );
+  const taskRunner = deps.initTaskRunner<SecurityCheckTask, SuspiciousFileResult | null>({
+    numOfTasks: rawFiles.length + gitDiffTasks.length + gitLogTasks.length,
+    workerPath: new URL('./workers/securityCheckWorker.js', import.meta.url).href,
+  });
   const fileTasks = rawFiles.map(
     (file) =>
       ({

--- a/tests/core/file/fileCollect.test.ts
+++ b/tests/core/file/fileCollect.test.ts
@@ -9,6 +9,7 @@ import { collectFiles } from '../../../src/core/file/fileCollect.js';
 import type { FileCollectTask } from '../../../src/core/file/workers/fileCollectWorker.js';
 import fileCollectWorker from '../../../src/core/file/workers/fileCollectWorker.js';
 import { logger } from '../../../src/shared/logger.js';
+import type { WorkerRuntime } from '../../../src/shared/processConcurrency.js';
 import { createMockConfig } from '../../testing/testUtils.js';
 
 // Define the max file size constant for tests
@@ -20,7 +21,21 @@ vi.mock('jschardet');
 vi.mock('iconv-lite');
 vi.mock('../../../src/shared/logger');
 
-const mockInitTaskRunner = <T, R>(_numOfTasks: number, _workerPath: string) => {
+interface MockInitTaskRunner {
+  <T, R>(
+    numOfTasks: number,
+    workerPath: string,
+    runtime?: WorkerRuntime,
+  ): {
+    run: (task: T) => Promise<R>;
+    cleanup: () => Promise<void>;
+  };
+  lastRuntime?: WorkerRuntime;
+}
+
+const mockInitTaskRunner = <T, R>(_numOfTasks: number, _workerPath: string, runtime?: WorkerRuntime) => {
+  // Store runtime for verification in tests
+  (mockInitTaskRunner as MockInitTaskRunner).lastRuntime = runtime;
   return {
     run: async (task: T) => {
       return (await fileCollectWorker(task as FileCollectTask)) as R;
@@ -194,5 +209,22 @@ describe('fileCollect', () => {
       `Failed to read file: ${path.resolve('/root/error.txt')}`,
       expect.any(Error),
     );
+  });
+
+  it('should use worker_threads runtime when calling initTaskRunner', async () => {
+    const mockFilePaths = ['test.txt'];
+    const mockRootDir = '/root';
+    const mockConfig = createMockConfig();
+
+    vi.mocked(isBinary).mockReturnValue(false);
+    vi.mocked(fs.readFile).mockResolvedValue(Buffer.from('file content'));
+    vi.mocked(jschardet.detect).mockReturnValue({ encoding: 'utf-8', confidence: 0.99 });
+    vi.mocked(iconv.decode).mockReturnValue('decoded content');
+
+    await collectFiles(mockFilePaths, mockRootDir, mockConfig, () => {}, {
+      initTaskRunner: mockInitTaskRunner,
+    });
+
+    expect((mockInitTaskRunner as MockInitTaskRunner).lastRuntime).toBe('worker_threads');
   });
 });

--- a/tests/core/file/fileProcess.test.ts
+++ b/tests/core/file/fileProcess.test.ts
@@ -5,6 +5,7 @@ import { processContent } from '../../../src/core/file/fileProcessContent.js';
 import type { RawFile } from '../../../src/core/file/fileTypes.js';
 import type { FileProcessTask } from '../../../src/core/file/workers/fileProcessWorker.js';
 import fileProcessWorker from '../../../src/core/file/workers/fileProcessWorker.js';
+import type { WorkerRuntime } from '../../../src/shared/processConcurrency.js';
 import { createMockConfig } from '../../testing/testUtils.js';
 
 const createMockFileManipulator = (): FileManipulator => ({
@@ -19,7 +20,7 @@ const mockGetFileManipulator = (filePath: string): FileManipulator | null => {
   return null;
 };
 
-const mockInitTaskRunner = <T, R>(_numOfTasks: number, _workerPath: string) => {
+const mockInitTaskRunner = <T, R>(_numOfTasks: number, _workerPath: string, _runtime?: WorkerRuntime) => {
   return {
     run: async (task: T) => {
       return (await fileProcessWorker(task as FileProcessTask)) as R;

--- a/tests/core/metrics/calculateOutputMetrics.test.ts
+++ b/tests/core/metrics/calculateOutputMetrics.test.ts
@@ -3,10 +3,11 @@ import { calculateOutputMetrics } from '../../../src/core/metrics/calculateOutpu
 import type { OutputMetricsTask } from '../../../src/core/metrics/workers/outputMetricsWorker.js';
 import outputMetricsWorker from '../../../src/core/metrics/workers/outputMetricsWorker.js';
 import { logger } from '../../../src/shared/logger.js';
+import type { WorkerRuntime } from '../../../src/shared/processConcurrency.js';
 
 vi.mock('../../../src/shared/logger');
 
-const mockInitTaskRunner = <T, R>(_numOfTasks: number, _workerPath: string) => {
+const mockInitTaskRunner = <T, R>(_numOfTasks: number, _workerPath: string, _runtime?: WorkerRuntime) => {
   return {
     run: async (task: T) => {
       return (await outputMetricsWorker(task as OutputMetricsTask)) as R;
@@ -46,7 +47,7 @@ describe('calculateOutputMetrics', () => {
     const encoding = 'o200k_base';
     const mockError = new Error('Worker error');
 
-    const mockErrorTaskRunner = <T, _R>(_numOfTasks: number, _workerPath: string) => {
+    const mockErrorTaskRunner = <T, _R>(_numOfTasks: number, _workerPath: string, _runtime?: WorkerRuntime) => {
       return {
         run: async (_task: T) => {
           throw mockError;
@@ -96,7 +97,7 @@ describe('calculateOutputMetrics', () => {
     const path = 'large-file.txt';
 
     let chunksProcessed = 0;
-    const mockParallelTaskRunner = <T, R>(_numOfTasks: number, _workerPath: string) => {
+    const mockParallelTaskRunner = <T, R>(_numOfTasks: number, _workerPath: string, _runtime?: WorkerRuntime) => {
       return {
         run: async (_task: T) => {
           chunksProcessed++;
@@ -122,7 +123,7 @@ describe('calculateOutputMetrics', () => {
     const encoding = 'o200k_base';
     const mockError = new Error('Parallel processing error');
 
-    const mockErrorTaskRunner = <T, _R>(_numOfTasks: number, _workerPath: string) => {
+    const mockErrorTaskRunner = <T, _R>(_numOfTasks: number, _workerPath: string, _runtime?: WorkerRuntime) => {
       return {
         run: async (_task: T) => {
           throw mockError;
@@ -147,7 +148,7 @@ describe('calculateOutputMetrics', () => {
     const encoding = 'o200k_base';
     const processedChunks: string[] = [];
 
-    const mockChunkTrackingTaskRunner = <T, R>(_numOfTasks: number, _workerPath: string) => {
+    const mockChunkTrackingTaskRunner = <T, R>(_numOfTasks: number, _workerPath: string, _runtime?: WorkerRuntime) => {
       return {
         run: async (task: T) => {
           const outputTask = task as OutputMetricsTask;

--- a/tests/core/metrics/calculateSelectiveFileMetrics.test.ts
+++ b/tests/core/metrics/calculateSelectiveFileMetrics.test.ts
@@ -3,13 +3,14 @@ import type { ProcessedFile } from '../../../src/core/file/fileTypes.js';
 import { calculateSelectiveFileMetrics } from '../../../src/core/metrics/calculateSelectiveFileMetrics.js';
 import type { FileMetricsTask } from '../../../src/core/metrics/workers/fileMetricsWorker.js';
 import fileMetricsWorker from '../../../src/core/metrics/workers/fileMetricsWorker.js';
+import type { WorkerRuntime } from '../../../src/shared/processConcurrency.js';
 import type { RepomixProgressCallback } from '../../../src/shared/types.js';
 
 vi.mock('../../shared/processConcurrency', () => ({
   getProcessConcurrency: () => 1,
 }));
 
-const mockInitTaskRunner = <T, R>(_numOfTasks: number, _workerPath: string) => {
+const mockInitTaskRunner = <T, R>(_numOfTasks: number, _workerPath: string, _runtime?: WorkerRuntime) => {
   return {
     run: async (task: T) => {
       return (await fileMetricsWorker(task as FileMetricsTask)) as R;

--- a/tests/core/security/securityCheck.test.ts
+++ b/tests/core/security/securityCheck.test.ts
@@ -9,6 +9,7 @@ import type { SecurityCheckTask } from '../../../src/core/security/workers/secur
 import securityCheckWorker from '../../../src/core/security/workers/securityCheckWorker.js';
 import { logger } from '../../../src/shared/logger.js';
 import { repomixLogLevels } from '../../../src/shared/logger.js';
+import type { WorkerRuntime } from '../../../src/shared/processConcurrency.js';
 
 vi.mock('../../../src/shared/logger');
 vi.mock('../../../src/shared/processConcurrency', () => ({
@@ -39,7 +40,7 @@ const mockFiles: RawFile[] = [
   },
 ];
 
-const mockInitTaskRunner = <T, R>(_numOfTasks: number, _workerPath: string) => {
+const mockInitTaskRunner = <T, R>(_numOfTasks: number, _workerPath: string, _runtime?: WorkerRuntime) => {
   return {
     run: async (task: T) => {
       return (await securityCheckWorker(task as SecurityCheckTask)) as R;
@@ -78,7 +79,7 @@ describe('runSecurityCheck', () => {
 
   it('should handle worker errors gracefully', async () => {
     const mockError = new Error('Worker error');
-    const mockErrorTaskRunner = () => {
+    const mockErrorTaskRunner = (_numOfTasks?: number, _workerPath?: string, _runtime?: WorkerRuntime) => {
       return {
         run: async () => {
           throw mockError;

--- a/tests/integration-tests/packager.test.ts
+++ b/tests/integration-tests/packager.test.ts
@@ -24,13 +24,14 @@ import { copyToClipboardIfEnabled } from '../../src/core/packager/copyToClipboar
 import { writeOutputToDisk } from '../../src/core/packager/writeOutputToDisk.js';
 import { filterOutUntrustedFiles } from '../../src/core/security/filterOutUntrustedFiles.js';
 import { validateFileSafety } from '../../src/core/security/validateFileSafety.js';
+import type { WorkerRuntime } from '../../src/shared/processConcurrency.js';
 import { isWindows } from '../testing/testUtils.js';
 
 const fixturesDir = path.join(__dirname, 'fixtures', 'packager');
 const inputsDir = path.join(fixturesDir, 'inputs');
 const outputsDir = path.join(fixturesDir, 'outputs');
 
-const mockCollectFileInitTaskRunner = <T, R>(_numOfTasks: number, _workerPath: string) => {
+const mockCollectFileInitTaskRunner = <T, R>(_numOfTasks: number, _workerPath: string, _runtime?: WorkerRuntime) => {
   return {
     run: async (task: T) => {
       return (await fileCollectWorker(task as FileCollectTask)) as R;

--- a/tests/shared/processConcurrency.test.ts
+++ b/tests/shared/processConcurrency.test.ts
@@ -87,6 +87,23 @@ describe('processConcurrency', () => {
       });
       expect(tinypool).toBeDefined();
     });
+
+    it('should initialize Tinypool with worker_threads runtime when specified', () => {
+      const workerPath = '/path/to/worker.js';
+      const tinypool = createWorkerPool(500, workerPath, 'worker_threads');
+
+      expect(Tinypool).toHaveBeenCalledWith({
+        filename: workerPath,
+        runtime: 'worker_threads',
+        minThreads: 1,
+        maxThreads: 4, // Math.min(4, 500/100) = 4
+        idleTimeout: 5000,
+        workerData: {
+          logLevel: 2,
+        },
+      });
+      expect(tinypool).toBeDefined();
+    });
   });
 
   describe('initTaskRunner', () => {
@@ -109,6 +126,19 @@ describe('processConcurrency', () => {
       expect(taskRunner).toHaveProperty('cleanup');
       expect(typeof taskRunner.run).toBe('function');
       expect(typeof taskRunner.cleanup).toBe('function');
+    });
+
+    it('should pass runtime parameter to createWorkerPool', () => {
+      const workerPath = '/path/to/worker.js';
+      const taskRunner = initTaskRunner(100, workerPath, 'worker_threads');
+
+      expect(Tinypool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runtime: 'worker_threads',
+        }),
+      );
+      expect(taskRunner).toHaveProperty('run');
+      expect(taskRunner).toHaveProperty('cleanup');
     });
   });
 });

--- a/tests/shared/processConcurrency.test.ts
+++ b/tests/shared/processConcurrency.test.ts
@@ -73,7 +73,7 @@ describe('processConcurrency', () => {
 
     it('should initialize Tinypool with correct configuration', () => {
       const workerPath = '/path/to/worker.js';
-      const tinypool = createWorkerPool(500, workerPath);
+      const tinypool = createWorkerPool({ numOfTasks: 500, workerPath });
 
       expect(Tinypool).toHaveBeenCalledWith({
         filename: workerPath,
@@ -90,7 +90,7 @@ describe('processConcurrency', () => {
 
     it('should initialize Tinypool with worker_threads runtime when specified', () => {
       const workerPath = '/path/to/worker.js';
-      const tinypool = createWorkerPool(500, workerPath, 'worker_threads');
+      const tinypool = createWorkerPool({ numOfTasks: 500, workerPath, runtime: 'worker_threads' });
 
       expect(Tinypool).toHaveBeenCalledWith({
         filename: workerPath,
@@ -120,7 +120,7 @@ describe('processConcurrency', () => {
 
     it('should return a TaskRunner with run and cleanup methods', () => {
       const workerPath = '/path/to/worker.js';
-      const taskRunner = initTaskRunner(100, workerPath);
+      const taskRunner = initTaskRunner({ numOfTasks: 100, workerPath });
 
       expect(taskRunner).toHaveProperty('run');
       expect(taskRunner).toHaveProperty('cleanup');
@@ -130,7 +130,7 @@ describe('processConcurrency', () => {
 
     it('should pass runtime parameter to createWorkerPool', () => {
       const workerPath = '/path/to/worker.js';
-      const taskRunner = initTaskRunner(100, workerPath, 'worker_threads');
+      const taskRunner = initTaskRunner({ numOfTasks: 100, workerPath, runtime: 'worker_threads' });
 
       expect(Tinypool).toHaveBeenCalledWith(
         expect.objectContaining({


### PR DESCRIPTION
Consolidates the arguments for `createWorkerPool` and `initTaskRunner` functions into a single `WorkerOptions` interface for improved type safety and usability.

## Changes

- **Added `WorkerOptions` interface** with `numOfTasks`, `workerPath`, and optional `runtime` properties
- **Refactored `createWorkerPool`** to accept a single `WorkerOptions` object instead of separate parameters
- **Refactored `initTaskRunner`** to use the same `WorkerOptions` interface
- **Updated all call sites** across the codebase to use the new interface:
  - File collection and processing workers
  - Metrics calculation workers (git diff, git log, output, selective file metrics)
  - Security check workers
  - Globby execution workers
- **Updated tests** to reflect the new API

## Benefits

- **Improved type safety**: Named parameters prevent argument order mistakes
- **Better readability**: Clear parameter names make code more self-documenting
- **Enhanced maintainability**: Consistent interface across all worker pool usage
- **Future extensibility**: Easy to add new options without breaking existing code

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`