### PR TITLE
fix(cli): Move stdin processing to main process to resolve hang in child_process worker

### DIFF
--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -4,6 +4,7 @@ import { buildCliConfig, runDefaultAction } from '../../../src/cli/actions/defau
 import { Spinner } from '../../../src/cli/cliSpinner.js';
 import type { CliOptions } from '../../../src/cli/types.js';
 import * as configLoader from '../../../src/config/configLoad.js';
+import * as fileStdin from '../../../src/core/file/fileStdin.js';
 import * as packageJsonParser from '../../../src/core/file/packageJsonParse.js';
 import * as packager from '../../../src/core/packager.js';
 
@@ -13,6 +14,7 @@ import { createMockConfig } from '../../testing/testUtils.js';
 vi.mock('../../../src/core/packager');
 vi.mock('../../../src/config/configLoad');
 vi.mock('../../../src/core/file/packageJsonParse');
+vi.mock('../../../src/core/file/fileStdin');
 vi.mock('../../../src/shared/logger');
 vi.mock('../../../src/shared/processConcurrency');
 
@@ -85,6 +87,10 @@ describe('defaultAction', () => {
         },
       }),
     );
+    vi.mocked(fileStdin.readFilePathsFromStdin).mockResolvedValue({
+      filePaths: ['test1.txt', 'test2.txt'],
+      emptyDirPaths: [],
+    });
     vi.mocked(packager.pack).mockResolvedValue({
       totalFiles: 10,
       totalCharacters: 1000,
@@ -168,7 +174,6 @@ describe('defaultAction', () => {
       cliOptions: expect.objectContaining({
         include: '*.js,*.ts',
       }),
-      isStdin: false,
     });
   });
 
@@ -188,7 +193,7 @@ describe('defaultAction', () => {
       cliOptions: expect.objectContaining({
         stdin: true,
       }),
-      isStdin: true,
+      stdinFilePaths: expect.any(Array),
     });
   });
 


### PR DESCRIPTION
This PR fixes the `--stdin` option hang issue reported in #867.

## Summary

In v1.6.0, `defaultAction` was changed to run in a `child_process` worker for better resource isolation. However, `child_process` workers don't inherit stdin from the parent process by default, causing the worker to hang when trying to read from `process.stdin`.

## Changes

- Move stdin processing from worker to main process before worker creation
- Change `DefaultActionTask` interface from `isStdin` to `stdinFilePaths`
- Pass already-read file paths from stdin to the worker
- Maintain resource isolation benefits of child_process while restoring stdin functionality

## Technical Details

The root cause was that `readFilePathsFromStdin()` was called inside the child_process worker, but stdin was not inherited. The fix moves stdin reading to the main process and passes the file paths to the worker as a parameter.

This approach:
- ✅ Preserves child_process resource isolation and stability
- ✅ Minimal code changes
- ✅ Returns to v1.5.0-like behavior for stdin processing
- ✅ Lightweight stdin reading doesn't impact main process performance

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

Fixes #867