### PR TITLE
feat(mcp): add style parameter support to MCP tools

### DIFF
--- a/src/mcp/tools/packCodebaseTool.ts
+++ b/src/mcp/tools/packCodebaseTool.ts
@@ -4,6 +4,7 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { runCli } from '../../cli/cliRun.js';
 import type { CliOptions } from '../../cli/types.js';
+import { defaultFilePathMap, repomixOutputStyleSchema } from '../../config/configSchema.js';
 import {
   buildMcpToolErrorResponse,
   convertErrorToJson,
@@ -36,6 +37,12 @@ const packCodebaseInputSchema = z.object({
     .optional()
     .default(10)
     .describe('Number of largest files by size to display in the metrics summary for codebase analysis (default: 10)'),
+  style: repomixOutputStyleSchema
+    .optional()
+    .default('xml')
+    .describe(
+      'Output format style: xml (structured tags, default), markdown (human-readable with code blocks), json (machine-readable key-value), or plain (simple text with separators)',
+    ),
 });
 
 const packCodebaseOutputSchema = z.object({
@@ -54,7 +61,7 @@ export const registerPackCodebaseTool = (mcpServer: McpServer) => {
     {
       title: 'Pack Local Codebase',
       description:
-        'Package a local code directory into a consolidated XML file for AI analysis. This tool analyzes the codebase structure, extracts relevant code content, and generates a comprehensive report including metrics, file tree, and formatted code content. Supports Tree-sitter compression for efficient token usage.',
+        'Package a local code directory into a consolidated file for AI analysis. This tool analyzes the codebase structure, extracts relevant code content, and generates a comprehensive report including metrics, file tree, and formatted code content. Supports multiple output formats: XML (structured with <file> tags), Markdown (human-readable with ## headers and code blocks), JSON (machine-readable with files as key-value pairs), and Plain text (simple format with separators). Also supports Tree-sitter compression for efficient token usage.',
       inputSchema: packCodebaseInputSchema.shape,
       outputSchema: packCodebaseOutputSchema.shape,
       annotations: {
@@ -64,19 +71,27 @@ export const registerPackCodebaseTool = (mcpServer: McpServer) => {
         openWorldHint: false,
       },
     },
-    async ({ directory, compress, includePatterns, ignorePatterns, topFilesLength }): Promise<CallToolResult> => {
+    async ({
+      directory,
+      compress,
+      includePatterns,
+      ignorePatterns,
+      topFilesLength,
+      style,
+    }): Promise<CallToolResult> => {
       let tempDir = '';
 
       try {
         tempDir = await createToolWorkspace();
-        const outputFilePath = path.join(tempDir, 'repomix-output.xml');
+        const outputFileName = defaultFilePathMap[style || 'xml'];
+        const outputFilePath = path.join(tempDir, outputFileName);
 
         const cliOptions = {
           compress,
           include: includePatterns,
           ignore: ignorePatterns,
           output: outputFilePath,
-          style: 'xml',
+          style: style || 'xml',
           securityCheck: true,
           topFilesLen: topFilesLength,
           quiet: true,

--- a/src/mcp/tools/packRemoteRepositoryTool.ts
+++ b/src/mcp/tools/packRemoteRepositoryTool.ts
@@ -4,6 +4,7 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { runCli } from '../../cli/cliRun.js';
 import type { CliOptions } from '../../cli/types.js';
+import { defaultFilePathMap, repomixOutputStyleSchema } from '../../config/configSchema.js';
 import {
   buildMcpToolErrorResponse,
   convertErrorToJson,
@@ -40,6 +41,12 @@ const packRemoteRepositoryInputSchema = z.object({
     .optional()
     .default(10)
     .describe('Number of largest files by size to display in the metrics summary for codebase analysis (default: 10)'),
+  style: repomixOutputStyleSchema
+    .optional()
+    .default('xml')
+    .describe(
+      'Output format style: xml (structured tags, default), markdown (human-readable with code blocks), json (machine-readable key-value), or plain (simple text with separators)',
+    ),
 });
 
 const packRemoteRepositoryOutputSchema = z.object({
@@ -58,7 +65,7 @@ export const registerPackRemoteRepositoryTool = (mcpServer: McpServer) => {
     {
       title: 'Pack Remote Repository',
       description:
-        'Fetch, clone, and package a GitHub repository into a consolidated XML file for AI analysis. This tool automatically clones the remote repository, analyzes its structure, and generates a comprehensive report. Supports various GitHub URL formats and includes security checks to prevent exposure of sensitive information.',
+        'Fetch, clone, and package a GitHub repository into a consolidated file for AI analysis. This tool automatically clones the remote repository, analyzes its structure, and generates a comprehensive report. Supports multiple output formats: XML (structured with <file> tags), Markdown (human-readable with ## headers and code blocks), JSON (machine-readable with files as key-value pairs), and Plain text (simple format with separators). Also supports various GitHub URL formats and includes security checks to prevent exposure of sensitive information.',
       inputSchema: packRemoteRepositoryInputSchema.shape,
       outputSchema: packRemoteRepositoryOutputSchema.shape,
       annotations: {
@@ -68,12 +75,13 @@ export const registerPackRemoteRepositoryTool = (mcpServer: McpServer) => {
         openWorldHint: true,
       },
     },
-    async ({ remote, compress, includePatterns, ignorePatterns, topFilesLength }): Promise<CallToolResult> => {
+    async ({ remote, compress, includePatterns, ignorePatterns, topFilesLength, style }): Promise<CallToolResult> => {
       let tempDir = '';
 
       try {
         tempDir = await createToolWorkspace();
-        const outputFilePath = path.join(tempDir, 'repomix-output.xml');
+        const outputFileName = defaultFilePathMap[style || 'xml'];
+        const outputFilePath = path.join(tempDir, outputFileName);
 
         const cliOptions = {
           remote,
@@ -81,7 +89,7 @@ export const registerPackRemoteRepositoryTool = (mcpServer: McpServer) => {
           include: includePatterns,
           ignore: ignorePatterns,
           output: outputFilePath,
-          style: 'xml',
+          style: style || 'xml',
           securityCheck: true,
           topFilesLen: topFilesLength,
           quiet: true,

--- a/tests/mcp/tools/attachPackedOutputTool.test.ts
+++ b/tests/mcp/tools/attachPackedOutputTool.test.ts
@@ -45,6 +45,10 @@ describe('AttachPackedOutputTool', () => {
     vi.mocked(path.join).mockImplementation((...args) => args.join('/'));
     vi.mocked(path.basename).mockImplementation((p) => p.split('/').pop() || '');
     vi.mocked(path.dirname).mockImplementation((p) => p.split('/').slice(0, -1).join('/') || '.');
+    vi.mocked(path.extname).mockImplementation((p) => {
+      const parts = p.split('.');
+      return parts.length > 1 ? `.${parts[parts.length - 1]}` : '';
+    });
 
     // Mock fs functions
     vi.mocked(fs.stat).mockResolvedValue({
@@ -142,8 +146,8 @@ describe('AttachPackedOutputTool', () => {
     );
   });
 
-  test('should handle non-XML file error', async () => {
-    const testFilePath = '/test/not-xml-file.txt';
+  test('should handle non-supported file format error', async () => {
+    const testFilePath = '/test/not-supported-file.xyz';
 
     const result = await toolHandler({ path: testFilePath });
 


### PR DESCRIPTION
This PR adds support for specifying output format styles in MCP tools, allowing users to choose between XML, Markdown, JSON, and Plain text formats for their AI analysis workflows.

## Summary

- ✅ Added `style` parameter to `packCodebaseTool` and `packRemoteRepositoryTool`
- ✅ Enhanced `attachPackedOutputTool` to handle multiple input formats (xml, md, txt, json)
- ✅ Added detailed format descriptions to help users choose the right format:
  - **XML**: Structured with `<file>` tags (default)
  - **Markdown**: Human-readable with `##` headers and code blocks
  - **JSON**: Machine-readable with files as key-value pairs
  - **Plain**: Simple format with separators
- ✅ Implemented format-specific parsing functions for each output style
- ✅ Maintained backward compatibility with XML as the default format
- ✅ Updated tests to handle new function signatures

## Changes

### Modified Files
- `src/mcp/tools/packCodebaseTool.ts` - Added style parameter with detailed descriptions
- `src/mcp/tools/packRemoteRepositoryTool.ts` - Added style parameter with detailed descriptions
- `src/mcp/tools/attachPackedOutputTool.ts` - Added multi-format support and parsing functions
- `tests/mcp/tools/attachPackedOutputTool.test.ts` - Updated tests for new functionality

### New Features
- Style parameter defaults to 'xml' for backward compatibility
- Dynamic output filename based on selected style
- Comprehensive format-specific content parsing
- Enhanced tool descriptions explaining format differences

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`