### PR TITLE
chore(renovate): Exclude isbinaryfile from auto-updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,6 +16,7 @@
   ],
   "ignoreDeps": [
     "node",
+    "isbinaryfile", // v6+ requires Node.js >= 24
   ],
   "minimumReleaseAge": "7 days"
 }


### PR DESCRIPTION
Exclude `isbinaryfile` from Renovate auto-updates.

`isbinaryfile` v6+ requires Node.js >= 24, which would break our current Node.js >= 20 support. This PR excludes it from Renovate until we're ready to bump our minimum Node.js version.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`