### PR TITLE
chore(devcontainer): Add CLI tools and improve shell history persistence

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,7 +25,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   jq \
   nano \
   vim \
+  fd-find \
+  ripgrep \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Create symlink for fd (Debian/Ubuntu names it fdfind)
+RUN ln -s $(which fdfind) /usr/local/bin/fd
+
+# Install ast-grep
+RUN ARCH=$(dpkg --print-architecture) && \
+  case "$ARCH" in \
+    amd64) AST_ARCH="x86_64-unknown-linux-gnu" ;; \
+    arm64) AST_ARCH="aarch64-unknown-linux-gnu" ;; \
+    *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
+  esac && \
+  wget -qO- "https://github.com/ast-grep/ast-grep/releases/latest/download/ast-grep-${AST_ARCH}.tar.gz" | tar xz -C /usr/local/bin
 
 # Ensure default node user has access to /usr/local/share
 RUN mkdir -p /usr/local/share/npm-global && \
@@ -33,10 +47,10 @@ RUN mkdir -p /usr/local/share/npm-global && \
 
 ARG USERNAME=node
 
-# Persist bash history.
-RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
-  && mkdir /commandhistory \
+# Persist shell history (both bash and zsh)
+RUN mkdir /commandhistory \
   && touch /commandhistory/.bash_history \
+  && touch /commandhistory/.zsh_history \
   && chown -R $USERNAME /commandhistory
 
 # Set `DEVCONTAINER` environment variable to help with orientation
@@ -75,7 +89,11 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
   -p fzf \
   -a "source /usr/share/doc/fzf/examples/key-bindings.zsh" \
   -a "source /usr/share/doc/fzf/examples/completion.zsh" \
-  -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  -a "export HISTFILE=/commandhistory/.zsh_history" \
+  -a "export HISTSIZE=10000" \
+  -a "export SAVEHIST=10000" \
+  -a "setopt SHARE_HISTORY" \
+  -a "setopt HIST_IGNORE_DUPS" \
   -x
 
 # Install Claude

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,7 @@
     "--cap-add=NET_ADMIN",
     "--cap-add=NET_RAW"
   ],
+  "postCreateCommand": "npm install",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -35,8 +36,9 @@
   },
   "remoteUser": "node",
   "mounts": [
-    "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
-    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume"
+    "source=${localEnv:HOME}/.claude,target=/home/node/.claude,type=bind",
+    "source=${localEnv:HOME}/.claude.json,target=/home/node/.claude.json,type=bind",
+    "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume"
   ],
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",


### PR DESCRIPTION
Improve devcontainer setup with additional CLI tools and better shell configuration.

## Changes

- Add `fd-find`, `ripgrep`, and `ast-grep` for better code search capabilities
- Persist zsh history with proper settings (HISTSIZE=10000, SAVEHIST=10000, SHARE_HISTORY, HIST_IGNORE_DUPS)
- Add `postCreateCommand` to run `npm install` automatically on container creation
- Mount host `.claude` config for consistent Claude Code settings across sessions

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`