### PR TITLE
style(website): Adjust Tower sponsor image width

### DIFF
--- a/website/client/src/shared/sponsors-section.md
+++ b/website/client/src/shared/sponsors-section.md
@@ -21,7 +21,7 @@
   <br>
 
    <a href="https://git-tower.com/?utm_source=repomix&utm_medium=referral" target="_blank">
-      <img alt="Tower sponsorship" width="255" src="/images/sponsors/tower/tower-dock-icon-light.png">
+      <img alt="Tower sponsorship" width="225" src="/images/sponsors/tower/tower-dock-icon-light.png">
    </a>
 
   [Tower, the most powerful Git client for Mac and Windows](https://git-tower.com/?utm_source=repomix&utm_medium=referral)


### PR DESCRIPTION
Reduce Tower sponsor image width from 255 to 225 for better visual balance.

## Checklist

- [ ] Run `npm run test`
- [ ] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
