### PR TITLE
ci(review): Skip Claude Code review for draft PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,9 +13,11 @@ on:
 jobs:
   claude-review:
     # Skip if:
+    # - PR is a draft
     # - PR is from a fork (secrets are not available)
     # - PR is from a bot (workflow validation may fail)
     if: |
+      github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.type != 'Bot'
 


### PR DESCRIPTION
Skip Claude Code review when PR is in draft state to avoid unnecessary reviews while work is still in progress.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`