### PR TITLE
docs(skills): improve agent-memory skill guidelines

### DIFF
--- a/.claude/skills/agent-memory/SKILL.md
+++ b/.claude/skills/agent-memory/SKILL.md
@@ -137,10 +137,11 @@ EOF
 
 ## Guidelines
 
-1. **Write self-contained notes**: Include full context so the reader needs no prior knowledge to understand and act on the content
-2. **Keep summaries decisive**: Reading the summary should tell you if you need the details
-3. **Stay current**: Update or delete outdated information
-4. **Be practical**: Save what's actually useful, not everything
+1. **Write for resumption**: Memories exist to resume work later. Capture all key points needed to continue without losing context - decisions made, reasons why, current state, and next steps.
+2. **Write self-contained notes**: Include full context so the reader needs no prior knowledge to understand and act on the content
+3. **Keep summaries decisive**: Reading the summary should tell you if you need the details
+4. **Stay current**: Update or delete outdated information
+5. **Be practical**: Save what's actually useful, not everything
 
 ## Content Reference
 


### PR DESCRIPTION
Improve the agent-memory skill documentation with clearer guidance on how to write effective memories.

## Changes

- **Clarify summary field purpose**: Added explanation that summaries are the decision point for agents scanning memories via `rg "^summary:"`. This helps agents understand they need to include enough context in summaries for the decision of whether to read the full content.

- **Add resumption guideline**: Added "Write for resumption" as the first guideline to emphasize that memories exist to resume work later and should capture all key points needed to continue without losing context.

## Checklist

- [x] Run `npm run test` - N/A (docs only)
- [x] Run `npm run lint` - N/A (docs only)