### PR TITLE
chore(security): Add min-release-age to sub-package .npmrc files

### DIFF
--- a/browser/.npmrc
+++ b/browser/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/scripts/memory/.npmrc
+++ b/scripts/memory/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/website/client/.npmrc
+++ b/website/client/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/website/server/.npmrc
+++ b/website/server/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
Add `.npmrc` with `min-release-age=7` to all sub-package directories (`browser/`, `website/client/`, `website/server/`, `scripts/memory/`).

npm only reads `.npmrc` from the same directory as the project's `package.json`, not from parent directories. This means sub-packages that run `npm ci` independently (e.g., in CI workflows or Docker builds) were not protected by the root `.npmrc`'s `min-release-age=7` setting.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
