### PR TITLE
chore(skill,devcontainer): Update memory skill docs and fix ast-grep install

### DIFF
--- a/.claude/skills/memory/SKILL.md
+++ b/.claude/skills/memory/SKILL.md
@@ -63,12 +63,14 @@ tags: [performance, worker]
 
 ### Recall
 
+**Note:** Memory files are gitignored, so use `--no-ignore` (or `-I`) and `--hidden` (or `-H`) flags.
+
 ```bash
 # List all memories
-fd . .claude/skills/memory/memories/ --type f
+fd . .claude/skills/memory/memories/ --type f --no-ignore --hidden
 
 # Search by content
-rg "<query>" .claude/skills/memory/memories/ -g "*.md"
+rg "<query>" .claude/skills/memory/memories/ --no-ignore --hidden
 ```
 
 ### Maintain

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -39,7 +39,9 @@ RUN ARCH=$(dpkg --print-architecture) && \
     arm64) AST_ARCH="aarch64-unknown-linux-gnu" ;; \
     *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
   esac && \
-  wget -qO- "https://github.com/ast-grep/ast-grep/releases/latest/download/ast-grep-${AST_ARCH}.tar.gz" | tar xz -C /usr/local/bin
+  wget -q "https://github.com/ast-grep/ast-grep/releases/latest/download/app-${AST_ARCH}.zip" -O /tmp/ast-grep.zip && \
+  unzip -q /tmp/ast-grep.zip -d /usr/local/bin && \
+  rm /tmp/ast-grep.zip
 
 # Ensure default node user has access to /usr/local/share
 RUN mkdir -p /usr/local/share/npm-global && \


### PR DESCRIPTION
## Summary

- Add note to memory skill about gitignored files requiring `--no-ignore` and `--hidden` flags for `fd` and `rg` commands
- Fix ast-grep installation in devcontainer to use zip format instead of tar.gz (upstream changed release format)

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`