### PR TITLE
chore(ci): Add Node.js 25 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [20.x, 22.x, 24.x, 25.x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -215,7 +215,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [20.x, 22.x, 24.x, 25.x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Added Node.js 25.x to the CI test matrix to ensure compatibility with the latest Node.js version.

This change updates both the `test` and `build-and-run` jobs in the CI workflow to include Node.js 25.x alongside the existing versions (20.x, 22.x, 24.x).

## Changes

- Updated `.github/workflows/ci.yml` to add `25.x` to the node-version matrix in the `test` job
- Updated `.github/workflows/ci.yml` to add `25.x` to the node-version matrix in the `build-and-run` job

## Testing

Each job will now run across 12 combinations:
- 3 operating systems (Ubuntu, Windows, macOS)
- 4 Node.js versions (20.x, 22.x, 24.x, 25.x)

## Checklist

- [ ] Run `npm run test`
- [ ] Run `npm run lint`