### PR TITLE
fix(treeSitter): use tree-sitter-tsx.wasm for .tsx files instead of t…

### DIFF
--- a/src/core/treeSitter/languageConfig.ts
+++ b/src/core/treeSitter/languageConfig.ts
@@ -40,6 +40,7 @@ export type SupportedLang =
   | 'rust'
   | 'solidity'
   | 'swift'
+  | 'tsx'
   | 'typescript'
   | 'vue';
 
@@ -70,7 +71,13 @@ export const LANGUAGE_CONFIGS: readonly LanguageConfig[] = [
   },
   {
     name: 'typescript',
-    extensions: ['ts', 'tsx', 'mts', 'mtsx', 'cts'],
+    extensions: ['ts', 'mts', 'cts'],
+    query: queryTypescript,
+    createStrategy: () => new TypeScriptParseStrategy(),
+  },
+  {
+    name: 'tsx',
+    extensions: ['tsx', 'mtsx'],
     query: queryTypescript,
     createStrategy: () => new TypeScriptParseStrategy(),
   },

--- a/tests/core/treeSitter/LanguageParser.test.ts
+++ b/tests/core/treeSitter/LanguageParser.test.ts
@@ -13,6 +13,7 @@ describe('LanguageParser', () => {
       const testCases = [
         { filePath: 'file.js', expected: 'javascript' },
         { filePath: 'file.ts', expected: 'typescript' },
+        { filePath: 'file.tsx', expected: 'tsx' },
         { filePath: 'file.sol', expected: 'solidity' },
         { filePath: 'Contract.sol', expected: 'solidity' },
         { filePath: 'path/to/MyContract.sol', expected: 'solidity' },

--- a/tests/core/treeSitter/parseFile.typescript.test.ts
+++ b/tests/core/treeSitter/parseFile.typescript.test.ts
@@ -102,6 +102,46 @@ describe('TypeScript File Parsing', () => {
         expect(result).toContain(expectContent);
       }
     });
+
+    test('should parse TSX with JSX syntax correctly', async () => {
+      const fileContent = `
+        import React from 'react';
+
+        interface ButtonProps {
+          label: string;
+          onClick: () => void;
+          disabled?: boolean;
+        }
+
+        /**
+         * A reusable button component
+         */
+        export function Button({ label, onClick, disabled }: ButtonProps) {
+          return (
+            <button onClick={onClick} disabled={disabled}>
+              {label}
+            </button>
+          );
+        }
+      `;
+      const filePath = 'Button.tsx';
+      const config = {};
+      const result = await parseFile(fileContent, filePath, config as RepomixConfigMerged);
+      expect(typeof result).toBe('string');
+
+      const expectContents = [
+        'ButtonProps',
+        'label',
+        'onClick',
+        'disabled',
+        'Button',
+        'A reusable button component',
+      ];
+
+      for (const expectContent of expectContents) {
+        expect(result).toContain(expectContent);
+      }
+    });
   });
 
   describe('TypeScript Parse Strategy', () => {


### PR DESCRIPTION
…ree-sitter-typescript

.tsx files were grouped under the 'typescript' language config, causing them to be parsed with tree-sitter-typescript.wasm which does not understand JSX syntax. This splits .tsx/.mtsx into a separate 'tsx' config entry so they load tree-sitter-tsx.wasm instead.

<!-- Please include a summary of the changes -->

## Checklist

- [ ] Run `npm run test`
- [ ] Run `npm run lint`
