### PR TITLE
feat(cli): Add pr-prepare slash command

### DIFF
--- a/.agents/commands/git/pr-prepare.md
+++ b/.agents/commands/git/pr-prepare.md
@@ -1,1 +1,3 @@
-Prepare the current changes for PR creation. Run tests, lint, create a branch if needed, commit, and push. Do NOT create the PR itself.
+Prepare the current changes for PR creation. Run `npm run test` and `npm run lint`, create a branch if needed, commit, and push. Do NOT create the PR itself.
+
+The commit message should follow the rules specified in CLAUDE.md.


### PR DESCRIPTION
Add a new `/git:pr-prepare` slash command that prepares changes for PR creation (tests, lint, branch, commit, push) without actually creating the PR.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
