### PR TITLE
docs(website): Add Tower sponsor to website sponsors section

### DIFF
--- a/website/client/src/shared/sponsors-section.md
+++ b/website/client/src/shared/sponsors-section.md
@@ -17,6 +17,14 @@
    </a>
 
   [Tuple, the premier screen sharing app for developers on macOS and Windows.](https://tuple.app/repomix)
+
+  <br>
+
+   <a href="https://git-tower.com/?utm_source=repomix&utm_medium=referral" target="_blank">
+      <img alt="Tower sponsorship" width="255" src="/images/sponsors/tower/tower-dock-icon-light.png">
+   </a>
+
+  [Tower, the most powerful Git client for Mac and Windows](https://git-tower.com/?utm_source=repomix&utm_medium=referral)
 </div>
 
 [![Sponsors](https://cdn.jsdelivr.net/gh/yamadashy/sponsor-list/sponsors/sponsors.png)](https://github.com/sponsors/yamadashy)


### PR DESCRIPTION
Add Tower sponsor to the website's shared sponsors section.

Tower was already listed as a sponsor in README.md but was missing from `website/client/src/shared/sponsors-section.md`, which is used across all language pages on the website.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
