### PR TITLE
fix(ci): Add id-token permission to Claude issue workflows

### DIFF
--- a/.github/workflows/claude-issue-similar.yml
+++ b/.github/workflows/claude-issue-similar.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      id-token: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      id-token: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The `claude-code-action` uses OIDC authentication to obtain GitHub tokens, which requires the `id-token: write` permission. Without this permission, the workflows fail with:

```
Error: Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

This PR adds the missing `id-token: write` permission to:
- `claude-issue-triage.yml`
- `claude-issue-similar.yml`

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

(No code changes, only CI workflow permissions)