### PR TITLE
feat(cli): add token count display for git logs

### DIFF
--- a/src/cli/cliReport.ts
+++ b/src/cli/cliReport.ts
@@ -79,6 +79,18 @@ export const reportSummary = (packResult: PackResult, config: RepomixConfigMerge
     }
     logger.log(`${pc.white('    Git Diffs:')} ${gitDiffsMessage}`);
   }
+
+  if (config.output.git?.includeLogs) {
+    let gitLogsMessage = '';
+    if (packResult.gitLogTokenCount) {
+      gitLogsMessage = pc.white(
+        `✔ Git logs included ${pc.dim(`(${packResult.gitLogTokenCount.toLocaleString()} tokens)`)}`,
+      );
+    } else {
+      gitLogsMessage = pc.dim('✖ No git logs included');
+    }
+    logger.log(`${pc.white('     Git Logs:')} ${gitLogsMessage}`);
+  }
 };
 
 export const reportSecurityCheck = (


### PR DESCRIPTION
This PR adds token count display for git logs in the CLI summary report, providing consistency with the existing git diffs token count display.

## Summary

- Add token count display for git logs in `reportSummary` function
- Display format: "✔ Git logs included (X tokens)" when logs are included
- Display format: "✖ No git logs included" when logs are not included  
- Only shows when `config.output.git?.includeLogs` is enabled
- Maintains consistency with existing git diffs display format

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`