### PR TITLE
[WIP] Add tests for .ignore file behavior with customPatterns (#959)

### DIFF
--- a/tests/config/configMerge.test.ts
+++ b/tests/config/configMerge.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'vitest';
+import { mergeConfigs } from '../../src/config/configLoad.js';
+import type { RepomixConfigFile, RepomixConfigCli } from '../../src/config/configSchema.js';
+
+describe('configMerge', () => {
+  describe('ignore settings merge', () => {
+    test('should preserve useDotIgnore when customPatterns is defined in fileConfig', () => {
+      const cwd = '/test/dir';
+      const fileConfig: RepomixConfigFile = {
+        ignore: {
+          customPatterns: ['bin/'],
+        },
+      };
+      const cliConfig: RepomixConfigCli = {};
+
+      const merged = mergeConfigs(cwd, fileConfig, cliConfig);
+
+      // useDotIgnore should be true by default and should not be affected by customPatterns
+      expect(merged.ignore.useDotIgnore).toBe(true);
+      expect(merged.ignore.useGitignore).toBe(true);
+      expect(merged.ignore.useDefaultPatterns).toBe(true);
+      expect(merged.ignore.customPatterns).toEqual(['bin/']);
+    });
+
+    test('should preserve all ignore settings when customPatterns is defined', () => {
+      const cwd = '/test/dir';
+      const fileConfig: RepomixConfigFile = {
+        ignore: {
+          customPatterns: ['bin/', 'tmp/'],
+        },
+      };
+      const cliConfig: RepomixConfigCli = {};
+
+      const merged = mergeConfigs(cwd, fileConfig, cliConfig);
+
+      expect(merged.ignore).toEqual({
+        useGitignore: true,
+        useDotIgnore: true,
+        useDefaultPatterns: true,
+        customPatterns: ['bin/', 'tmp/'],
+      });
+    });
+
+    test('should allow explicitly disabling useDotIgnore', () => {
+      const cwd = '/test/dir';
+      const fileConfig: RepomixConfigFile = {
+        ignore: {
+          useDotIgnore: false,
+          customPatterns: ['bin/'],
+        },
+      };
+      const cliConfig: RepomixConfigCli = {};
+
+      const merged = mergeConfigs(cwd, fileConfig, cliConfig);
+
+      expect(merged.ignore.useDotIgnore).toBe(false);
+      expect(merged.ignore.useGitignore).toBe(true);
+      expect(merged.ignore.customPatterns).toEqual(['bin/']);
+    });
+
+    test('should merge customPatterns from all sources', () => {
+      const cwd = '/test/dir';
+      const fileConfig: RepomixConfigFile = {
+        ignore: {
+          customPatterns: ['from-file/'],
+        },
+      };
+      const cliConfig: RepomixConfigCli = {
+        ignore: {
+          customPatterns: ['from-cli/'],
+        },
+      };
+
+      const merged = mergeConfigs(cwd, fileConfig, cliConfig);
+
+      expect(merged.ignore.customPatterns).toEqual(['from-file/', 'from-cli/']);
+      expect(merged.ignore.useDotIgnore).toBe(true);
+    });
+  });
+});

--- a/tests/config/configMerge.test.ts
+++ b/tests/config/configMerge.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { mergeConfigs } from '../../src/config/configLoad.js';
-import type { RepomixConfigFile, RepomixConfigCli } from '../../src/config/configSchema.js';
+import type { RepomixConfigCli, RepomixConfigFile } from '../../src/config/configSchema.js';
 
 describe('configMerge', () => {
   describe('ignore settings merge', () => {

--- a/tests/config/configSchema.zod.test.ts
+++ b/tests/config/configSchema.zod.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest';
+import { repomixConfigFileSchema } from '../../src/config/configSchema.js';
+
+describe('configSchema - Zod parsing behavior', () => {
+  test('should parse config with only customPatterns', () => {
+    const input = {
+      ignore: {
+        customPatterns: ['bin/'],
+      },
+    };
+
+    const result = repomixConfigFileSchema.parse(input);
+
+    // useDotIgnore should not be set when not provided in input
+    expect(result.ignore?.useDotIgnore).toBeUndefined();
+    expect(result.ignore?.useGitignore).toBeUndefined();
+    expect(result.ignore?.useDefaultPatterns).toBeUndefined();
+    expect(result.ignore?.customPatterns).toEqual(['bin/']);
+  });
+
+  test('should parse config with useDotIgnore explicitly set', () => {
+    const input = {
+      ignore: {
+        useDotIgnore: true,
+        customPatterns: ['bin/'],
+      },
+    };
+
+    const result = repomixConfigFileSchema.parse(input);
+
+    expect(result.ignore?.useDotIgnore).toBe(true);
+    expect(result.ignore?.customPatterns).toEqual(['bin/']);
+  });
+
+  test('should parse empty config', () => {
+    const input = {};
+
+    const result = repomixConfigFileSchema.parse(input);
+
+    expect(result.ignore).toBeUndefined();
+  });
+});

--- a/tests/core/file/fileSearch.ignore.integration.test.ts
+++ b/tests/core/file/fileSearch.ignore.integration.test.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { describe, expect, test, afterEach } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 import { searchFiles } from '../../../src/core/file/fileSearch.js';
 import { createMockConfig } from '../../testing/testUtils.js';
 

--- a/tests/core/file/fileSearch.ignore.integration.test.ts
+++ b/tests/core/file/fileSearch.ignore.integration.test.ts
@@ -1,0 +1,111 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { describe, expect, test, afterEach } from 'vitest';
+import { searchFiles } from '../../../src/core/file/fileSearch.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+describe('fileSearch - .ignore integration', () => {
+  const testDir = path.join(process.cwd(), 'tests/fixtures/ignore-test-temp');
+
+  afterEach(async () => {
+    // Clean up test directory
+    try {
+      await fs.rm(testDir, { recursive: true, force: true });
+    } catch {
+      // Ignore errors
+    }
+  });
+
+  test('should respect .ignore file when customPatterns is defined in config', async () => {
+    // Setup test directory structure
+    await fs.mkdir(testDir, { recursive: true });
+    await fs.mkdir(path.join(testDir, 'bin'), { recursive: true });
+    await fs.mkdir(path.join(testDir, 'spec', 'data'), { recursive: true });
+
+    // Create test files
+    await fs.writeFile(path.join(testDir, 'bin', 'test.sh'), 'bin content');
+    await fs.writeFile(path.join(testDir, 'spec', 'data', 'test.txt'), 'test content');
+    await fs.writeFile(path.join(testDir, 'main.js'), 'main content');
+
+    // Create .ignore file
+    await fs.writeFile(path.join(testDir, '.ignore'), 'spec/data/\n');
+
+    // Create config with customPatterns
+    const config = createMockConfig({
+      ignore: {
+        useGitignore: false,
+        useDotIgnore: true,
+        useDefaultPatterns: false,
+        customPatterns: ['bin/'],
+      },
+    });
+
+    const result = await searchFiles(testDir, config);
+
+    // Both bin/ (from customPatterns) and spec/data/ (from .ignore) should be excluded
+    expect(result.filePaths).not.toContain('bin/test.sh');
+    expect(result.filePaths).not.toContain('spec/data/test.txt');
+    expect(result.filePaths).toContain('main.js');
+    expect(result.filePaths).toContain('.ignore');
+  });
+
+  test('should respect .ignore file when customPatterns is empty', async () => {
+    // Setup test directory structure
+    await fs.mkdir(testDir, { recursive: true });
+    await fs.mkdir(path.join(testDir, 'spec', 'data'), { recursive: true });
+
+    // Create test files
+    await fs.writeFile(path.join(testDir, 'spec', 'data', 'test.txt'), 'test content');
+    await fs.writeFile(path.join(testDir, 'main.js'), 'main content');
+
+    // Create .ignore file
+    await fs.writeFile(path.join(testDir, '.ignore'), 'spec/data/\n');
+
+    // Create config without customPatterns
+    const config = createMockConfig({
+      ignore: {
+        useGitignore: false,
+        useDotIgnore: true,
+        useDefaultPatterns: false,
+        customPatterns: [],
+      },
+    });
+
+    const result = await searchFiles(testDir, config);
+
+    // spec/data/ (from .ignore) should be excluded
+    expect(result.filePaths).not.toContain('spec/data/test.txt');
+    expect(result.filePaths).toContain('main.js');
+    expect(result.filePaths).toContain('.ignore');
+  });
+
+  test('should not use .ignore when useDotIgnore is false', async () => {
+    // Setup test directory structure
+    await fs.mkdir(testDir, { recursive: true });
+    await fs.mkdir(path.join(testDir, 'spec', 'data'), { recursive: true });
+
+    // Create test files
+    await fs.writeFile(path.join(testDir, 'spec', 'data', 'test.txt'), 'test content');
+    await fs.writeFile(path.join(testDir, 'main.js'), 'main content');
+
+    // Create .ignore file
+    await fs.writeFile(path.join(testDir, '.ignore'), 'spec/data/\n');
+
+    // Create config with useDotIgnore: false
+    const config = createMockConfig({
+      ignore: {
+        useGitignore: false,
+        useDotIgnore: false,
+        useDefaultPatterns: false,
+        customPatterns: [],
+      },
+    });
+
+    const result = await searchFiles(testDir, config);
+
+    // spec/data/ should NOT be excluded because useDotIgnore is false
+    expect(result.filePaths).toContain('spec/data/test.txt');
+    expect(result.filePaths).toContain('main.js');
+    expect(result.filePaths).toContain('.ignore');
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds comprehensive test coverage for the issue reported in #959 where `.ignore` files are allegedly ignored when `customPatterns` is defined in the configuration.

## What's Included

- Config merge behavior tests
- Integration tests with actual `.ignore` files
- Zod schema parsing tests

## Current Status

All tests pass, indicating that the reported issue cannot be reproduced in the current codebase (v1.9.1). Further investigation is needed to understand the exact reproduction steps.

## Checklist

- [x] Run `npm run test`
- [ ] Run `npm run lint`
- [ ] Identify root cause if bug exists
- [ ] Implement fix if needed