### PR TITLE
chore(ci): Remove end-of-life Node.js versions 21 and 23 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [20.x, 21.x, 22.x, 23.x, 24.x]
+        node-version: [20.x, 22.x, 24.x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
@@ -209,7 +209,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [20.x, 21.x, 22.x, 23.x, 24.x]
+        node-version: [20.x, 22.x, 24.x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4


### PR DESCRIPTION
This PR removes Node.js versions 21 and 23 from the CI test matrix as they have reached end-of-life status and are no longer supported by the Node.js project.

## Changes
- Removed Node.js 21.x and 23.x from the test matrix in `.github/workflows/ci.yml`
- Updated both the `test` and `build-and-run` job matrices
- CI now tests only currently supported versions: 20.x (LTS), 22.x (Active LTS), and 24.x (Current)

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`