### PR TITLE
docs(website): Add TypeScript/JavaScript config support to all language docs

### DIFF
--- a/website/client/src/de/guide/configuration.md
+++ b/website/client/src/de/guide/configuration.md
@@ -196,9 +196,15 @@ Repomix sucht in folgender Reihenfolge nach Konfigurationsdateien:
    - TypeScript: `repomix.config.ts`, `repomix.config.mts`, `repomix.config.cts`
    - JavaScript: `repomix.config.js`, `repomix.config.mjs`, `repomix.config.cjs`
    - JSON: `repomix.config.json5`, `repomix.config.jsonc`, `repomix.config.json`
-2. Globale Konfigurationsdatei:
-   - Windows: `%LOCALAPPDATA%\Repomix\repomix.config.json`
-   - macOS/Linux: `~/.config/repomix/repomix.config.json`
+2. Globale Konfigurationsdatei (Priorität: TS > JS > JSON)
+   - Windows:
+     - TypeScript: `%LOCALAPPDATA%\Repomix\repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `%LOCALAPPDATA%\Repomix\repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `%LOCALAPPDATA%\Repomix\repomix.config.json5`, `.jsonc`, `.json`
+   - macOS/Linux:
+     - TypeScript: `~/.config/repomix/repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `~/.config/repomix/repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `~/.config/repomix/repomix.config.json5`, `.jsonc`, `.json`
 
 Kommandozeilenoptionen haben Vorrang vor Einstellungen in der Konfigurationsdatei.
 

--- a/website/client/src/en/guide/configuration.md
+++ b/website/client/src/en/guide/configuration.md
@@ -196,9 +196,15 @@ Repomix looks for configuration files in the following order:
    - TypeScript: `repomix.config.ts`, `repomix.config.mts`, `repomix.config.cts`
    - JavaScript: `repomix.config.js`, `repomix.config.mjs`, `repomix.config.cjs`
    - JSON: `repomix.config.json5`, `repomix.config.jsonc`, `repomix.config.json`
-2. Global configuration file:
-   - Windows: `%LOCALAPPDATA%\Repomix\repomix.config.json`
-   - macOS/Linux: `~/.config/repomix/repomix.config.json`
+2. Global configuration file (priority order: TS > JS > JSON)
+   - Windows:
+     - TypeScript: `%LOCALAPPDATA%\Repomix\repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `%LOCALAPPDATA%\Repomix\repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `%LOCALAPPDATA%\Repomix\repomix.config.json5`, `.jsonc`, `.json`
+   - macOS/Linux:
+     - TypeScript: `~/.config/repomix/repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `~/.config/repomix/repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `~/.config/repomix/repomix.config.json5`, `.jsonc`, `.json`
 
 Command-line options take precedence over configuration file settings.
 

--- a/website/client/src/es/guide/configuration.md
+++ b/website/client/src/es/guide/configuration.md
@@ -196,9 +196,15 @@ Repomix busca los archivos de configuración en el siguiente orden:
    - TypeScript: `repomix.config.ts`, `repomix.config.mts`, `repomix.config.cts`
    - JavaScript: `repomix.config.js`, `repomix.config.mjs`, `repomix.config.cjs`
    - JSON: `repomix.config.json5`, `repomix.config.jsonc`, `repomix.config.json`
-2. Archivo de configuración global:
-   - Windows: `%LOCALAPPDATA%\Repomix\repomix.config.json`
-   - macOS/Linux: `~/.config/repomix/repomix.config.json`
+2. Archivo de configuración global (orden de prioridad: TS > JS > JSON)
+   - Windows:
+     - TypeScript: `%LOCALAPPDATA%\Repomix\repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `%LOCALAPPDATA%\Repomix\repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `%LOCALAPPDATA%\Repomix\repomix.config.json5`, `.jsonc`, `.json`
+   - macOS/Linux:
+     - TypeScript: `~/.config/repomix/repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `~/.config/repomix/repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `~/.config/repomix/repomix.config.json5`, `.jsonc`, `.json`
 
 Las opciones de línea de comandos tienen prioridad sobre la configuración del archivo.
 

--- a/website/client/src/fr/guide/configuration.md
+++ b/website/client/src/fr/guide/configuration.md
@@ -196,9 +196,15 @@ Repomix recherche les fichiers de configuration dans l'ordre suivant :
    - TypeScript : `repomix.config.ts`, `repomix.config.mts`, `repomix.config.cts`
    - JavaScript : `repomix.config.js`, `repomix.config.mjs`, `repomix.config.cjs`
    - JSON : `repomix.config.json5`, `repomix.config.jsonc`, `repomix.config.json`
-2. Fichier de configuration global :
-   - Windows : `%LOCALAPPDATA%\Repomix\repomix.config.json`
-   - macOS/Linux : `~/.config/repomix/repomix.config.json`
+2. Fichier de configuration global (ordre de priorité : TS > JS > JSON)
+   - Windows :
+     - TypeScript : `%LOCALAPPDATA%\Repomix\repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript : `%LOCALAPPDATA%\Repomix\repomix.config.js`, `.mjs`, `.cjs`
+     - JSON : `%LOCALAPPDATA%\Repomix\repomix.config.json5`, `.jsonc`, `.json`
+   - macOS/Linux :
+     - TypeScript : `~/.config/repomix/repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript : `~/.config/repomix/repomix.config.js`, `.mjs`, `.cjs`
+     - JSON : `~/.config/repomix/repomix.config.json5`, `.jsonc`, `.json`
 
 Les options en ligne de commande ont la priorité sur les paramètres du fichier de configuration.
 

--- a/website/client/src/hi/guide/configuration.md
+++ b/website/client/src/hi/guide/configuration.md
@@ -196,9 +196,15 @@ Repomix निम्नलिखित क्रम में कॉन्फि
    - TypeScript: `repomix.config.ts`, `repomix.config.mts`, `repomix.config.cts`
    - JavaScript: `repomix.config.js`, `repomix.config.mjs`, `repomix.config.cjs`
    - JSON: `repomix.config.json5`, `repomix.config.jsonc`, `repomix.config.json`
-2. ग्लोबल कॉन्फिगरेशन फ़ाइल:
-   - Windows: `%LOCALAPPDATA%\Repomix\repomix.config.json`
-   - macOS/Linux: `~/.config/repomix/repomix.config.json`
+2. ग्लोबल कॉन्फिगरेशन फ़ाइल (प्राथमिकता क्रम: TS > JS > JSON)
+   - Windows:
+     - TypeScript: `%LOCALAPPDATA%\Repomix\repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `%LOCALAPPDATA%\Repomix\repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `%LOCALAPPDATA%\Repomix\repomix.config.json5`, `.jsonc`, `.json`
+   - macOS/Linux:
+     - TypeScript: `~/.config/repomix/repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `~/.config/repomix/repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `~/.config/repomix/repomix.config.json5`, `.jsonc`, `.json`
 
 कमांड-लाइन विकल्प कॉन्फिगरेशन फ़ाइल सेटिंग्स से प्राथमिकता रखते हैं।
 

--- a/website/client/src/id/guide/configuration.md
+++ b/website/client/src/id/guide/configuration.md
@@ -196,9 +196,15 @@ Repomix mencari file konfigurasi dalam urutan berikut:
    - TypeScript: `repomix.config.ts`, `repomix.config.mts`, `repomix.config.cts`
    - JavaScript: `repomix.config.js`, `repomix.config.mjs`, `repomix.config.cjs`
    - JSON: `repomix.config.json5`, `repomix.config.jsonc`, `repomix.config.json`
-2. File konfigurasi global:
-   - Windows: `%LOCALAPPDATA%\Repomix\repomix.config.json`
-   - macOS/Linux: `~/.config/repomix/repomix.config.json`
+2. File konfigurasi global (urutan prioritas: TS > JS > JSON)
+   - Windows:
+     - TypeScript: `%LOCALAPPDATA%\Repomix\repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `%LOCALAPPDATA%\Repomix\repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `%LOCALAPPDATA%\Repomix\repomix.config.json5`, `.jsonc`, `.json`
+   - macOS/Linux:
+     - TypeScript: `~/.config/repomix/repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `~/.config/repomix/repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `~/.config/repomix/repomix.config.json5`, `.jsonc`, `.json`
 
 Opsi baris perintah memiliki prioritas lebih tinggi daripada pengaturan file konfigurasi.
 

--- a/website/client/src/ja/guide/configuration.md
+++ b/website/client/src/ja/guide/configuration.md
@@ -196,9 +196,15 @@ Repomixは以下の順序で設定ファイルを探します：
    - TypeScript: `repomix.config.ts`、`repomix.config.mts`、`repomix.config.cts`
    - JavaScript: `repomix.config.js`、`repomix.config.mjs`、`repomix.config.cjs`
    - JSON: `repomix.config.json5`、`repomix.config.jsonc`、`repomix.config.json`
-2. グローバル設定ファイル：
-   - Windows: `%LOCALAPPDATA%\Repomix\repomix.config.json`
-   - macOS/Linux: `~/.config/repomix/repomix.config.json`
+2. グローバル設定ファイル（優先順位: TS > JS > JSON）
+   - Windows:
+     - TypeScript: `%LOCALAPPDATA%\Repomix\repomix.config.ts`、`.mts`、`.cts`
+     - JavaScript: `%LOCALAPPDATA%\Repomix\repomix.config.js`、`.mjs`、`.cjs`
+     - JSON: `%LOCALAPPDATA%\Repomix\repomix.config.json5`、`.jsonc`、`.json`
+   - macOS/Linux:
+     - TypeScript: `~/.config/repomix/repomix.config.ts`、`.mts`、`.cts`
+     - JavaScript: `~/.config/repomix/repomix.config.js`、`.mjs`、`.cjs`
+     - JSON: `~/.config/repomix/repomix.config.json5`、`.jsonc`、`.json`
 
 コマンドラインオプションは設定ファイルの設定よりも優先されます。
 

--- a/website/client/src/ko/guide/configuration.md
+++ b/website/client/src/ko/guide/configuration.md
@@ -196,9 +196,15 @@ Repomix는 다음 순서로 설정 파일을 찾습니다:
    - TypeScript: `repomix.config.ts`, `repomix.config.mts`, `repomix.config.cts`
    - JavaScript: `repomix.config.js`, `repomix.config.mjs`, `repomix.config.cjs`
    - JSON: `repomix.config.json5`, `repomix.config.jsonc`, `repomix.config.json`
-2. 전역 설정 파일:
-   - Windows: `%LOCALAPPDATA%\Repomix\repomix.config.json`
-   - macOS/Linux: `~/.config/repomix/repomix.config.json`
+2. 전역 설정 파일 (우선순위: TS > JS > JSON)
+   - Windows:
+     - TypeScript: `%LOCALAPPDATA%\Repomix\repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `%LOCALAPPDATA%\Repomix\repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `%LOCALAPPDATA%\Repomix\repomix.config.json5`, `.jsonc`, `.json`
+   - macOS/Linux:
+     - TypeScript: `~/.config/repomix/repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `~/.config/repomix/repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `~/.config/repomix/repomix.config.json5`, `.jsonc`, `.json`
 
 명령줄 옵션은 설정 파일의 설정보다 우선합니다.
 

--- a/website/client/src/pt-br/guide/configuration.md
+++ b/website/client/src/pt-br/guide/configuration.md
@@ -196,9 +196,15 @@ O Repomix procura os arquivos de configuração na seguinte ordem:
    - TypeScript: `repomix.config.ts`, `repomix.config.mts`, `repomix.config.cts`
    - JavaScript: `repomix.config.js`, `repomix.config.mjs`, `repomix.config.cjs`
    - JSON: `repomix.config.json5`, `repomix.config.jsonc`, `repomix.config.json`
-2. Arquivo de configuração global:
-   - Windows: `%LOCALAPPDATA%\Repomix\repomix.config.json`
-   - macOS/Linux: `~/.config/repomix/repomix.config.json`
+2. Arquivo de configuração global (ordem de prioridade: TS > JS > JSON)
+   - Windows:
+     - TypeScript: `%LOCALAPPDATA%\Repomix\repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `%LOCALAPPDATA%\Repomix\repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `%LOCALAPPDATA%\Repomix\repomix.config.json5`, `.jsonc`, `.json`
+   - macOS/Linux:
+     - TypeScript: `~/.config/repomix/repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `~/.config/repomix/repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `~/.config/repomix/repomix.config.json5`, `.jsonc`, `.json`
 
 As opções de linha de comando têm precedência sobre as configurações do arquivo.
 

--- a/website/client/src/vi/guide/configuration.md
+++ b/website/client/src/vi/guide/configuration.md
@@ -196,9 +196,15 @@ Repomix tìm kiếm file cấu hình theo thứ tự sau:
    - TypeScript: `repomix.config.ts`, `repomix.config.mts`, `repomix.config.cts`
    - JavaScript: `repomix.config.js`, `repomix.config.mjs`, `repomix.config.cjs`
    - JSON: `repomix.config.json5`, `repomix.config.jsonc`, `repomix.config.json`
-2. File cấu hình toàn cục:
-   - Windows: `%LOCALAPPDATA%\Repomix\repomix.config.json`
-   - macOS/Linux: `~/.config/repomix/repomix.config.json`
+2. File cấu hình toàn cục (thứ tự ưu tiên: TS > JS > JSON)
+   - Windows:
+     - TypeScript: `%LOCALAPPDATA%\Repomix\repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `%LOCALAPPDATA%\Repomix\repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `%LOCALAPPDATA%\Repomix\repomix.config.json5`, `.jsonc`, `.json`
+   - macOS/Linux:
+     - TypeScript: `~/.config/repomix/repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `~/.config/repomix/repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `~/.config/repomix/repomix.config.json5`, `.jsonc`, `.json`
 
 Các tùy chọn dòng lệnh có ưu tiên cao hơn cài đặt file cấu hình.
 

--- a/website/client/src/zh-cn/guide/configuration.md
+++ b/website/client/src/zh-cn/guide/configuration.md
@@ -196,9 +196,15 @@ Repomix按以下顺序查找配置文件：
    - TypeScript: `repomix.config.ts`, `repomix.config.mts`, `repomix.config.cts`
    - JavaScript: `repomix.config.js`, `repomix.config.mjs`, `repomix.config.cjs`
    - JSON: `repomix.config.json5`, `repomix.config.jsonc`, `repomix.config.json`
-2. 全局配置文件：
-   - Windows：`%LOCALAPPDATA%\Repomix\repomix.config.json`
-   - macOS/Linux：`~/.config/repomix/repomix.config.json`
+2. 全局配置文件（优先级：TS > JS > JSON）
+   - Windows：
+     - TypeScript: `%LOCALAPPDATA%\Repomix\repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `%LOCALAPPDATA%\Repomix\repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `%LOCALAPPDATA%\Repomix\repomix.config.json5`, `.jsonc`, `.json`
+   - macOS/Linux：
+     - TypeScript: `~/.config/repomix/repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `~/.config/repomix/repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `~/.config/repomix/repomix.config.json5`, `.jsonc`, `.json`
 
 命令行选项优先于配置文件设置。
 

--- a/website/client/src/zh-tw/guide/configuration.md
+++ b/website/client/src/zh-tw/guide/configuration.md
@@ -196,9 +196,15 @@ Repomix按以下順序尋找設定檔：
    - TypeScript: `repomix.config.ts`, `repomix.config.mts`, `repomix.config.cts`
    - JavaScript: `repomix.config.js`, `repomix.config.mjs`, `repomix.config.cjs`
    - JSON: `repomix.config.json5`, `repomix.config.jsonc`, `repomix.config.json`
-2. 全域設定檔：
-   - Windows：`%LOCALAPPDATA%\Repomix\repomix.config.json`
-   - macOS/Linux：`~/.config/repomix/repomix.config.json`
+2. 全域設定檔（優先順序：TS > JS > JSON）
+   - Windows：
+     - TypeScript: `%LOCALAPPDATA%\Repomix\repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `%LOCALAPPDATA%\Repomix\repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `%LOCALAPPDATA%\Repomix\repomix.config.json5`, `.jsonc`, `.json`
+   - macOS/Linux：
+     - TypeScript: `~/.config/repomix/repomix.config.ts`, `.mts`, `.cts`
+     - JavaScript: `~/.config/repomix/repomix.config.js`, `.mjs`, `.cjs`
+     - JSON: `~/.config/repomix/repomix.config.json5`, `.jsonc`, `.json`
 
 命令列選項優先於設定檔設定。
 


### PR DESCRIPTION
Add TypeScript and JavaScript configuration file documentation to all 12 language versions of the configuration guide, matching the changes made to README in PR #886.

This PR ensures users can learn about TypeScript/JavaScript config file support in their preferred language on the website documentation.

## Changes

- Add "Configuration File Formats" section explaining priority order (TS > JS > JSON)
- Add "JSON Configuration" subsection (moved from previous "Quick Start")
- Add "TypeScript Configuration" subsection with:
  - Installation instructions (`npm install -D repomix`)
  - Example using `defineConfig`
  - Benefits (type checking, autocomplete, dynamic values)
  - Dynamic values example (timestamp-based filename)
- Add "JavaScript Configuration" subsection
- Update "Configuration File Locations" section to include all file formats with priority

## Languages Updated

All 12 languages:
- English (en)
- Japanese (ja)
- Chinese Simplified (zh-cn)
- Chinese Traditional (zh-tw)
- German (de)
- French (fr)
- Spanish (es)
- Portuguese (pt-br)
- Indonesian (id)
- Vietnamese (vi)
- Hindi (hi)
- Korean (ko)

## Related

- Follows up on PR #886 which added TS/JS config support to README
- Ensures consistency between README and website documentation

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`