### PR TITLE
refactor(ci): Improve claude-code-action workflows

### DIFF
--- a/.agents/commands/git/pr-review.md
+++ b/.agents/commands/git/pr-review.md
@@ -1,5 +1,29 @@
-Please review the provided PR.
+---
+allowed-tools: mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)
+description: Review a pull request
+---
 
-Even if there are no issues to point out, please leave a review comment on GitHub.
+$ARGUMENTS
 
-You can use the `gh` command for comments.
+If REPO and PR_NUMBER are not provided above, use `gh pr view` to detect the current PR.
+
+Please review this pull request and provide feedback on:
+- Code quality and best practices
+- Potential bugs or issues
+- Performance considerations
+- Security concerns
+- Test coverage
+
+Perform a premortem analysis: identify potential failure scenarios (e.g., edge cases, integration issues, deployment risks) and suggest mitigations.
+
+Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+## How to Comment:
+1. Before starting your review, read ALL existing comments on this PR using `gh pr view --comments` to see the full conversation
+2. If there are any previous comments from you (Claude), identify what feedback you've already provided
+3. Only provide NEW feedback that hasn't been mentioned yet, or updates to previous feedback if the code has changed
+4. Avoid repeating feedback that has already been given - focus on providing incremental value with each review
+5. For highlighting specific code issues, use `mcp__github_inline_comment__create_inline_comment` to leave inline comments
+   - When possible, provide actionable fix suggestions with code examples
+6. Use `gh pr comment` with your Bash tool to leave your overall review as a comment on the PR
+7. Wrap detailed feedback in <details><summary>Details</summary>...</details> tags, keeping only a brief summary visible

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -37,32 +37,8 @@ jobs:
         uses: anthropics/claude-code-action@a7e4c51380c42dd89b127f5e5f9be7b54020bc6b # v1.0.21
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
-
-            Perform a premortem analysis: identify potential failure scenarios (e.g., edge cases, integration issues, deployment risks) and suggest mitigations.
-
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
-
-            ## How to Comment:
-            1. Before starting your review, read ALL existing comments on this PR using `gh pr view --comments` to see the full conversation
-            2. If there are any previous comments from you (Claude), identify what feedback you've already provided
-            3. Only provide NEW feedback that hasn't been mentioned yet, or updates to previous feedback if the code has changed
-            4. Avoid repeating feedback that has already been given - focus on providing incremental value with each review
-            5. For highlighting specific code issues, use `mcp__github_inline_comment__create_inline_comment` to leave inline comments
-              - When possible, provide actionable fix suggestions with code examples
-            6. Use `gh pr comment` with your Bash tool to leave your overall review as a comment on the PR
-            7. Wrap detailed feedback in <details><summary>Details</summary>...</details> tags, keeping only a brief summary visible
-
+          prompt: "/git:pr-review REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--model opus --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          claude_args: '--model opus'
 

--- a/.github/workflows/claude-issue-similar.yml
+++ b/.github/workflows/claude-issue-similar.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: "*"
-          claude_args: '--model opus --allowed-tools "Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh search:*)"'
+          claude_args: '--model opus --allowedTools "Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh search:*)"'
           prompt: |
             You're an assistant that finds similar issues in the repository.
 

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: "*"
-          claude_args: '--model opus --allowed-tools "Bash(gh label list:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh search:*)"'
+          claude_args: '--model opus --allowedTools "Bash(gh label list:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh search:*)"'
           prompt: |
             You're an issue triage assistant for the Repomix repository. Your task is to analyze the issue and select appropriate labels from the repository's label list.
 


### PR DESCRIPTION
Improve claude-code-action workflow configurations based on latest documentation.

## Changes

- **PR Review**: Migrate prompt to slash command format (`.agents/commands/git/pr-review.md`)
  - Enables local usage with `/git:pr-review` command
  - Manages `allowed-tools` in frontmatter for better maintainability
- **All workflows**: Fix CLI argument from `--allowed-tools` to `--allowedTools` (correct camelCase format)
- **PR Review**: Change `pull-requests` permission from `read` to `write` for posting comments
- **PR Review**: Update documentation URL to `code.claude.com`

## Checklist

- [x] Run `npm run test` (N/A - CI config changes only)
- [x] Run `npm run lint` (N/A - CI config changes only)