### PR TITLE
fix(test): Add type guards for MCP SDK content type changes

### DIFF
--- a/tests/mcp/tools/packCodebaseTool.test.ts
+++ b/tests/mcp/tools/packCodebaseTool.test.ts
@@ -146,7 +146,11 @@ describe('PackCodebaseTool', () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toHaveLength(1);
-    const parsedResult = JSON.parse(result.content[0].text as string);
+    const content = result.content[0];
+    if (content.type !== 'text') {
+      throw new Error(`Expected content type to be "text", but received "${content.type}"`);
+    }
+    const parsedResult = JSON.parse(content.text);
     expect(parsedResult.errorMessage).toBe('Failed to return a result');
   });
 
@@ -159,7 +163,11 @@ describe('PackCodebaseTool', () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toHaveLength(1);
-    const parsedResult = JSON.parse(result.content[0].text as string);
+    const content = result.content[0];
+    if (content.type !== 'text') {
+      throw new Error(`Expected content type to be "text", but received "${content.type}"`);
+    }
+    const parsedResult = JSON.parse(content.text);
     expect(parsedResult.errorMessage).toBe('Pack failed');
   });
 
@@ -172,7 +180,11 @@ describe('PackCodebaseTool', () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toHaveLength(1);
-    const parsedResult = JSON.parse(result.content[0].text as string);
+    const content = result.content[0];
+    if (content.type !== 'text') {
+      throw new Error(`Expected content type to be "text", but received "${content.type}"`);
+    }
+    const parsedResult = JSON.parse(content.text);
     expect(parsedResult.errorMessage).toBe('Workspace creation failed');
   });
 });


### PR DESCRIPTION
The @modelcontextprotocol/sdk 1.22.0 update changed the CallToolResult content type to a union type including text, image, audio, and embedded resource types. Added proper type guards to access the text property safely after verifying content.type === 'text'.

<!-- Please include a summary of the changes -->

## Checklist

- [ ] Run `npm run test`
- [ ] Run `npm run lint`
