### PR TITLE
feat(deps): Update web-tree-sitter to 0.26.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@clack/prompts": "^0.11.0",
         "@modelcontextprotocol/sdk": "^1.24.3",
         "@repomix/strip-comments": "^2.4.2",
-        "@repomix/tree-sitter-wasms": "^0.1.15",
+        "@repomix/tree-sitter-wasms": "^0.1.16",
         "@secretlint/core": "^11.2.5",
         "@secretlint/secretlint-rule-preset-recommend": "^11.2.5",
         "clipboardy": "^5.0.1",
@@ -33,7 +33,7 @@
         "picocolors": "^1.1.1",
         "tiktoken": "^1.0.22",
         "tinypool": "^2.0.0",
-        "web-tree-sitter": "^0.25.10",
+        "web-tree-sitter": "^0.26.3",
         "zod": "^4.1.13"
       },
       "bin": {
@@ -1099,9 +1099,9 @@
       }
     },
     "node_modules/@repomix/tree-sitter-wasms": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@repomix/tree-sitter-wasms/-/tree-sitter-wasms-0.1.15.tgz",
-      "integrity": "sha512-ReBeD3jcIqJTJcm4OS1gltWzUmia/Vuq3AE3630Ac1fGNP3fIH2nSPof4ksQR3rG/gwjPpcuW8l25B+dju8FsQ==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@repomix/tree-sitter-wasms/-/tree-sitter-wasms-0.1.16.tgz",
+      "integrity": "sha512-CIINozBWFwjhH4DQALN/b4n1S08fHhXQOdjX2G7s4w+Urew37aLU0AHVyCjHM5Pbnh63tDYt4YyUkS6vRUV38A==",
       "license": "Unlicense"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -6321,18 +6321,10 @@
       }
     },
     "node_modules/web-tree-sitter": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
-      "integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/emscripten": "^1.40.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/emscripten": {
-          "optional": true
-        }
-      }
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.3.tgz",
+      "integrity": "sha512-JIVgIKFS1w6lejxSntCtsS/QsE/ecTS00en809cMxMPxaor6MvUnQ+ovG8uTTTvQCFosSh4MeDdI5bSGw5SoBw==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@clack/prompts": "^0.11.0",
     "@modelcontextprotocol/sdk": "^1.24.3",
     "@repomix/strip-comments": "^2.4.2",
-    "@repomix/tree-sitter-wasms": "^0.1.15",
+    "@repomix/tree-sitter-wasms": "^0.1.16",
     "@secretlint/core": "^11.2.5",
     "@secretlint/secretlint-rule-preset-recommend": "^11.2.5",
     "clipboardy": "^5.0.1",
@@ -97,7 +97,7 @@
     "picocolors": "^1.1.1",
     "tiktoken": "^1.0.22",
     "tinypool": "^2.0.0",
-    "web-tree-sitter": "^0.25.10",
+    "web-tree-sitter": "^0.26.3",
     "zod": "^4.1.13"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Update `web-tree-sitter` from `^0.25.10` to `^0.26.3`
- Update `@repomix/tree-sitter-wasms` from `^0.1.15` to `^0.1.16`

The tree-sitter-wasms package was rebuilt with tree-sitter-cli 0.26.x to ensure WASM compatibility with the new web-tree-sitter version.

### Key changes in web-tree-sitter 0.26.x:
- Rewritten in TypeScript with better type definitions
- ESM and CommonJS dual module support  
- WASM build switched from emscripten to wasi-sdk

Related: #1015

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`