### PR TITLE
chore(renovate): Ignore iconv-lite until ESM types are fixed

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,6 +17,7 @@
   "ignoreDeps": [
     "node",
     "isbinaryfile", // v6+ requires Node.js >= 24
+    "iconv-lite", // v0.7.1 has broken ESM types: https://github.com/pillarjs/iconv-lite/issues/363
   ],
   "minimumReleaseAge": "7 days"
 }


### PR DESCRIPTION
## Summary

Exclude `iconv-lite` from Renovate updates until the ESM TypeScript types issue is fixed.

### Problem

iconv-lite v0.7.1 has broken TypeScript types for ESM projects:
- Types define functions under `.default` (e.g., `iconv.default.decode()`)
- Runtime exports functions directly (e.g., `iconv.decode()`)
- This causes CI failures in #1015

### Solution

Add `iconv-lite` to `ignoreDeps` in Renovate config until upstream fixes the issue.

### Related

- Upstream issue: https://github.com/pillarjs/iconv-lite/issues/363
- Affected PR: #1015

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`