### PR TITLE
chore(config): Add cache directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@ node_modules/
 # Build output
 lib/
 website/client/.vitepress/dist/
+website/client/.vitepress/cache/
 website/server/dist/
+website/server/.compile-cache/
 
 # Logs
 *.log


### PR DESCRIPTION
Add website cache directories to root `.gitignore` to speed up `npm run lint-secretlint`:

- `website/client/.vitepress/cache/`
- `website/server/.compile-cache/`

These directories were already in their respective subdirectory `.gitignore` files, but secretlint's `--secretlintignore` option only reads the specified single file (root `.gitignore`), not subdirectory `.gitignore` files like git does.

**Result**: Scanned files reduced from 2,506 to 1,007 (60% reduction).

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1107">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
