### PR TITLE
docs(website): Add Privacy Policy page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1649,29 +1649,7 @@ We welcome contributions from the community! To get started, please refer to our
 
 ## 🔒 Privacy Policy
 
-### Repomix CLI Tool
-
-- **Data Collection**: The Repomix CLI tool does **not** collect, transmit, or store any user data, telemetry, or repository information.
-- **Network Usage**: Repomix CLI operates fully offline after installation. The only cases where an internet connection is needed are:
-  - Installation via npm/yarn.
-  - Using the `--remote` flag to process remote repositories.
-  - Checking for updates (manually triggered).
-- **Security Considerations**: Since all processing is local, Repomix CLI is safe to use with private and internal repositories.
-
-### Repomix Website ([repomix.com](https://repomix.com/))
-
-- **Data Collection**: The Repomix website uses **Google Analytics** to collect usage data, such as page views and user interactions. This helps us understand how the website is used and improve the user experience.
-- **File Processing**: When uploading ZIP files or folders, your files are temporarily stored on our servers for processing. All uploaded files and processed data are automatically deleted immediately after processing is complete.
-
-### Repomix Browser Extension
-
-- **Data Collection**: The Repomix browser extension does **not** collect, transmit, or store any user data, telemetry, or repository information.
-- **Permissions**: The extension only requires minimal permissions necessary to add the Repomix button to GitHub repository pages. It does not access or modify repository data.
-
-### Liability Disclaimer
-
-Repomix (the CLI tool, website, and browser extension) is provided "as is" without any warranties or guarantees.  
-We do not take responsibility for how the generated output is used, including but not limited to its accuracy, legality, or any potential consequences arising from its use.
+See our [Privacy Policy](https://repomix.com/guide/privacy).
 
 ## 📜 License
 

--- a/website/client/.vitepress/config/configDe.ts
+++ b/website/client/.vitepress/config/configDe.ts
@@ -53,6 +53,7 @@ export const configDe = defineConfig({
             { text: 'Community-Projekte', link: '/de/guide/community-projects' },
             { text: 'Zu Repomix beitragen', link: '/de/guide/development/' },
             { text: 'Sponsoren', link: '/de/guide/sponsors' },
+            { text: 'Privacy Policy', link: '/de/guide/privacy' },
           ],
         },
       ],

--- a/website/client/.vitepress/config/configEnUs.ts
+++ b/website/client/.vitepress/config/configEnUs.ts
@@ -53,6 +53,7 @@ export const configEnUs = defineConfig({
             { text: 'Community Projects', link: '/guide/community-projects' },
             { text: 'Contributing to Repomix', link: '/guide/development/' },
             { text: 'Sponsors', link: '/guide/sponsors' },
+            { text: 'Privacy Policy', link: '/guide/privacy' },
           ],
         },
       ],

--- a/website/client/.vitepress/config/configEs.ts
+++ b/website/client/.vitepress/config/configEs.ts
@@ -53,6 +53,7 @@ export const configEs = defineConfig({
             { text: 'Proyectos de la Comunidad', link: '/es/guide/community-projects' },
             { text: 'Contribuir a Repomix', link: '/es/guide/development/' },
             { text: 'Patrocinadores', link: '/es/guide/sponsors' },
+            { text: 'Privacy Policy', link: '/es/guide/privacy' },
           ],
         },
       ],

--- a/website/client/.vitepress/config/configFr.ts
+++ b/website/client/.vitepress/config/configFr.ts
@@ -56,6 +56,7 @@ export const configFr = defineConfig({
             { text: 'Projets de la Communauté', link: '/fr/guide/community-projects' },
             { text: 'Contribuer à Repomix', link: '/fr/guide/development/' },
             { text: 'Sponsors', link: '/fr/guide/sponsors' },
+            { text: 'Privacy Policy', link: '/fr/guide/privacy' },
           ],
         },
       ],

--- a/website/client/.vitepress/config/configHi.ts
+++ b/website/client/.vitepress/config/configHi.ts
@@ -53,6 +53,7 @@ export const configHi = defineConfig({
             { text: 'समुदाय प्रोजेक्ट्स', link: '/hi/guide/community-projects' },
             { text: 'Repomix में योगदान', link: '/hi/guide/development/' },
             { text: 'प्रायोजक', link: '/hi/guide/sponsors' },
+            { text: 'Privacy Policy', link: '/hi/guide/privacy' },
           ],
         },
       ],

--- a/website/client/.vitepress/config/configId.ts
+++ b/website/client/.vitepress/config/configId.ts
@@ -56,6 +56,7 @@ export const configId = defineConfig({
             { text: 'Proyek Komunitas', link: '/id/guide/community-projects' },
             { text: 'Berkontribusi ke Repomix', link: '/id/guide/development/' },
             { text: 'Sponsor', link: '/id/guide/sponsors' },
+            { text: 'Privacy Policy', link: '/id/guide/privacy' },
           ],
         },
       ],

--- a/website/client/.vitepress/config/configJa.ts
+++ b/website/client/.vitepress/config/configJa.ts
@@ -51,6 +51,7 @@ export const configJa = defineConfig({
             { text: 'コミュニティプロジェクト', link: '/ja/guide/community-projects' },
             { text: 'Repomixに貢献する', link: '/ja/guide/development/' },
             { text: 'スポンサー', link: '/ja/guide/sponsors' },
+            { text: 'Privacy Policy', link: '/ja/guide/privacy' },
           ],
         },
       ],

--- a/website/client/.vitepress/config/configKo.ts
+++ b/website/client/.vitepress/config/configKo.ts
@@ -53,6 +53,7 @@ export const configKo = defineConfig({
             { text: '커뮤니티 프로젝트', link: '/ko/guide/community-projects' },
             { text: 'Repomix에 기여하기', link: '/ko/guide/development/' },
             { text: '후원자', link: '/ko/guide/sponsors' },
+            { text: 'Privacy Policy', link: '/ko/guide/privacy' },
           ],
         },
       ],

--- a/website/client/.vitepress/config/configPtBr.ts
+++ b/website/client/.vitepress/config/configPtBr.ts
@@ -53,6 +53,7 @@ export const configPtBr = defineConfig({
             { text: 'Projetos da Comunidade', link: '/pt-br/guide/community-projects' },
             { text: 'Contribuindo para o Repomix', link: '/pt-br/guide/development/' },
             { text: 'Patrocinadores', link: '/pt-br/guide/sponsors' },
+            { text: 'Privacy Policy', link: '/pt-br/guide/privacy' },
           ],
         },
       ],

--- a/website/client/.vitepress/config/configVi.ts
+++ b/website/client/.vitepress/config/configVi.ts
@@ -56,6 +56,7 @@ export const configVi = defineConfig({
             { text: 'Dự án Cộng đồng', link: '/vi/guide/community-projects' },
             { text: 'Đóng góp cho Repomix', link: '/vi/guide/development/' },
             { text: 'Nhà tài trợ', link: '/vi/guide/sponsors' },
+            { text: 'Privacy Policy', link: '/vi/guide/privacy' },
           ],
         },
       ],

--- a/website/client/.vitepress/config/configZhCn.ts
+++ b/website/client/.vitepress/config/configZhCn.ts
@@ -50,6 +50,7 @@ export const configZhCn = defineConfig({
             { text: '社区项目', link: '/zh-cn/guide/community-projects' },
             { text: '为Repomix做贡献', link: '/zh-cn/guide/development/' },
             { text: '赞助商', link: '/zh-cn/guide/sponsors' },
+            { text: 'Privacy Policy', link: '/zh-cn/guide/privacy' },
           ],
         },
       ],

--- a/website/client/.vitepress/config/configZhTw.ts
+++ b/website/client/.vitepress/config/configZhTw.ts
@@ -53,6 +53,7 @@ export const configZhTw = defineConfig({
             { text: '社群專案', link: '/zh-tw/guide/community-projects' },
             { text: '為Repomix做貢獻', link: '/zh-tw/guide/development/' },
             { text: '贊助商', link: '/zh-tw/guide/sponsors' },
+            { text: 'Privacy Policy', link: '/zh-tw/guide/privacy' },
           ],
         },
       ],

--- a/website/client/src/de/guide/privacy.md
+++ b/website/client/src/de/guide/privacy.md
@@ -1,0 +1,1 @@
+<!--@include: ../../en/guide/privacy.md-->

--- a/website/client/src/en/guide/privacy.md
+++ b/website/client/src/en/guide/privacy.md
@@ -1,0 +1,25 @@
+# Privacy Policy
+
+## Repomix CLI Tool
+
+- **Data Collection**: The Repomix CLI tool does **not** collect, transmit, or store any user data, telemetry, or repository information.
+- **Network Usage**: Repomix CLI operates fully offline after installation. The only cases where an internet connection is needed are:
+  - Installation via npm/yarn.
+  - Using the `--remote` flag to process remote repositories.
+  - Checking for updates (manually triggered).
+- **Security Considerations**: Since all processing is local, Repomix CLI is safe to use with private and internal repositories.
+
+## Repomix Website ([repomix.com](https://repomix.com/))
+
+- **Data Collection**: The Repomix website uses **Google Analytics** to collect usage data, such as page views and user interactions. This helps us understand how the website is used and improve the user experience.
+- **File Processing**: When uploading ZIP files or folders, your files are temporarily stored on our servers for processing. All uploaded files and processed data are automatically deleted immediately after processing is complete.
+
+## Repomix Browser Extension
+
+- **Data Collection**: The Repomix browser extension does **not** collect, transmit, or store any user data, telemetry, or repository information.
+- **Permissions**: The extension only requires minimal permissions necessary to add the Repomix button to GitHub repository pages. It does not access or modify repository data.
+
+## Liability Disclaimer
+
+Repomix (the CLI tool, website, and browser extension) is provided "as is" without any warranties or guarantees.
+We do not take responsibility for how the generated output is used, including but not limited to its accuracy, legality, or any potential consequences arising from its use.

--- a/website/client/src/es/guide/privacy.md
+++ b/website/client/src/es/guide/privacy.md
@@ -1,0 +1,1 @@
+<!--@include: ../../en/guide/privacy.md-->

--- a/website/client/src/fr/guide/privacy.md
+++ b/website/client/src/fr/guide/privacy.md
@@ -1,0 +1,1 @@
+<!--@include: ../../en/guide/privacy.md-->

--- a/website/client/src/hi/guide/privacy.md
+++ b/website/client/src/hi/guide/privacy.md
@@ -1,0 +1,1 @@
+<!--@include: ../../en/guide/privacy.md-->

--- a/website/client/src/id/guide/privacy.md
+++ b/website/client/src/id/guide/privacy.md
@@ -1,0 +1,1 @@
+<!--@include: ../../en/guide/privacy.md-->

--- a/website/client/src/ja/guide/privacy.md
+++ b/website/client/src/ja/guide/privacy.md
@@ -1,0 +1,1 @@
+<!--@include: ../../en/guide/privacy.md-->

--- a/website/client/src/ko/guide/privacy.md
+++ b/website/client/src/ko/guide/privacy.md
@@ -1,0 +1,1 @@
+<!--@include: ../../en/guide/privacy.md-->

--- a/website/client/src/pt-br/guide/privacy.md
+++ b/website/client/src/pt-br/guide/privacy.md
@@ -1,0 +1,1 @@
+<!--@include: ../../en/guide/privacy.md-->

--- a/website/client/src/vi/guide/privacy.md
+++ b/website/client/src/vi/guide/privacy.md
@@ -1,0 +1,1 @@
+<!--@include: ../../en/guide/privacy.md-->

--- a/website/client/src/zh-cn/guide/privacy.md
+++ b/website/client/src/zh-cn/guide/privacy.md
@@ -1,0 +1,1 @@
+<!--@include: ../../en/guide/privacy.md-->

--- a/website/client/src/zh-tw/guide/privacy.md
+++ b/website/client/src/zh-tw/guide/privacy.md
@@ -1,0 +1,1 @@
+<!--@include: ../../en/guide/privacy.md-->


### PR DESCRIPTION
Add a dedicated Privacy Policy page to the website, addressing user feedback about privacy information being hard to find on repomix.com.

## Changes

- Create Privacy Policy page with content from README (CLI, Website, Browser Extension, Liability Disclaimer)
- Add sidebar links in the Community section for all supported languages
- Non-English pages include English content via VitePress `@include` directive
- Simplify README Privacy Policy section to link only to the website

## Background

Discord user feedback indicated that privacy documentation was not easily discoverable on the website. Users who need to verify data handling for their work environment had to dig into the README to find this information.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`