### PR TITLE
Add PR preparation command documentation

### DIFF
--- a/.agents/commands/git/pr-prepare.md
+++ b/.agents/commands/git/pr-prepare.md
@@ -1,1 +1,3 @@
-Prepare the current changes for PR creation. Run tests, lint, create a branch if needed, commit, and push. Do NOT create the PR itself.
+Prepare the current changes for PR creation. Run `npm run test` and `npm run lint`, create a branch if needed, commit, and push. Do NOT create the PR itself.
+
+The commit message should follow the rules specified in CLAUDE.md.


### PR DESCRIPTION
## Summary

Added documentation for the `pr-prepare` command that guides users through preparing changes for PR creation. This command runs tests and linting, manages branching, commits, and pushes changes without creating the PR itself.

## Checklist

- [ ] Run `npm run test`
- [ ] Run `npm run lint`

## Notes

This is a documentation-only change that provides instructions for the PR preparation workflow. The commit message should follow the rules specified in CLAUDE.md.

https://claude.ai/code/session_01DNkqCaRDdMoNFzh8zZgnP1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
