### PR TITLE
feat: add block-no-verify PreToolUse hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,17 @@
 {
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      }
+    ]
+  },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   }


### PR DESCRIPTION
<!-- Adds block-no-verify PreToolUse hook to .claude/settings.json -->

Adds `block-no-verify@1.1.2` as a `PreToolUse` Bash hook in `.claude/settings.json` to prevent Claude Code agents from bypassing git hooks via the hook-skip flag.

## Checklist

- [ ] Run `npm run test`
- [ ] Run `npm run lint`

---

The diff is a single settings file change: the existing `env` config is preserved, and a `hooks.PreToolUse` section is added with one Bash hook entry running `npx block-no-verify@1.1.2`.

Closes #1246

_Disclosure: I am the author and maintainer of `block-no-verify`._

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
