### PR TITLE
refactor(cli): Use multi-agent parallel review in pr-review command

### DIFF
--- a/.agents/commands/code/review-loop.md
+++ b/.agents/commands/code/review-loop.md
@@ -9,7 +9,7 @@ Repeat the following cycle on the current branch's changes against `main` (max 3
    - **Agent 2 — Security**: Vulnerabilities, injection risks, secret exposure, unsafe patterns
    - **Agent 3 — Performance**: Inefficiencies, resource leaks, unnecessary allocations
    - **Agent 4 — Test coverage**: Missing tests, untested edge cases, test quality
-   - **Agent 5 — Conventions**: Project conventions (CLAUDE.md, .agents/rules/base.md), naming, structure
+   - **Agent 5 — Conventions**: Project conventions (.agents/rules/base.md), naming, structure
    - **Agent 6 — Holistic review**: Overall design concerns, side effects of changes, integration risks that individual agents may miss
    Each agent should only report noteworthy findings.
 2. **Triage** — Review agent findings and keep only what you also deem noteworthy. Classify each as **Fix** (clear defects, must fix) or **Skip** (style, nitpicks, scope creep). Show a brief table before changing anything.

--- a/.agents/commands/git/pr-review.md
+++ b/.agents/commands/git/pr-review.md
@@ -12,7 +12,7 @@ Spawn 6 agents in parallel, each reviewing the PR diff from a different angle:
 - **Agent 2 — Security**: Vulnerabilities, injection risks, secret exposure, unsafe patterns
 - **Agent 3 — Performance**: Inefficiencies, resource leaks, unnecessary allocations
 - **Agent 4 — Test coverage**: Missing tests, untested edge cases, test quality
-- **Agent 5 — Conventions**: Project conventions (CLAUDE.md, .agents/rules/base.md), naming, structure
+- **Agent 5 — Conventions**: Project conventions (.agents/rules/base.md), naming, structure
 - **Agent 6 — Holistic review**: Overall design concerns, side effects, integration risks, and premortem analysis (potential failure scenarios, deployment risks)
 
 Each agent should only report noteworthy findings. After all agents report back, review their findings and keep only what you also deem noteworthy. Be constructive and helpful in your feedback.


### PR DESCRIPTION
Replace single-agent review with 6 specialized parallel agents, aligned with the review-loop command (#1285):

1. **Code quality** — Bugs, logic errors, edge cases, code smells
2. **Security** — Vulnerabilities, injection risks, secret exposure
3. **Performance** — Inefficiencies, resource leaks, unnecessary allocations
4. **Test coverage** — Missing tests, untested edge cases, test quality
5. **Conventions** — Project conventions (.agents/rules/base.md), naming, structure
6. **Holistic review** — Overall design, side effects, integration risks

Also adds double-filter pattern: each agent reports only noteworthy findings, then the main agent re-filters before posting.

AI Bot inline comment evaluation and commenting sections are unchanged.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
