### PR TITLE
fix(ignore): use case-sensitive matching to prevent BUILD file exclusion on macOS

### DIFF
--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -316,6 +316,9 @@ const createBaseGlobbyOptions = (
   absolute: false,
   dot: true,
   followSymbolicLinks: false,
+  // Force case-sensitive pattern matching regardless of OS filesystem case sensitivity.
+  // Without this, on macOS (HFS+/APFS case-insensitive), the default ignore pattern
+  // `build/**` would incorrectly exclude Pants BUILD files.
   caseSensitiveMatch: true,
 });
 

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -316,6 +316,7 @@ const createBaseGlobbyOptions = (
   absolute: false,
   dot: true,
   followSymbolicLinks: false,
+  caseSensitiveMatch: true,
 });
 
 export const getIgnoreFilePatterns = async (config: RepomixConfigMerged): Promise<string[]> => {

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -290,6 +290,7 @@ node_modules
           absolute: false,
           dot: true,
           followSymbolicLinks: false,
+          caseSensitiveMatch: true,
         }),
       );
     });
@@ -943,6 +944,7 @@ node_modules
           absolute: false,
           dot: true,
           followSymbolicLinks: false,
+          caseSensitiveMatch: true,
         });
 
         // Each call should have either onlyFiles or onlyDirectories, but not both

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -956,6 +956,29 @@ node_modules
         }
       }
     });
+    test('should not exclude uppercase BUILD files when build/** is in ignore patterns', async () => {
+      const mockConfig = createMockConfig({
+        include: ['**/*'],
+        ignore: {
+          useGitignore: false,
+          useDefaultPatterns: false,
+          customPatterns: ['build/**'],
+        },
+      });
+
+      // Globby with caseSensitiveMatch: true should NOT exclude BUILD files
+      vi.mocked(globby).mockResolvedValue(['src/BUILD', 'BUILD']);
+
+      const result = await searchFiles('/mock/root', mockConfig);
+
+      expect(result.filePaths).toContain('src/BUILD');
+      expect(result.filePaths).toContain('BUILD');
+      expect(globby).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ caseSensitiveMatch: true }),
+      );
+    });
+
 
     test('should respect gitignore config consistently across all functions', async () => {
       const mockConfigWithoutGitignore = createMockConfig({


### PR DESCRIPTION
## Summary

On case-insensitive file systems (macOS HFS+/APFS), the default ignore pattern `build/**` incorrectly matches Pants build tool's `BUILD` files. This one-line fix ensures ignore patterns match with exact case.

## Problem

- Default ignore has `build/**` ([defaultIgnore.ts:111](https://github.com/yamadashy/repomix/blob/main/src/config/defaultIgnore.ts#L111))
- macOS HFS+/APFS is case-insensitive by default
- `BUILD` files (used by [Pants](https://www.pantsbuild.org/)) get matched by `build/**`
- Users can't simply add `!BUILD` to include patterns

## Fix

Sets `caseSensitiveMatch: true` in `createBaseGlobbyOptions()`. This is a globby/fast-glob option that forces case-sensitive pattern matching regardless of the OS filesystem. `build/**` will only match lowercase `build/` directories — not `BUILD` source files.

This is the simplest and most correct approach from the potential solutions listed in #980 (option 1). It also matches the behavior users expect from their `.gitignore` and `.repomixignore` patterns.

## Changes

- `src/core/file/fileSearch.ts`: Add `caseSensitiveMatch: true` to `createBaseGlobbyOptions()`
- `tests/core/file/fileSearch.test.ts`: Update globby options assertions

Fixes #980
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
