### PR TITLE
feat: add --no-color flag and respect NO_COLOR environment variable

### DIFF
--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -44,6 +44,8 @@ const semanticSuggestionMap: Record<string, string[]> = {
   print: ['--stdout'],
   console: ['--stdout'],
   terminal: ['--stdout'],
+  plain: ['--no-color'],
+  monochrome: ['--no-color'],
   pipe: ['--stdin'],
 };
 
@@ -74,6 +76,7 @@ export const run = async () => {
       )
       .option('--stdin', 'Read file paths from stdin, one per line (specified files are processed directly)')
       .option('--copy', 'Copy the generated output to system clipboard after processing')
+      .option('--no-color', 'Disable colored output (also respects NO_COLOR env variable, see https://no-color.org)')
       .option(
         '--token-count-tree [threshold]',
         'Show file tree with token counts; optional threshold to show only files with ≥N tokens (e.g., --token-count-tree 100)',

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -69,4 +69,5 @@ export interface CliOptions extends OptionValues {
   topFilesLen?: number;
   verbose?: boolean;
   quiet?: boolean;
+  color?: boolean;
 }


### PR DESCRIPTION
## Summary
Fixes #1057

- Added `--no-color` CLI flag to Commander so it is recognized by the CLI parser
- The underlying color library (picocolors) already natively disables coloring when `--no-color` is in `process.argv` or `NO_COLOR` is set in the environment — this PR simply registers the flag so Commander doesn't reject it as an unknown option
- Added semantic suggestions (`plain`, `monochrome`) pointing to `--no-color` for discoverability
- Added `color` property to `CliOptions` type

This follows the [NO_COLOR standard](https://no-color.org/) and provides users with terminal color schemes (like solarized) a way to disable coloring.

## Test Plan
- [x] All 1097 existing tests pass
- [x] `repomix --no-color --version` works without error
- [x] `NO_COLOR=1 repomix --version` works without error
- [x] Previously, `repomix --no-color` produced `error: unknown option '--no-color'`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
