### PR TITLE
feat(agents): Add AI bot inline comment evaluation to PR review

### DIFF
--- a/.agents/commands/git/pr-review.md
+++ b/.agents/commands/git/pr-review.md
@@ -28,11 +28,10 @@ Before starting your own review, evaluate existing AI bot inline review comments
    ```
 
 2. **Filter bot inline comments**:
-   - Only evaluate comments where `user.type === "Bot"`
+   - Only evaluate comments where `user.type === "Bot"` and `path` field is not null (inline comments only)
    - **SKIP comments from `claude`** - do not respond to Claude's own comments
-   - **SKIP if Claude already replied** - check `in_reply_to_id` field to see if any comment from `claude` already exists as a reply
+   - **SKIP if Claude already replied** - for each bot comment, check if any comment exists where `user.login` contains `claude` and `in_reply_to_id` matches the bot comment's `id`
    - Target bots: `gemini-code-assist[bot]`, `coderabbitai[bot]`, etc.
-   - Skip non-inline comments (general PR comments)
 
 3. **Judge priority for each inline comment**:
    - **Required**: Security issues, clear bugs, potential crashes, critical logic errors
@@ -41,9 +40,7 @@ Before starting your own review, evaluate existing AI bot inline review comments
 
 4. **Reply to each bot inline comment** with your judgment (in English):
    ```bash
-   gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies -f body="\`Priority: {Required/Recommended/Not needed}\`
-
-   {Brief explanation of your judgment}"
+   gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies -f body="\`Priority: {Required/Recommended/Not needed}\`\n\n{Brief explanation of your judgment}"
    ```
 
 5. **If clarification is needed**, ask in the reply:


### PR DESCRIPTION
Add functionality to evaluate and respond to AI bot review comments (e.g., gemini-code-assist, coderabbitai) during PR reviews.

## Purpose

This reduces maintainer cognitive load by having Claude automatically evaluate AI bot inline comments and provide priority judgments:

- `Priority: Required` - Security issues, clear bugs, potential crashes
- `Priority: Recommended` - Code quality improvements, best practice violations  
- `Priority: Not needed` - Style suggestions, false positives, already addressed

## Changes

- Add `gh api` commands to allowed-tools for fetching/replying to PR review comments
- Add "AI Bot Inline Comment Evaluation" section with clear workflow
- Skip Claude's own comments and already-replied comments
- Use backtick format for priority labels

## Example Output

```
`Priority: Not needed`

Already addressed. The `getSkillLocation()` function was added which uses `getSkillBaseDir()` to correctly determine the skill location.
```

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`