### PR TITLE
perf(cli): Propagate compile cache to child_process workers

### DIFF
--- a/bin/repomix.cjs
+++ b/bin/repomix.cjs
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
 
 // https://nodejs.org/api/module.html#module-compile-cache
+// Enable compile cache for the main process and propagate the cache directory
+// via NODE_COMPILE_CACHE env var so child_process workers inherit it at startup
+// (before any modules are loaded), which is critical for ESM static imports.
 const nodeModule = require('node:module');
 if (nodeModule.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
   try {
-    nodeModule.enableCompileCache();
+    const result = nodeModule.enableCompileCache();
+    if (result && result.directory && !process.env.NODE_COMPILE_CACHE) {
+      process.env.NODE_COMPILE_CACHE = result.directory;
+    }
   } catch {
     // Ignore errors
   }


### PR DESCRIPTION
The existing `enableCompileCache()` in `bin/repomix.cjs` only applied to the main process. Tinypool child_process workers (`defaultAction`) were spawned without compile cache because `NODE_COMPILE_CACHE` env var was not set.

This PR captures the cache directory from `enableCompileCache()`'s return value and sets it as `NODE_COMPILE_CACHE` env var, so child_process workers inherit it at startup — before any ESM static imports are resolved.

Note: `worker_threads` workers (`fileProcess`, `securityCheck`, `calculateMetrics`) already benefit from the main process's `enableCompileCache()` call since they share the same V8 isolate.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
