### PR TITLE
fix(ci): Add concurrency to prevent Claude CLI install conflicts

### DIFF
--- a/.github/workflows/claude-issue-similar.yml
+++ b/.github/workflows/claude-issue-similar.yml
@@ -8,6 +8,9 @@ jobs:
   find-similar:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    concurrency:
+      group: claude-issue-${{ github.event.issue.number }}
+      cancel-in-progress: false
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -8,6 +8,9 @@ jobs:
   triage-issue:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    concurrency:
+      group: claude-issue-${{ github.event.issue.number }}
+      cancel-in-progress: false
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
When multiple Claude issue workflows (`claude-issue-similar.yml` and `claude-issue-triage.yml`) run simultaneously for the same issue, they conflict during Claude CLI installation with the error:

```
Could not install - another process is currently installing Claude.
```

This PR adds `concurrency` settings to both workflows with the same group key (`claude-issue-${{ github.event.issue.number }}`), ensuring sequential execution and preventing installation conflicts.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

(CI workflow changes only - no code changes)