### PR TITLE
fix(website): Specify Dockerfile path for Cloud Build trigger

### DIFF
--- a/website/server/cloudbuild.yaml
+++ b/website/server/cloudbuild.yaml
@@ -10,7 +10,9 @@ steps:
       - '$_REGION-docker.pkg.dev/$PROJECT_ID/repomix/server:latest'
       - '--build-arg'
       - 'NODE_ENV=production'
-      - '.'
+      - '-f'
+      - 'website/server/Dockerfile'
+      - 'website/server'
 
   # Push the container image
   - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
## Summary

Cloud Build triggers execute from the repository root, not from the cloudbuild.yaml directory location. This caused the build to use the wrong Dockerfile and context, resulting in `rimraf not found` errors.

Changes:
- Added `-f website/server/Dockerfile` to explicitly specify the Dockerfile path
- Changed build context from `.` to `website/server`

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

Note: This is a Cloud Build configuration change only, no code changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1108">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
