### PR TITLE
chore(config): rename devcontainer and update Renovate schedule

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Claude Code Sandbox",
+  "name": "Repomix",
   "build": {
     "dockerfile": "Dockerfile",
     "args": {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,9 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "schedule:weekly",
     'group:allNonMajor'
   ],
+  "schedule": ["before 9am on saturday"],
   "rangeStrategy": "bump",
   "dependencyDashboard": false,
   "labels": ["dependencies", "renovate"],


### PR DESCRIPTION
- Rename devcontainer from "Claude Code Sandbox" to "Repomix"
- Change Renovate schedule from weekly (Monday) to Saturday

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`