### PR TITLE
chore(ci): Add MCP inline comment tool to Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,5 +53,5 @@ jobs:
           
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -8,6 +8,7 @@ jobs:
   auto-review:
     permissions:
       contents: read
+      pull-requests: write
       id-token: write
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Add `mcp__github_inline_comment__create_inline_comment` to the allowed tools in the Claude Code Review workflow. This enables the review agent to create inline comments on specific lines of code in pull requests.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`