### PR TITLE
fix(core): Update iconv-lite import for 0.7.1 type compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "git-url-parse": "^16.1.0",
         "globby": "^16.0.0",
         "handlebars": "^4.7.8",
-        "iconv-lite": "^0.7.0",
+        "iconv-lite": "^0.7.1",
         "is-binary-path": "^3.0.0",
         "isbinaryfile": "^5.0.2",
         "jiti": "^2.6.1",
@@ -3247,9 +3247,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
+      "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "git-url-parse": "^16.1.0",
     "globby": "^16.0.0",
     "handlebars": "^4.7.8",
-    "iconv-lite": "^0.7.0",
+    "iconv-lite": "^0.7.1",
     "is-binary-path": "^3.0.0",
     "isbinaryfile": "^5.0.2",
     "jiti": "^2.6.1",

--- a/src/core/file/fileRead.ts
+++ b/src/core/file/fileRead.ts
@@ -1,9 +1,11 @@
 import * as fs from 'node:fs/promises';
-import iconv from 'iconv-lite';
+import iconvLite from 'iconv-lite';
 import isBinaryPath from 'is-binary-path';
 import { isBinaryFile } from 'isbinaryfile';
 import jschardet from 'jschardet';
 import { logger } from '../../shared/logger.js';
+
+const iconv = iconvLite.default ?? iconvLite;
 
 export type FileSkipReason = 'binary-extension' | 'binary-content' | 'size-limit' | 'encoding-error';
 

--- a/tests/core/file/fileCollect.test.ts
+++ b/tests/core/file/fileCollect.test.ts
@@ -1,7 +1,7 @@
 import type { Stats } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import path from 'node:path';
-import iconv from 'iconv-lite';
+import iconvLite from 'iconv-lite';
 import isBinaryPath from 'is-binary-path';
 import { isBinaryFile } from 'isbinaryfile';
 import jschardet from 'jschardet';
@@ -12,6 +12,8 @@ import fileCollectWorker from '../../../src/core/file/workers/fileCollectWorker.
 import { logger } from '../../../src/shared/logger.js';
 import type { WorkerOptions, WorkerRuntime } from '../../../src/shared/processConcurrency.js';
 import { createMockConfig } from '../../testing/testUtils.js';
+
+const iconv = iconvLite.default ?? iconvLite;
 
 // Define the max file size constant for tests
 const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB


### PR DESCRIPTION
## Summary

Fixes the CI failure in #1015 caused by iconv-lite 0.7.1's breaking TypeScript type definition changes.

### Problem

iconv-lite 0.7.1 changed its type definitions from:
```typescript
declare module 'iconv-lite' {
  export function decode(...): string;
  export function encodingExists(...): boolean;
}
```

To:
```typescript
declare namespace iconv {
  const iconv: { decode(...), encodingExists(...) }
  export { iconv as default }
}
export = iconv
```

This breaks `import iconv from 'iconv-lite'` even with `esModuleInterop: true`.

### Solution

Use `iconvLite.default ?? iconvLite` pattern for backwards compatibility:
```typescript
import iconvLite from 'iconv-lite';
const iconv = iconvLite.default ?? iconvLite;
```

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`