### PR TITLE
chore(config): Add minimum release age to Renovate config for security

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,5 +16,6 @@
   ],
   "ignoreDeps": [
     "node",
-  ]
+  ],
+  "minimumReleaseAge": "7 days"
 }


### PR DESCRIPTION
## Summary

Add `minimumReleaseAge: "7 days"` to the Renovate configuration to enhance security by introducing a waiting period before automatically updating dependencies.

This change ensures that newly released packages have time for potential security issues to be discovered and reported before being automatically adopted in our project.

## Changes

- Added `minimumReleaseAge: "7 days"` to `.github/renovate.json5`
- This applies to all dependency updates managed by Renovate

## Benefits

- **Security**: Reduces risk of immediately adopting packages with undiscovered vulnerabilities
- **Stability**: Allows community feedback and bug reports to surface before updates
- **Best Practice**: Follows security-conscious dependency management practices

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`