### PR TITLE
refactor(config): Replace prepare with prepack lifecycle script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "bin": "./bin/repomix.cjs",
   "scripts": {
-    "prepare": "npm run build",
+    "prepack": "npm run build",
     "build": "rimraf lib && tsc -p tsconfig.build.json",
     "build-bun": "bun run build",
     "lint": "node --run lint-biome && node --run lint-oxlint && node --run lint-ts && node --run lint-secretlint",


### PR DESCRIPTION
Replace `prepare` with `prepack` lifecycle script in package.json to fix the root cause of Docker and CI build failures.

### Background

The `prepare` script (`npm run build`) runs on `npm install` and `npm ci`, which caused failures when devDependencies (rimraf, tsc) were unavailable — notably during Docker builds and CI production dependency steps. PR #1213 worked around this by switching to `npm prune --omit=dev`, but the root cause remained.

### Why `prepack`

| Scenario | `prepare` | `prepack` |
|---|---|---|
| `npm install` / `npm ci` | Runs | Does NOT run |
| `npm pack` / `npm publish` | Runs | Runs |
| Git dependency install | Runs | Runs |

- `prepack` does NOT run on `npm ci` → Docker/CI issue resolved at the root
- `prepack` DOES run on git dependency install → `website/server` requirement (`"repomix": "github:yamadashy/repomix#main"`) still satisfied
- `prepack` DOES run on `npm pack` / `npm publish` → release workflow unaffected
- Dockerfile and CI workflows already have explicit `npm run build` steps, so no downstream changes needed

## Checklist

- [ ] Run `npm run test`
- [ ] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
