### PR TITLE
fix(mcp): remove redundant structuredContent from error response

### DIFF
--- a/src/mcp/tools/mcpToolRuntime.ts
+++ b/src/mcp/tools/mcpToolRuntime.ts
@@ -242,5 +242,7 @@ export const buildMcpToolErrorResponse = (structuredContent: McpToolStructuredCo
         text: textContent,
       },
     ],
+    // structuredContent is intentionally omitted for error responses
+    // Error messages have different schema than success responses and may cause validation issues
   };
 };

--- a/src/mcp/tools/mcpToolRuntime.ts
+++ b/src/mcp/tools/mcpToolRuntime.ts
@@ -242,6 +242,5 @@ export const buildMcpToolErrorResponse = (structuredContent: McpToolStructuredCo
         text: textContent,
       },
     ],
-    structuredContent: structuredContent,
   };
 };

--- a/tests/mcp/tools/fileSystemReadDirectoryTool.test.ts
+++ b/tests/mcp/tools/fileSystemReadDirectoryTool.test.ts
@@ -46,9 +46,9 @@ describe('FileSystemReadDirectoryTool', () => {
           text: JSON.stringify({ errorMessage: `Error: Path must be absolute. Received: ${testPath}` }, null, 2),
         },
       ],
-      structuredContent: {
-        errorMessage: `Error: Path must be absolute. Received: ${testPath}`,
-      },
+      // structuredContent: {
+      //   errorMessage: `Error: Path must be absolute. Received: ${testPath}`,
+      // },
     });
   });
 
@@ -67,9 +67,9 @@ describe('FileSystemReadDirectoryTool', () => {
           text: JSON.stringify({ errorMessage: `Error: Directory not found at path: ${testPath}` }, null, 2),
         },
       ],
-      structuredContent: {
-        errorMessage: `Error: Directory not found at path: ${testPath}`,
-      },
+      // structuredContent: {
+      //   errorMessage: `Error: Directory not found at path: ${testPath}`,
+      // },
     });
   });
 });

--- a/tests/mcp/tools/fileSystemReadDirectoryTool.test.ts
+++ b/tests/mcp/tools/fileSystemReadDirectoryTool.test.ts
@@ -46,9 +46,6 @@ describe('FileSystemReadDirectoryTool', () => {
           text: JSON.stringify({ errorMessage: `Error: Path must be absolute. Received: ${testPath}` }, null, 2),
         },
       ],
-      // structuredContent: {
-      //   errorMessage: `Error: Path must be absolute. Received: ${testPath}`,
-      // },
     });
   });
 
@@ -67,9 +64,6 @@ describe('FileSystemReadDirectoryTool', () => {
           text: JSON.stringify({ errorMessage: `Error: Directory not found at path: ${testPath}` }, null, 2),
         },
       ],
-      // structuredContent: {
-      //   errorMessage: `Error: Directory not found at path: ${testPath}`,
-      // },
     });
   });
 });

--- a/tests/mcp/tools/fileSystemReadFileTool.test.ts
+++ b/tests/mcp/tools/fileSystemReadFileTool.test.ts
@@ -46,9 +46,6 @@ describe('FileSystemReadFileTool', () => {
           text: JSON.stringify({ errorMessage: `Error: Path must be absolute. Received: ${testPath}` }, null, 2),
         },
       ],
-      // structuredContent: {
-      //   errorMessage: `Error: Path must be absolute. Received: ${testPath}`,
-      // },
     });
   });
 
@@ -67,9 +64,6 @@ describe('FileSystemReadFileTool', () => {
           text: JSON.stringify({ errorMessage: `Error: File not found at path: ${testPath}` }, null, 2),
         },
       ],
-      // structuredContent: {
-      //   errorMessage: `Error: File not found at path: ${testPath}`,
-      // },
     });
   });
 });

--- a/tests/mcp/tools/fileSystemReadFileTool.test.ts
+++ b/tests/mcp/tools/fileSystemReadFileTool.test.ts
@@ -46,9 +46,9 @@ describe('FileSystemReadFileTool', () => {
           text: JSON.stringify({ errorMessage: `Error: Path must be absolute. Received: ${testPath}` }, null, 2),
         },
       ],
-      structuredContent: {
-        errorMessage: `Error: Path must be absolute. Received: ${testPath}`,
-      },
+      // structuredContent: {
+      //   errorMessage: `Error: Path must be absolute. Received: ${testPath}`,
+      // },
     });
   });
 
@@ -67,9 +67,9 @@ describe('FileSystemReadFileTool', () => {
           text: JSON.stringify({ errorMessage: `Error: File not found at path: ${testPath}` }, null, 2),
         },
       ],
-      structuredContent: {
-        errorMessage: `Error: File not found at path: ${testPath}`,
-      },
+      // structuredContent: {
+      //   errorMessage: `Error: File not found at path: ${testPath}`,
+      // },
     });
   });
 });

--- a/tests/mcp/tools/mcpToolRuntime.test.ts
+++ b/tests/mcp/tools/mcpToolRuntime.test.ts
@@ -296,7 +296,6 @@ describe('mcpToolRuntime', () => {
             text: JSON.stringify(errorContent, null, 2),
           },
         ],
-        // structuredContent: errorContent,
       });
     });
 
@@ -316,7 +315,6 @@ describe('mcpToolRuntime', () => {
             text: JSON.stringify(errorContent, null, 2),
           },
         ],
-        // structuredContent: errorContent,
       });
     });
 

--- a/tests/mcp/tools/mcpToolRuntime.test.ts
+++ b/tests/mcp/tools/mcpToolRuntime.test.ts
@@ -296,7 +296,7 @@ describe('mcpToolRuntime', () => {
             text: JSON.stringify(errorContent, null, 2),
           },
         ],
-        structuredContent: errorContent,
+        // structuredContent: errorContent,
       });
     });
 
@@ -316,7 +316,7 @@ describe('mcpToolRuntime', () => {
             text: JSON.stringify(errorContent, null, 2),
           },
         ],
-        structuredContent: errorContent,
+        // structuredContent: errorContent,
       });
     });
 


### PR DESCRIPTION
This pull request makes a small change to the `buildMcpToolErrorResponse` function in `mcpToolRuntime.ts`, removing the unnecessary inclusion of the `structuredContent` property from the returned object.

Fix https://github.com/yamadashy/repomix/issues/833

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
