### PR TITLE
fix(ci): Restrict allowedTools to current issue number in Claude workflows

### DIFF
--- a/.github/workflows/claude-issue-similar.yml
+++ b/.github/workflows/claude-issue-similar.yml
@@ -28,7 +28,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: "*"
-          claude_args: '--model opus --allowedTools "Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh search:*)"'
+          claude_args: '--model opus --allowedTools "Bash(gh issue view ${{ github.event.issue.number }}:*),Bash(gh issue comment ${{ github.event.issue.number }}:*),Bash(gh search:*)"'
           prompt: |
             You're an assistant that finds similar issues in the repository.
 

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -28,7 +28,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: "*"
-          claude_args: '--model opus --allowedTools "Bash(gh label list:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh search:*)"'
+          claude_args: '--model opus --allowedTools "Bash(gh label list:*),Bash(gh issue view ${{ github.event.issue.number }}:*),Bash(gh issue edit ${{ github.event.issue.number }}:*),Bash(gh search:*)"'
           prompt: |
             You're an issue triage assistant for the Repomix repository. Your task is to analyze the issue and select appropriate labels from the repository's label list.
 


### PR DESCRIPTION
Restrict `allowedTools` in Claude issue triage and similar issue workflows to only allow `gh` commands targeting the current issue number (`${{ github.event.issue.number }}`).

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
