### PR TITLE
chore(config): Add .claude/worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ repomix-output.*
 /.mcp.json
 .agents/local/
 .claude/settings.local.json
+.claude/worktrees/
 
 # serena
 .serena/


### PR DESCRIPTION
`.claude/worktrees/` に Claude Code のワークツリーが作成されますが、これは git で追跡すべきでないため `.gitignore` に追加します。

## Checklist

- [ ] Run `npm run test`
- [ ] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
