### PR TITLE
chore(plugin): Bump marketplace version to 1.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Official Repomix plugins for Claude Code",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "plugins": [
     {


### PR DESCRIPTION
This PR bumps the Claude Code plugin marketplace version from 1.0.0 to 1.0.1 to ensure that plugin updates are properly propagated to users.

Related to PR #898, which removes the unsupported `requires` field from the marketplace configuration.

## Checklist

- [ ] Run `npm run test`
- [ ] Run `npm run lint`