### PR TITLE
feat(ci): Add npm publish workflow with trusted publisher support

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,58 @@
+name: npm-publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Run in dry-run mode (no actual publish)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write # Required for OIDC trusted publishing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version-file: .tool-versions
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check if version already published
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          if npm view "repomix@${PACKAGE_VERSION}" version 2>/dev/null; then
+            echo "::error::Version ${PACKAGE_VERSION} is already published to npm"
+            exit 1
+          fi
+          echo "Version ${PACKAGE_VERSION} is not yet published"
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test-coverage
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify npm audit signatures
+        run: npm audit signatures
+
+      - name: Publish (dry-run)
+        if: ${{ inputs.dry-run }}
+        run: npm publish --provenance --dry-run
+
+      - name: Publish
+        if: ${{ !inputs.dry-run }}
+        run: npm publish --provenance

--- a/package.json
+++ b/package.json
@@ -37,11 +37,6 @@
     "memory-check-one-file": "node --run repomix -- --verbose --include 'package.json' | grep Memory",
     "website": "docker compose -f website/compose.yml up --build",
     "website-generate-schema": "tsx website/client/scripts/generateSchema.ts",
-    "npm-publish": "node --run npm-publish-check-branch && node --run lint && node --run test-coverage && node --run build && npm publish",
-    "npm-publish-check-branch": "git branch --show-current | grep -q '^main$' || (echo 'Release is only allowed from the main branch' && exit 1)",
-    "npm-release-patch": "npm version patch && node --run npm-publish",
-    "npm-release-minor": "npm version minor && node --run npm-publish",
-    "npm-release-prerelease": "npm version prerelease && node --run npm-publish",
     "pinact-run": "pinact run",
     "pinact-check": "pinact run --check"
   },


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow for npm publishing using OIDC-based trusted publishing instead of long-lived npm tokens.

### Features
- Manual trigger (`workflow_dispatch`) with dry-run option for testing
- Full CI checks (lint, test, build) before publishing
- `npm audit signatures` verification
- Provenance attestation for supply chain security (`--provenance`)
- No `NPM_TOKEN` secret required (uses OIDC authentication)

### Setup Required
After merging, configure trusted publisher on npmjs.com:
1. Go to repomix package settings on npmjs.com
2. Add trusted publisher with:
   - **Organization/User**: `yamadashy`
   - **Repository**: `repomix`
   - **Workflow filename**: `npm-publish.yml`

### References
- [npm Trusted Publishers](https://docs.npmjs.com/trusted-publishers/)
- [GitHub Changelog - npm trusted publishing with OIDC](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/)

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`