### PR TITLE
chore(cli): Add review-loop command

### DIFF
--- a/.agents/commands/code/review-loop.md
+++ b/.agents/commands/code/review-loop.md
@@ -4,12 +4,13 @@ description: Iterative review-and-fix loop
 
 Repeat the following cycle on the current branch's changes against `main` (max 3 iterations):
 
-1. **Review** — Spawn 5 agents in parallel, each reviewing the current diff from a different angle:
+1. **Review** — Spawn 6 agents in parallel, each reviewing the current diff from a different angle:
    - **Agent 1 — Code quality**: Bugs, logic errors, edge cases, code smells
    - **Agent 2 — Security**: Vulnerabilities, injection risks, secret exposure, unsafe patterns
    - **Agent 3 — Performance**: Inefficiencies, resource leaks, unnecessary allocations
    - **Agent 4 — Test coverage**: Missing tests, untested edge cases, test quality
    - **Agent 5 — Conventions**: Project conventions (.agents/rules/base.md), naming, structure
+   - **Agent 6 — Holistic review**: Overall design concerns, side effects of changes, integration risks that individual agents may miss
    Each agent should only report noteworthy findings.
 2. **Triage** — Review agent findings and keep only what you also deem noteworthy. Classify each as **Fix** (clear defects, must fix) or **Skip** (style, nitpicks, scope creep). Show a brief table before changing anything.
 3. **Fix** only the "Fix" items. Keep changes minimal.


### PR DESCRIPTION
Add a `review-loop` custom command that performs iterative code review and fix cycles.

The command spawns 5 parallel review agents, each examining the diff from a different angle:
- **Correctness**: Bugs, logic errors, edge cases, regressions
- **Security**: Vulnerabilities, injection risks, secret exposure
- **Performance**: Inefficiencies, resource leaks, unnecessary allocations
- **Conventions**: Project conventions (CLAUDE.md), naming, structure, test coverage
- **Free review**: Catch-all for anything the other agents missed

It then triages findings (fix vs skip), applies fixes, verifies with lint+test, and repeats until clean (max 3 iterations).

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
