### PR TITLE
fix(ci): Improve Claude issue triage to preserve existing labels

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -44,6 +44,7 @@ jobs:
 
             2. Next, use gh commands to get context about the issue:
                - Use `gh issue view ${{ github.event.issue.number }}` to retrieve the current issue's details
+               - Check if the issue already has any labels applied and avoid adding duplicate or conflicting labels
                - Use `gh search issues` to find similar issues that might provide context for proper categorization
 
             3. Analyze the issue content, considering:
@@ -68,6 +69,7 @@ jobs:
 
             5. Apply the selected labels:
                - Use `gh issue edit ${{ github.event.issue.number }} --add-label "label1,label2"` to apply your selected labels
+               - Do not remove existing labels
                - DO NOT post any comments explaining your decision
                - DO NOT communicate directly with users
                - If no labels are clearly applicable, do not apply any labels


### PR DESCRIPTION
Improve the Claude issue triage workflow to better handle existing labels:

- Add instruction to check if the issue already has labels applied and avoid duplicates
- Add explicit instruction to not remove existing labels

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

(No code changes, only workflow prompt updates)