### PR TITLE
fix(security): Add --receive-pack to git URL validation

### DIFF
--- a/src/core/git/gitCommand.ts
+++ b/src/core/git/gitCommand.ts
@@ -190,7 +190,9 @@ export const execGitLog = async (
  * @throws {RepomixError} If the URL is invalid or contains potentially dangerous parameters
  */
 export const validateGitUrl = (url: string): void => {
-  if (url.includes('--upload-pack') || url.includes('--config') || url.includes('--exec')) {
+  // Block dangerous git parameters that could be used for command injection
+  const dangerousParams = ['--upload-pack', '--receive-pack', '--config', '--exec'];
+  if (dangerousParams.some((param) => url.includes(param))) {
     throw new RepomixError(`Invalid repository URL. URL contains potentially dangerous parameters: ${url}`);
   }
 


### PR DESCRIPTION
Add `--receive-pack` parameter to the list of blocked dangerous git parameters in `validateGitUrl` function.

This parameter, like `--upload-pack`, can be used to execute arbitrary binaries and poses a security risk. This change aligns with security practices used in other git libraries.

## Changes

- Added `--receive-pack` to blocked parameters in `validateGitUrl`
- Reorganized security check tests into a dedicated `describe` block
- Added test case for `--receive-pack` parameter validation

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`