### PR TITLE
fix (actions) remove no supported --no-compress  argument

### DIFF
--- a/.github/actions/repomix/action.yml
+++ b/.github/actions/repomix/action.yml
@@ -75,9 +75,7 @@ runs:
           ARGS+=(--ignore "${{ inputs.ignore }}")
         fi
 
-        if [ "${{ inputs.compress }}" = "false" ]; then
-          ARGS+=(--no-compress)
-        else
+        if [ "${{ inputs.compress }}" = "true" ]; then
           ARGS+=(--compress)
         fi
 


### PR DESCRIPTION
This PR fixes a GitHub Actions bug where passing `compress: false` incorrectly added the `--no-compress` argument, which is not a supported flag.
The logic is now corrected so that the `--compress` argument is added only when `compress: true` is provided.