### PR TITLE
fix: Remove 'requires' field from marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,8 +32,7 @@
       "keywords": ["repomix", "commands", "pack", "productivity"],
       "category": "productivity",
       "license": "MIT",
-      "strict": false,
-      "requires": ["repomix-mcp"]
+      "strict": false
     }
   ]
 }


### PR DESCRIPTION
This pull request makes a minor update to the `.claude-plugin/marketplace.json` configuration file by removing the unnecessary `requires` field from the plugin definition. This simplifies the plugin metadata without affecting functionality.

Fixes https://github.com/yamadashy/repomix/issues/897