### PR TITLE
chore(config): Optimize tsconfig for TypeScript 5.x and Node.js 20+

### DIFF
--- a/tests/fixtures/config-ts/repomix.config.cts
+++ b/tests/fixtures/config-ts/repomix.config.cts
@@ -1,6 +1,6 @@
 // Don't import defineConfig to avoid jiti transforming src/ files during tests
 // This ensures stable coverage by preventing double instrumentation
-export default {
+module.exports = {
   output: {
     filePath: 'cts-output.xml',
     style: 'plain',

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "declaration": true,
     "sourceMap": false,
     "declarationMap": false,
     "removeComments": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,13 @@
 {
-  "compileOnSave": false,
   "compilerOptions": {
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "target": "es2016",
+    "moduleDetection": "force",
+    "target": "es2022",
     "outDir": "./lib",
     "rootDir": ".",
     "strict": true,
-    "esModuleInterop": true,
-    "noImplicitAny": true,
+    "verbatimModuleSyntax": true,
     "skipLibCheck": true,
     "lib": ["es2022"],
     "declaration": true,


### PR DESCRIPTION
Optimize TypeScript configuration for modern TypeScript 5.x and Node.js 20+ environment.

## Changes

### tsconfig.json
- **target**: `es2016` → `es2022` - Node.js 20+ fully supports ES2022, reducing unnecessary downlevel compilation
- **moduleDetection**: Added `"force"` - Ensures all files are treated as modules in ESM project
- **verbatimModuleSyntax**: Added `true` - TypeScript 5.0+ recommended setting for explicit control over import/export
- **esModuleInterop**: Removed - Replaced by `verbatimModuleSyntax`
- **noImplicitAny**: Removed - Redundant, already included in `strict: true`
- **compileOnSave**: Removed - VS Code ignores this option, only affects legacy Visual Studio

### tsconfig.build.json
- **declaration**: Removed - Already set in base tsconfig.json

### tests/fixtures/config-ts/repomix.config.cts
- Changed `export default` to `module.exports` - `.cts` files are CommonJS, so must use CommonJS syntax with `verbatimModuleSyntax: true`

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`