### PR TITLE
docs(releases): Add release notes for v1.9.1

### DIFF
--- a/.github/releases/v1.x/v1.9.1.md
+++ b/.github/releases/v1.x/v1.9.1.md
@@ -1,0 +1,41 @@
+This release fixes an issue with output file extensions introduced in v1.9.0 and reduces package size, making Repomix more intuitive and efficient!
+
+## Bug Fixes 🐛
+
+### Fixed Output File Extension Not Matching Style (#947)
+
+Fixed an issue where the output file extension didn't automatically match the selected style. Now when you use `--style markdown`, `--style json`, or `--style plain`, the output filename will automatically use the corresponding extension (`.md`, `.json`, or `.txt`).
+
+**Before (v1.9.0):**
+```bash
+repomix --style markdown
+# Output: repomix-output.xml (wrong extension!)
+```
+
+**After (v1.9.1):**
+```bash
+repomix --style markdown
+# Output: repomix-output.md ✨
+```
+
+This behavior applies when the output filename is not explicitly specified via `--output` or in the config file.
+
+Special thanks to @Ahmad8864 for their first contribution fixing this issue! 🎉
+
+We also appreciate @pranc1ngpegasus for their alternative implementation in #949 and detailed investigation of this issue!
+
+## Improvements ⚡
+
+### Reduced Package Size (#942)
+
+Replaced `tree-sitter-wasms` with `@repomix/tree-sitter-wasms`, which contains only the language parsers needed for Repomix. This reduces the total package size by approximately **25%**, resulting in faster installation times and lower disk usage.
+
+## How to Update
+
+```bash
+npm update -g repomix
+```
+
+---
+
+As always, if you have any issues or suggestions, please let us know on GitHub issues or our [Discord community](https://discord.gg/wNYzTwZFku).


### PR DESCRIPTION
Add release notes for v1.9.1 documenting the bug fix and improvements.

## Summary

This PR adds release notes for v1.9.1, which includes:
- Bug fix for output file extension not matching style parameter (#947)
- Package size reduction by replacing tree-sitter-wasms (#942)  
- Dependency updates (#944)

Special thanks to @Ahmad8864 for their first contribution and @pranc1ngpegasus for their alternative implementation and investigation.

## Checklist

- [x] Run `npm run test` (not applicable for documentation)
- [x] Run `npm run lint` (not applicable for documentation)