### PR TITLE
feat(clawhub): Add OpenClaw ClawHub skill for Repomix

### DIFF
--- a/.agents/clawhub/SKILL.md
+++ b/.agents/clawhub/SKILL.md
@@ -51,7 +51,7 @@ Pack entire codebases into a single, AI-friendly file for analysis. Repomix inte
 npx repomix@latest --remote <owner/repo> --output /tmp/<repo-name>-analysis.xml
 ```
 
-Always output to `/tmp` for remote repositories to avoid polluting the user's working directory.
+Always output to a temporary directory (`/tmp` on Unix, `%TEMP%` on Windows) for remote repositories to avoid polluting the user's working directory.
 
 ### Pack a Local Directory
 
@@ -84,10 +84,10 @@ npx repomix@latest --remote yamadashy/repomix --output /tmp/repomix-analysis.xml
 npx repomix@latest --remote facebook/react --compress --output /tmp/react-analysis.xml
 
 # Local directory
-npx repomix@latest ./src
+npx repomix@latest ./src --output /tmp/src-analysis.xml
 
 # Specific file types only
-npx repomix@latest --include "**/*.{ts,tsx,js,jsx}"
+npx repomix@latest --include "**/*.{ts,tsx,js,jsx}" --output /tmp/filtered-analysis.xml
 ```
 
 ### Step 2: Check Command Output
@@ -106,19 +106,19 @@ Note the output file location for subsequent analysis.
 1. Search for the file tree section (near the beginning of the output)
 2. Check the metrics summary for overall statistics
 
-**Search for patterns:**
+**Search for patterns** (use the output file path from Step 2):
 ```bash
 # Find exports and main entry points
-grep -iE "export.*function|export.*class" /tmp/analysis.xml
+grep -iE "export.*function|export.*class" <output-file>
 
 # Search with context
-grep -iE -A 5 -B 5 "authentication|auth" /tmp/analysis.xml
+grep -iE -A 5 -B 5 "authentication|auth" <output-file>
 
 # Find API endpoints
-grep -iE "router|route|endpoint|api" /tmp/analysis.xml
+grep -iE "router|route|endpoint|api" <output-file>
 
 # Find database models
-grep -iE "model|schema|database|query" /tmp/analysis.xml
+grep -iE "model|schema|database|query" <output-file>
 ```
 
 **Read specific sections** using offset/limit for large outputs.
@@ -134,7 +134,7 @@ grep -iE "model|schema|database|query" /tmp/analysis.xml
 
 1. **Use `--compress` for large repos** (>100k lines) to reduce token usage by ~70%
 2. **Use pattern search first** before reading entire output files
-3. **Use `/tmp` for output** to keep the user's workspace clean
+3. **Use a temporary directory for output** (`/tmp` on Unix, `%TEMP%` on Windows) to keep the user's workspace clean
 4. **Use `--include` to focus** on specific parts of a codebase
 5. **XML is the default and recommended format** — it has clear file boundaries for structured analysis
 


### PR DESCRIPTION
Add a Repomix skill for [OpenClaw](https://openclaw.ai/)'s [ClawHub](https://clawhub.ai/) skill registry, enabling OpenClaw users to pack and analyze codebases via messaging platforms (Slack, WhatsApp, Telegram, etc.).

The skill has already been published to ClawHub and is available for installation: `clawhub install repomix`

### What is OpenClaw?

OpenClaw is an open-source autonomous AI agent (327K+ GitHub stars) that connects LLMs to 20+ messaging platforms. It natively supports MCP and has a public skill registry (ClawHub) with 13,700+ community skills.

### What this skill does

- Packs entire codebases into AI-friendly single files using Repomix CLI
- Supports both local directories and remote GitHub repositories
- Includes options for output format (XML, Markdown, Plain, JSON), compression, and file filtering
- Provides metrics on files, size, and estimated token count
- Built-in security checks to exclude sensitive files

### File added

- `.agents/clawhub/SKILL.md` — OpenClaw ClawHub skill definition (YAML frontmatter + Markdown instructions)

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
