### PR TITLE
chore(core): Update web-tree-sitter from 0.24.7 to 0.25.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "tiktoken": "^1.0.22",
         "tinypool": "^2.0.0",
         "tree-sitter-wasms": "^0.1.12",
-        "web-tree-sitter": "^0.24.7",
+        "web-tree-sitter": "^0.25.10",
         "zod": "^3.24.3"
       },
       "bin": {
@@ -5916,10 +5916,18 @@
       }
     },
     "node_modules/web-tree-sitter": {
-      "version": "0.24.7",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.24.7.tgz",
-      "integrity": "sha512-CdC/TqVFbXqR+C51v38hv6wOPatKEUGxa39scAeFSm98wIhZxAYonhRQPSMmfZ2w7JDI0zQDdzdmgtNk06/krQ==",
-      "license": "MIT"
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
+      "integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/emscripten": "^1.40.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/emscripten": {
+          "optional": true
+        }
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "tiktoken": "^1.0.22",
     "tinypool": "^2.0.0",
     "tree-sitter-wasms": "^0.1.12",
-    "web-tree-sitter": "^0.24.7",
+    "web-tree-sitter": "^0.25.10",
     "zod": "^3.24.3"
   },
   "devDependencies": {

--- a/src/core/treeSitter/languageParser.ts
+++ b/src/core/treeSitter/languageParser.ts
@@ -1,5 +1,5 @@
 import * as path from 'node:path';
-import Parser from 'web-tree-sitter';
+import { Parser, Query } from 'web-tree-sitter';
 
 import { RepomixError } from '../../shared/errorHandle.js';
 import { logger } from '../../shared/logger.js';
@@ -11,7 +11,7 @@ import { createParseStrategy, type ParseStrategy } from './parseStrategies/Parse
 interface LanguageResources {
   lang: SupportedLang;
   parser: Parser;
-  query: Parser.Query;
+  query: Query;
   strategy: ParseStrategy;
 }
 
@@ -28,7 +28,7 @@ export class LanguageParser {
       const lang = await loadLanguage(name);
       const parser = new Parser();
       parser.setLanguage(lang);
-      const query = lang.query(lang2Query[name]);
+      const query = new Query(lang, lang2Query[name]);
       const strategy = createParseStrategy(name);
 
       const resources: LanguageResources = {
@@ -63,7 +63,7 @@ export class LanguageParser {
     return resources.parser;
   }
 
-  public async getQueryForLang(name: SupportedLang): Promise<Parser.Query> {
+  public async getQueryForLang(name: SupportedLang): Promise<Query> {
     const resources = await this.getResources(name);
     return resources.query;
   }

--- a/src/core/treeSitter/loadLanguage.ts
+++ b/src/core/treeSitter/loadLanguage.ts
@@ -1,17 +1,17 @@
 import fs from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import Parser from 'web-tree-sitter';
+import { Language } from 'web-tree-sitter';
 
 const require = createRequire(import.meta.url);
 
-export async function loadLanguage(langName: string): Promise<Parser.Language> {
+export async function loadLanguage(langName: string): Promise<Language> {
   if (!langName) {
     throw new Error('Invalid language name');
   }
 
   try {
     const wasmPath = await getWasmPath(langName);
-    return await Parser.Language.load(wasmPath);
+    return await Language.load(wasmPath);
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to load language ${langName}: ${message}`);

--- a/src/core/treeSitter/parseFile.ts
+++ b/src/core/treeSitter/parseFile.ts
@@ -38,6 +38,10 @@ export const parseFile = async (fileContent: string, filePath: string, config: R
   try {
     // Parse the file content into an Abstract Syntax Tree (AST)
     const tree = parser.parse(fileContent);
+    if (!tree) {
+      logger.debug(`Failed to parse file: ${filePath}`);
+      return undefined;
+    }
 
     // Get the appropriate parse strategy for the language
     const parseStrategy = createParseStrategy(lang);

--- a/src/core/treeSitter/parseStrategies/CssParseStrategy.ts
+++ b/src/core/treeSitter/parseStrategies/CssParseStrategy.ts
@@ -1,9 +1,9 @@
-import type { SyntaxNode } from 'web-tree-sitter';
+import type { Node } from 'web-tree-sitter';
 import type { ParseContext, ParseStrategy } from './ParseStrategy.js';
 
 export class CssParseStrategy implements ParseStrategy {
   parseCapture(
-    capture: { node: SyntaxNode; name: string },
+    capture: { node: Node; name: string },
     lines: string[],
     processedChunks: Set<string>,
     _context: ParseContext,

--- a/src/core/treeSitter/parseStrategies/DefaultParseStrategy.ts
+++ b/src/core/treeSitter/parseStrategies/DefaultParseStrategy.ts
@@ -1,9 +1,9 @@
-import type { SyntaxNode } from 'web-tree-sitter';
+import type { Node } from 'web-tree-sitter';
 import type { ParseContext, ParseStrategy } from './ParseStrategy.js';
 
 export class DefaultParseStrategy implements ParseStrategy {
   parseCapture(
-    capture: { node: SyntaxNode; name: string },
+    capture: { node: Node; name: string },
     lines: string[],
     processedChunks: Set<string>,
     _context: ParseContext,

--- a/src/core/treeSitter/parseStrategies/GoParseStrategy.ts
+++ b/src/core/treeSitter/parseStrategies/GoParseStrategy.ts
@@ -1,4 +1,4 @@
-import type { SyntaxNode } from 'web-tree-sitter';
+import type { Node } from 'web-tree-sitter';
 import type { ParseContext, ParseStrategy } from './ParseStrategy.js';
 
 enum CaptureType {
@@ -22,7 +22,7 @@ type ParseResult = {
 
 export class GoParseStrategy implements ParseStrategy {
   parseCapture(
-    capture: { node: SyntaxNode; name: string },
+    capture: { node: Node; name: string },
     lines: string[],
     processedChunks: Set<string>,
     _context: ParseContext,

--- a/src/core/treeSitter/parseStrategies/ParseStrategy.ts
+++ b/src/core/treeSitter/parseStrategies/ParseStrategy.ts
@@ -1,4 +1,4 @@
-import type { Query, SyntaxNode, Tree } from 'web-tree-sitter';
+import type { Node, Query, Tree } from 'web-tree-sitter';
 import type { RepomixConfigMerged } from '../../../config/configSchema.js';
 import type { SupportedLang } from '../lang2Query.js';
 import { CssParseStrategy } from './CssParseStrategy.js';
@@ -18,7 +18,7 @@ export interface ParseContext {
 
 export interface ParseStrategy {
   parseCapture(
-    capture: { node: SyntaxNode; name: string },
+    capture: { node: Node; name: string },
     lines: string[],
     processedChunks: Set<string>,
     context: ParseContext,

--- a/src/core/treeSitter/parseStrategies/PythonParseStrategy.ts
+++ b/src/core/treeSitter/parseStrategies/PythonParseStrategy.ts
@@ -1,4 +1,4 @@
-import type { SyntaxNode } from 'web-tree-sitter';
+import type { Node } from 'web-tree-sitter';
 import type { ParseContext, ParseStrategy } from './ParseStrategy.js';
 
 enum CaptureType {
@@ -16,7 +16,7 @@ type ParseResult = {
 
 export class PythonParseStrategy implements ParseStrategy {
   parseCapture(
-    capture: { node: SyntaxNode; name: string },
+    capture: { node: Node; name: string },
     lines: string[],
     processedChunks: Set<string>,
     _context: ParseContext,

--- a/src/core/treeSitter/parseStrategies/TypeScriptParseStrategy.ts
+++ b/src/core/treeSitter/parseStrategies/TypeScriptParseStrategy.ts
@@ -1,4 +1,4 @@
-import type { SyntaxNode } from 'web-tree-sitter';
+import type { Node } from 'web-tree-sitter';
 import type { ParseContext, ParseStrategy } from './ParseStrategy.js';
 
 enum CaptureType {
@@ -22,7 +22,7 @@ export class TypeScriptParseStrategy implements ParseStrategy {
   private static readonly FUNCTION_NAME_PATTERN = /(?:export\s+)?(?:const|let|var)\s+([a-zA-Z0-9_$]+)\s*=/;
 
   parseCapture(
-    capture: { node: SyntaxNode; name: string },
+    capture: { node: Node; name: string },
     lines: string[],
     processedChunks: Set<string>,
     _context: ParseContext,

--- a/src/core/treeSitter/parseStrategies/VueParseStrategy.ts
+++ b/src/core/treeSitter/parseStrategies/VueParseStrategy.ts
@@ -1,9 +1,9 @@
-import type { SyntaxNode } from 'web-tree-sitter';
+import type { Node } from 'web-tree-sitter';
 import type { ParseContext, ParseStrategy } from './ParseStrategy.js';
 
 export class VueParseStrategy implements ParseStrategy {
   parseCapture(
-    capture: { node: SyntaxNode; name: string },
+    capture: { node: Node; name: string },
     lines: string[],
     processedChunks: Set<string>,
     _context: ParseContext,

--- a/tests/core/treeSitter/loadLanguage.test.ts
+++ b/tests/core/treeSitter/loadLanguage.test.ts
@@ -1,14 +1,12 @@
 import fs from 'node:fs/promises';
 import { describe, expect, it, vi } from 'vitest';
-import Parser from 'web-tree-sitter';
+import { Language } from 'web-tree-sitter';
 import { loadLanguage } from '../../../src/core/treeSitter/loadLanguage.js';
 
 vi.mock('node:fs/promises');
 vi.mock('web-tree-sitter', () => ({
-  default: {
-    Language: {
-      load: vi.fn(),
-    },
+  Language: {
+    load: vi.fn(),
   },
 }));
 vi.mock('node:module', () => ({
@@ -27,7 +25,7 @@ describe('loadLanguage', () => {
     mockAccess.mockResolvedValue(undefined);
 
     const mockLoadLanguage = vi.fn().mockResolvedValue({ success: true });
-    Parser.Language.load = mockLoadLanguage;
+    Language.load = mockLoadLanguage;
 
     await loadLanguage('javascript');
 
@@ -49,7 +47,7 @@ describe('loadLanguage', () => {
     mockAccess.mockResolvedValue(undefined);
 
     const mockLoadLanguage = vi.fn().mockRejectedValue(new Error('Load failed'));
-    Parser.Language.load = mockLoadLanguage;
+    Language.load = mockLoadLanguage;
 
     await expect(loadLanguage('javascript')).rejects.toThrow('Failed to load language javascript: Load failed');
   });

--- a/tests/core/treeSitter/parseFile.typescript.test.ts
+++ b/tests/core/treeSitter/parseFile.typescript.test.ts
@@ -166,7 +166,7 @@ describe('TypeScript File Parsing', () => {
         reset(_node: Node): void {},
         resetTo(_cursor: TreeCursor): void {},
         copy(): TreeCursor {
-          return { ...this };
+          return { ...this } as TreeCursor;
         },
         delete(): void {},
       };

--- a/tests/core/treeSitter/parseFile.typescript.test.ts
+++ b/tests/core/treeSitter/parseFile.typescript.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from 'vitest';
-import type { Edit, Language, Point, Query, Range, SyntaxNode, Tree, TreeCursor } from 'web-tree-sitter';
+import type { Edit, Language, Node, Point, Query, Range, Tree, TreeCursor } from 'web-tree-sitter';
 import type { RepomixConfigMerged } from '../../../src/config/configSchema.js';
 import { parseFile } from '../../../src/core/treeSitter/parseFile.js';
 import { TypeScriptParseStrategy } from '../../../src/core/treeSitter/parseStrategies/TypeScriptParseStrategy.js';
@@ -110,12 +110,12 @@ describe('TypeScript File Parsing', () => {
     let mockContext: MockContext;
 
     // Helper function to create a mock capture object
-    const createMockCapture = (name: string, startRow: number, endRow: number): { node: SyntaxNode; name: string } => {
+    const createMockCapture = (name: string, startRow: number, endRow: number): { node: Node; name: string } => {
       return {
         node: {
           startPosition: { row: startRow } as Point,
           endPosition: { row: endRow } as Point,
-        } as SyntaxNode,
+        } as Node,
         name,
       };
     };
@@ -136,7 +136,7 @@ describe('TypeScript File Parsing', () => {
         startIndex: 0,
         endIndex: 0,
         nodeId: 0,
-        currentNode: {} as SyntaxNode,
+        currentNode: {} as Node,
         currentDepth: 0,
         currentDescendantIndex: 0,
         currentFieldId: 0,
@@ -162,18 +162,20 @@ describe('TypeScript File Parsing', () => {
         gotoFirstChildForPosition(_goalPosition: Point): boolean {
           return false;
         },
-        gotoDescendant(_goalDescendantIndex: number): boolean {
-          return false;
-        },
-        reset(): void {},
+        gotoDescendant(_goalDescendantIndex: number): void {},
+        reset(_node: Node): void {},
         resetTo(_cursor: TreeCursor): void {},
+        copy(): TreeCursor {
+          return this;
+        },
         delete(): void {},
       };
 
       const mockTree: Tree = {
-        rootNode: {} as SyntaxNode,
-        rootNodeWithOffset(_offsetBytes: number, _offsetExtent: Point): SyntaxNode {
-          return {} as SyntaxNode;
+        language: {} as Language,
+        rootNode: {} as Node,
+        rootNodeWithOffset(_offsetBytes: number, _offsetExtent: Point): Node {
+          return {} as Node;
         },
         getChangedRanges(_other: Tree): Range[] {
           return [];
@@ -186,9 +188,6 @@ describe('TypeScript File Parsing', () => {
         },
         delete() {},
         edit(_delta: Edit) {},
-        getLanguage(): Language {
-          return {} as Language;
-        },
         walk(): TreeCursor {
           return mockCursor;
         },

--- a/tests/core/treeSitter/parseFile.typescript.test.ts
+++ b/tests/core/treeSitter/parseFile.typescript.test.ts
@@ -166,7 +166,7 @@ describe('TypeScript File Parsing', () => {
         reset(_node: Node): void {},
         resetTo(_cursor: TreeCursor): void {},
         copy(): TreeCursor {
-          return this;
+          return { ...this };
         },
         delete(): void {},
       };


### PR DESCRIPTION
Update web-tree-sitter to the latest version (0.25.10) to benefit from bug fixes and improvements in WASM compilation, web bindings, and performance.

## Changes

- Updated `web-tree-sitter` from 0.24.7 to 0.25.10
- Adapted code to breaking API changes:
  - `Parser` changed from namespace to class
  - `Query` now instantiated with `new Query(language, source)` instead of `language.query(source)`
  - `SyntaxNode` type renamed to `Node`
  - Added null check for `Parser.parse()` return value
  - Updated `TreeCursor` and `Tree` interface signatures in tests

## Checklist

- [x] Run `npm run test` (783/783 tests passing)
- [x] Run `npm run lint` (no issues)