### PR TITLE
fix(cli): Skip file copy when absolute path is specified for remote repository output

### DIFF
--- a/src/cli/actions/remoteAction.ts
+++ b/src/cli/actions/remoteAction.ts
@@ -191,6 +191,13 @@ export const copyOutputToCurrentDirectory = async (
   const sourcePath = path.resolve(sourceDir, outputFileName);
   const targetPath = path.resolve(targetDir, outputFileName);
 
+  // Skip copy if source and target are the same
+  // This can happen when an absolute path is specified for the output file
+  if (sourcePath === targetPath) {
+    logger.trace(`Source and target are the same (${sourcePath}), skipping copy`);
+    return;
+  }
+
   try {
     logger.trace(`Copying output file from: ${sourcePath} to: ${targetPath}`);
 

--- a/tests/cli/actions/remoteAction.test.ts
+++ b/tests/cli/actions/remoteAction.test.ts
@@ -205,7 +205,7 @@ describe('remoteAction functions', () => {
   });
 
   describe('copyOutputToCurrentDirectory', () => {
-    test('should copy output file', async () => {
+    test('should copy output file when source and target are different', async () => {
       const sourceDir = '/source/dir';
       const targetDir = '/target/dir';
       const fileName = 'output.txt';
@@ -215,6 +215,34 @@ describe('remoteAction functions', () => {
       await copyOutputToCurrentDirectory(sourceDir, targetDir, fileName);
 
       expect(fs.copyFile).toHaveBeenCalledWith(path.resolve(sourceDir, fileName), path.resolve(targetDir, fileName));
+    });
+
+    test('should skip copy when source and target are the same', async () => {
+      const sourceDir = '/tmp/dir';
+      const targetDir = '/tmp/dir';
+      const fileName = 'output.txt';
+
+      vi.mocked(fs.copyFile).mockResolvedValue();
+
+      await copyOutputToCurrentDirectory(sourceDir, targetDir, fileName);
+
+      // Should not call copyFile when source and target are the same
+      expect(fs.copyFile).not.toHaveBeenCalled();
+    });
+
+    test('should skip copy when absolute path resolves to same location', async () => {
+      const sourceDir = '/tmp/repomix-123';
+      const targetDir = process.cwd();
+      const absolutePath = '/tmp/my_private_dir/output.xml';
+
+      vi.mocked(fs.copyFile).mockResolvedValue();
+
+      await copyOutputToCurrentDirectory(sourceDir, targetDir, absolutePath);
+
+      // When absolute path is used, both source and target resolve to the same path
+      // path.resolve('/tmp/repomix-123', '/tmp/my_private_dir/output.xml') -> '/tmp/my_private_dir/output.xml'
+      // path.resolve(process.cwd(), '/tmp/my_private_dir/output.xml') -> '/tmp/my_private_dir/output.xml'
+      expect(fs.copyFile).not.toHaveBeenCalled();
     });
 
     test('should throw error when copy fails', async () => {


### PR DESCRIPTION
## Summary

Fixes #873

When using the remote repository feature with an absolute path specified for the output file, the previous implementation attempted to copy the file even though source and target resolved to the same path. This resulted in an error:

```
RepomixError: Failed to copy output file: EINVAL: invalid argument, 
copyfile '/tmp/my_private_dir/output.xml' -> '/tmp/my_private_dir/output.xml'.
```

This PR fixes the issue by implementing a fundamental solution: checking if source and target paths are identical before attempting to copy.

## Changes

- Modified `copyOutputToCurrentDirectory` to check if source and target paths are the same before copying
- When they are identical, the copy operation is skipped with a trace log
- This handles absolute paths and any other edge cases where paths resolve to the same location
- The fix is self-contained within the function, making it more robust

## Why This Approach?

This is more fundamental than checking for absolute paths at the call site because:
- **More generic**: Handles any case where source equals target, not just absolute paths
- **Self-contained**: The function itself is responsible for its safe operation
- **Simpler**: No changes needed to calling code
- **Safer**: Prevents file copy errors in all edge cases

## Test Plan

- [x] Run `npm run test` - All 785 tests passing
- [x] Run `npm run lint` - No errors
- [x] Added test case: source and target are the same directory
- [x] Added test case: absolute path resolves to same location
- [x] Existing tests continue to pass

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`