### PR TITLE
fix(website): prevent Enter key from triggering cancel during pack processing

### DIFF
--- a/website/client/components/Home/PackButton.vue
+++ b/website/client/components/Home/PackButton.vue
@@ -28,7 +28,8 @@ const props = defineProps<{
 const emit = defineEmits<(e: 'cancel') => void>();
 
 function handleClick(event: MouseEvent) {
-  if (props.loading) {
+  // Only handle cancel on actual mouse clicks, not on form submission (Enter key)
+  if (props.loading && event.detail > 0) {
     event.preventDefault();
     event.stopPropagation();
     emit('cancel');


### PR DESCRIPTION
Fixes an issue where pressing Enter during pack processing would trigger the cancel functionality instead of allowing normal form submission.

## Summary

This PR addresses a UX issue where users pressing Enter while a pack request is processing would unintentionally cancel the request instead of submitting a new pack request.

### Key Changes

- **Event Handling**: Added `event.detail > 0` condition to distinguish between mouse clicks and keyboard events
- **Improved UX**: Enter key now properly submits new pack requests even during processing
- **Maintained Cancel Functionality**: Mouse clicks during processing still trigger cancel as intended

### Technical Implementation

The fix leverages the `MouseEvent.detail` property which is:
- `> 0` for actual mouse clicks → triggers cancel when loading
- `=== 0` for keyboard-triggered events (Enter key) → allows normal form submission

This ensures that:
- **Mouse clicks during processing**: Cancel the current request
- **Enter key during processing**: Submit a new pack request without canceling

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`