### PR TITLE
perf(core): Skip worker threads for lightweight file processing

### DIFF
--- a/src/core/file/fileCollect.ts
+++ b/src/core/file/fileCollect.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import pc from 'picocolors';
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
+import { promisePool } from '../../shared/promisePool.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
 import { readRawFile as defaultReadRawFile, type FileSkipReason } from './fileRead.js';
 import type { RawFile } from './fileTypes.js';
@@ -19,22 +20,6 @@ export interface FileCollectResults {
   rawFiles: RawFile[];
   skippedFiles: SkippedFileInfo[];
 }
-
-const promisePool = async <T, R>(items: T[], concurrency: number, fn: (item: T) => Promise<R>): Promise<R[]> => {
-  const results: R[] = Array.from({ length: items.length });
-  let nextIndex = 0;
-
-  const worker = async () => {
-    while (nextIndex < items.length) {
-      const i = nextIndex++;
-      results[i] = await fn(items[i]);
-    }
-  };
-
-  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
-
-  return results;
-};
 
 export const collectFiles = async (
   filePaths: string[],

--- a/src/core/file/fileProcess.ts
+++ b/src/core/file/fileProcess.ts
@@ -2,12 +2,30 @@ import pc from 'picocolors';
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
 import { initTaskRunner } from '../../shared/processConcurrency.js';
+import { promisePool } from '../../shared/promisePool.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
 import { type FileManipulator, getFileManipulator } from './fileManipulate.js';
+import { processContent } from './fileProcessContent.js';
 import type { ProcessedFile, RawFile } from './fileTypes.js';
 import type { FileProcessTask } from './workers/fileProcessWorker.js';
 
 type GetFileManipulator = (filePath: string) => FileManipulator | null;
+
+// Concurrency limit for main-thread file processing.
+// File processing is CPU-bound (regex/string ops), so concurrency here just
+// controls how many async processContent calls are in-flight at once.
+const FILE_PROCESS_CONCURRENCY = 50;
+
+/**
+ * Check whether file processing requires worker threads.
+ * Only compress mode (tree-sitter parsing) is CPU-heavy enough to benefit from workers.
+ * All other transformations (truncateBase64, removeComments, removeEmptyLines, showLineNumbers, trim)
+ * are lightweight regex/string operations where worker overhead (pool creation, structured clone,
+ * message passing) exceeds the computation cost.
+ */
+const needsWorkerThreads = (config: RepomixConfigMerged): boolean => {
+  return !!config.output.compress;
+};
 
 export const processFiles = async (
   rawFiles: RawFile[],
@@ -16,11 +34,39 @@ export const processFiles = async (
   deps: {
     initTaskRunner: typeof initTaskRunner;
     getFileManipulator: GetFileManipulator;
+    processContent: typeof processContent;
   } = {
     initTaskRunner,
     getFileManipulator,
+    processContent,
   },
 ): Promise<ProcessedFile[]> => {
+  // For lightweight transformations (no compress), process on main thread to avoid
+  // worker pool overhead (pool creation, structured clone of all file content,
+  // message passing per file, WASM module loading in each worker thread).
+  if (!needsWorkerThreads(config)) {
+    const startTime = process.hrtime.bigint();
+    logger.trace(`Starting file processing for ${rawFiles.length} files on main thread`);
+
+    let completedTasks = 0;
+    const totalTasks = rawFiles.length;
+
+    const results = await promisePool(rawFiles, FILE_PROCESS_CONCURRENCY, async (rawFile) => {
+      const content = await deps.processContent(rawFile, config);
+      completedTasks++;
+      progressCallback(`Processing file... (${completedTasks}/${totalTasks}) ${pc.dim(rawFile.path)}`);
+      logger.trace(`Processing file... (${completedTasks}/${totalTasks}) ${rawFile.path}`);
+      return { path: rawFile.path, content };
+    });
+
+    const endTime = process.hrtime.bigint();
+    const duration = Number(endTime - startTime) / 1e6;
+    logger.trace(`File processing completed in ${duration.toFixed(2)}ms`);
+
+    return results;
+  }
+
+  // Compress mode: use worker threads for CPU-heavy tree-sitter parsing
   const taskRunner = deps.initTaskRunner<FileProcessTask, ProcessedFile>({
     numOfTasks: rawFiles.length,
     workerType: 'fileProcess',

--- a/src/shared/promisePool.ts
+++ b/src/shared/promisePool.ts
@@ -1,0 +1,19 @@
+/**
+ * Run async tasks with a concurrency limit.
+ * Results are returned in the same order as the input items.
+ */
+export const promisePool = async <T, R>(items: T[], concurrency: number, fn: (item: T) => Promise<R>): Promise<R[]> => {
+  const results: R[] = Array.from({ length: items.length });
+  let nextIndex = 0;
+
+  const worker = async () => {
+    while (nextIndex < items.length) {
+      const i = nextIndex++;
+      results[i] = await fn(items[i]);
+    }
+  };
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
+
+  return results;
+};

--- a/tests/core/file/fileProcess.test.ts
+++ b/tests/core/file/fileProcess.test.ts
@@ -48,6 +48,7 @@ describe('fileProcess', () => {
       const result = await processFiles(mockRawFiles, config, () => {}, {
         initTaskRunner: mockInitTaskRunner,
         getFileManipulator: mockGetFileManipulator,
+        processContent,
       });
 
       expect(result).toEqual([


### PR DESCRIPTION
When compress mode is off (the default), file processing only does lightweight regex/string operations (truncateBase64, removeComments, removeEmptyLines, trim). Worker thread overhead (pool creation, structured clone of all file content, message passing) far exceeds the computation cost.

This change adds a `needsWorkerThreads()` check — when compress is disabled, files are processed directly on the main thread. When compress is enabled, the existing worker thread pool is used for CPU-heavy tree-sitter WASM parsing.

Based on cherry-pick from #1273 (`f2180f1f`), adapted for main without gpt-tokenizer dependency.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
