### PR TITLE
chore(devcontainer): Change workspace path to /workspace/repomix

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -57,10 +57,10 @@ RUN mkdir /commandhistory \
 ENV DEVCONTAINER=true
 
 # Create workspace and config directories and set permissions
-RUN mkdir -p /workspace /home/node/.claude && \
+RUN mkdir -p /workspace/repomix /home/node/.claude && \
   chown -R node:node /workspace /home/node/.claude
 
-WORKDIR /workspace
+WORKDIR /workspace/repomix
 
 ARG GIT_DELTA_VERSION=0.18.2
 RUN ARCH=$(dpkg --print-architecture) && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,8 +45,8 @@
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
     "POWERLEVEL9K_DISABLE_GITSTATUS": "true"
   },
-  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
-  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/repomix,type=bind,consistency=delegated",
+  "workspaceFolder": "/workspace/repomix",
   "postStartCommand": "sudo /usr/local/bin/init-firewall.sh",
   "waitFor": "postStartCommand"
 }


### PR DESCRIPTION
Change the devcontainer workspace path from `/workspace` to `/workspace/repomix` to avoid conflicts with other devcontainers that may use the default `/workspace` directory.

## Changes
- Update `workspaceMount` target in devcontainer.json
- Update `workspaceFolder` in devcontainer.json
- Update `mkdir` and `WORKDIR` in Dockerfile

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

Note: These changes only affect devcontainer configuration and don't require test/lint verification.