### PR TITLE
perf(cli): Enable Node.js module compile cache for faster startup

### DIFF
--- a/bin/repomix.cjs
+++ b/bin/repomix.cjs
@@ -1,5 +1,15 @@
 #!/usr/bin/env node
 
+// https://nodejs.org/api/module.html#module-compile-cache
+const nodeModule = require('node:module');
+if (nodeModule.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
+  try {
+    nodeModule.enableCompileCache();
+  } catch {
+    // Ignore errors
+  }
+}
+
 const nodeVersion = process.versions.node;
 const [major] = nodeVersion.split('.').map(Number);
 


### PR DESCRIPTION
Enable V8 compile cache via `module.enableCompileCache()` in the CLI entry point to speed up startup by caching compiled bytecode across runs.

- Available on Node.js >= 22.8.0, gracefully skipped on older versions
- Can be disabled via `NODE_DISABLE_COMPILE_CACHE` env var
- Benchmark results (`--version`, 50 runs each, sequential):

| | Mean | σ | Min | Max |
|---|---|---|---|---|
| **with compile cache** | 151.4ms | ±8.2ms | 139.5ms | 182.3ms |
| **without compile cache** | 167.4ms | ±12.5ms | 153.8ms | 213.4ms |

**~10% startup improvement** with zero downside.

Reference: https://nodejs.org/api/module.html#module-compile-cache

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
