### PR TITLE
docs(claude): Improve agent-memory skill guidelines

### DIFF
--- a/.claude/skills/agent-memory/SKILL.md
+++ b/.claude/skills/agent-memory/SKILL.md
@@ -16,14 +16,17 @@ Save memories when you discover something worth preserving:
 - Non-obvious patterns or gotchas in the codebase
 - Solutions to tricky problems
 - Architectural decisions and their rationale
+- In-progress work that may be resumed later
 
 Check memories when starting related work:
 - Before investigating a problem area
 - When working on a feature you've touched before
+- When resuming work after a conversation break
 
 Organize memories when needed:
 - Consolidate scattered memories on the same topic
 - Remove outdated or superseded information
+- Update status field when work completes, gets blocked, or is abandoned
 
 ## Folder Structure
 
@@ -64,6 +67,7 @@ created: 2025-01-15  # YYYY-MM-DD format
 summary: "Worker thread memory leak during large file processing - cause and solution"
 created: 2025-01-15
 updated: 2025-01-20
+status: in-progress  # in-progress | resolved | blocked | abandoned
 tags: [performance, worker, memory-leak]
 related: [src/core/file/fileProcessor.ts]
 ---
@@ -131,7 +135,17 @@ EOF
 
 ## Guidelines
 
-1. **Write for your future self**: Include enough context to be useful later
+1. **Write self-contained notes**: Include full context so the reader needs no prior knowledge to understand and act on the content
 2. **Keep summaries decisive**: Reading the summary should tell you if you need the details
 3. **Stay current**: Update or delete outdated information
 4. **Be practical**: Save what's actually useful, not everything
+
+## Content Reference
+
+When writing detailed memories, consider including:
+- **Context**: Goal, background, constraints
+- **State**: What's done, in progress, or blocked
+- **Details**: Key files, commands, code snippets
+- **Next steps**: What to do next, open questions
+
+Not all memories need all sections - use what's relevant.


### PR DESCRIPTION
Enhance agent-memory skill to better support resuming work from a fresh conversation.

## Changes

- **Guidelines**: Change "Write for your future self" to "Write self-contained notes" - emphasizes including full context so readers need no prior knowledge
- **Frontmatter**: Add optional `status` field (`in-progress` / `resolved` / `blocked` / `abandoned`) for tracking work state
- **Proactive Usage**: Add guidance for saving in-progress work and checking memories when resuming after a break
- **Content Reference**: New section with checklist for detailed memories (Context, State, Details, Next steps)

## Design Intent

- Keep simplicity while encouraging sufficient information for cold-start resumption
- Status field is optional - use for work logs, omit for reference knowledge
- Content Reference is a suggestion, not a rigid template

## Checklist

- [x] Run `npm run test` (N/A - documentation only)
- [x] Run `npm run lint` (N/A - documentation only)