### PR TITLE
ci(benchmark): Add performance benchmark workflow for PRs

### DIFF
--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -177,6 +177,7 @@ jobs:
           - Warmup: 2 runs (discarded)
           - Measurement: 10 runs (median)
           - ±: IQR (Interquartile Range) — middle 50% of measurements spread
+          - [Workflow run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})
 
           </details>"
 


### PR DESCRIPTION
Add a GitHub Actions workflow that benchmarks repomix by packing its own repository, comparing PR branch vs main branch performance.

### How it works

1. Checks out PR and main into **separate directories** for measurement isolation
2. Builds both branches independently
3. Runs **2 warmup + 5 measured runs** per branch, reports the **median**
4. Calculates time difference (seconds and %)
5. Posts a single comment on the PR (updates in-place on subsequent pushes)

### Comment example

| | Time |
|---|---:|
| PR branch | 4.52s |
| main branch | 4.48s |
| **Diff** | **+0.04s (+0.9%)** |

### Design decisions

- **Separate directory checkout**: Avoids OS page cache bias between measurements ([prior lesson](https://github.com/yamadashy/repomix/pull/1243))
- **Warmup runs**: Stabilizes JIT and page cache before measurement
- **Concurrency group**: Cancels outdated benchmark runs on the same PR
- **Single comment per PR**: Uses HTML comment marker (`<!-- repomix-perf-benchmark -->`) to find and update existing comments

## Checklist

- [ ] Run `npm run test`
- [ ] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
