### PR TITLE
fix(cli): Respect local config when using --remote option

### DIFF
--- a/src/config/configLoad.ts
+++ b/src/config/configLoad.ts
@@ -241,3 +241,12 @@ export const mergeConfigs = (
     throw error;
   }
 };
+
+/**
+ * Searches for a config file in the given directory using the default config file name priority order.
+ * Returns the absolute path to the found config file, or null if none found.
+ */
+export const findLocalConfigPath = async (dir: string): Promise<string | null> => {
+  const configPaths = defaultConfigPaths.map((configPath) => path.resolve(dir, configPath));
+  return await findConfigFile(configPaths, 'local (cwd)');
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export { setWasmBasePath } from './core/treeSitter/loadLanguage.js';
 // ---------------------------------------------------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------------------------------------------------
-export { loadFileConfig, mergeConfigs } from './config/configLoad.js';
+export { loadFileConfig, mergeConfigs, findLocalConfigPath } from './config/configLoad.js';
 export type { RepomixConfigFile as RepomixConfig } from './config/configSchema.js';
 export { defineConfig } from './config/configSchema.js';
 export { defaultIgnoreList } from './config/defaultIgnore.js';


### PR DESCRIPTION
<!-- Please include a summary of the changes -->

Fixes #1025

When using `--remote`, repomix ignores the local `repomix.config.json` because it searches for config files in the cloned temporary directory instead of the current working directory (CWD).

This PR resolves the issue by ensuring config paths are resolved from CWD before being passed to `runDefaultAction`:

1. **Explicit `-c` config paths** are resolved to absolute paths relative to CWD, so they remain valid even when the working directory changes to the temp clone directory.
2. **Auto-discovery** searches CWD for default config files (e.g., `repomix.config.json`) first via the new `findLocalConfigPath` utility, and passes the found absolute path to `runDefaultAction`.
3. If no local config is found in CWD, the behavior falls through to the existing global config search logic.

### Changed files

- `src/cli/actions/remoteAction.ts` — Resolve config from CWD before calling `runDefaultAction`
- `src/config/configLoad.ts` — Export new `findLocalConfigPath` helper
- `src/index.ts` — Add `findLocalConfigPath` to public API exports
- `tests/cli/actions/remoteAction.test.ts` — Add 3 tests for the config resolution behavior

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
