### PR TITLE
chore(renovate): Split dependency updates by directory

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    'group:allNonMajor'
   ],
   "schedule": ["before 9am on saturday"],
   "rangeStrategy": "bump",
@@ -12,6 +11,50 @@
     {
       matchDepTypes: ['peerDependencies'],
       enabled: false,
+    },
+    // Root package.json
+    {
+      matchFileNames: ['package.json'],
+      matchUpdateTypes: ['minor', 'patch'],
+      groupName: 'root non-major dependencies',
+    },
+    {
+      matchFileNames: ['package.json'],
+      matchUpdateTypes: ['major'],
+      groupName: 'root major dependencies',
+    },
+    // Browser extension
+    {
+      matchFileNames: ['browser/package.json'],
+      matchUpdateTypes: ['minor', 'patch'],
+      groupName: 'browser non-major dependencies',
+    },
+    {
+      matchFileNames: ['browser/package.json'],
+      matchUpdateTypes: ['major'],
+      groupName: 'browser major dependencies',
+    },
+    // Website packages (client & server)
+    {
+      matchFileNames: ['website/**/package.json'],
+      matchUpdateTypes: ['minor', 'patch'],
+      groupName: 'website non-major dependencies',
+    },
+    {
+      matchFileNames: ['website/**/package.json'],
+      matchUpdateTypes: ['major'],
+      groupName: 'website major dependencies',
+    },
+    // Scripts packages
+    {
+      matchFileNames: ['scripts/**/package.json'],
+      matchUpdateTypes: ['minor', 'patch'],
+      groupName: 'scripts non-major dependencies',
+    },
+    {
+      matchFileNames: ['scripts/**/package.json'],
+      matchUpdateTypes: ['major'],
+      groupName: 'scripts major dependencies',
     },
   ],
   "ignoreDeps": [


### PR DESCRIPTION
## Summary

Split Renovate dependency update PRs by directory for better maintainability:

- **root**: `package.json`
- **browser**: `browser/package.json`
- **website**: `website/**/package.json`
- **scripts**: `scripts/**/package.json`

Each directory is further split by major/non-major updates.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`