### PR TITLE
docs(treeSitter): Add rationale for using web-tree-sitter over native bindings

### DIFF
--- a/src/core/treeSitter/parseFile.ts
+++ b/src/core/treeSitter/parseFile.ts
@@ -1,3 +1,23 @@
+/**
+ * File parsing using tree-sitter for the compress feature.
+ *
+ * Why we use web-tree-sitter (WASM) instead of node-tree-sitter (native bindings):
+ *
+ * 1. Cross-platform compatibility: WASM works identically across all platforms
+ *    without requiring native compilation.
+ *
+ * 2. Easy installation: No build tools (Python, C++ compiler, node-gyp) required.
+ *    Users can install Repomix with just `npm install` on any environment.
+ *
+ * 3. Fewer dependencies: All language parsers are bundled in a single package
+ *    (@repomix/tree-sitter-wasms) instead of 15+ separate native packages.
+ *
+ * 4. Reliability: Native modules can fail to build on certain Node.js versions
+ *    (e.g., Node.js v23 has known issues with node-tree-sitter).
+ *
+ * The performance overhead of WASM is acceptable for the compress feature's use case.
+ */
+
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
 import type { SupportedLang } from './languageConfig.js';


### PR DESCRIPTION
Document why Repomix uses web-tree-sitter (WASM) instead of node-tree-sitter (native bindings) in the parseFile.ts header comment.

This helps future maintainers understand the architectural decision when they consider switching to native bindings for better performance.

Key reasons documented:
- Cross-platform compatibility without native compilation
- Easy installation without build tools (Python, C++ compiler, node-gyp)
- Fewer dependencies (single package vs 15+ native packages)
- Reliability across Node.js versions (e.g., Node.js v23 issues)

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1116">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
