### PR TITLE
fix(ci): Disable min-release-age for npm audit signatures

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -54,6 +54,9 @@ jobs:
 
       - name: Verify npm audit signatures
         run: npm audit signatures
+        env:
+          # Disable min-release-age during audit to avoid ETARGET errors for recently published dependencies
+          npm_config_min_release_age: 0
 
       - name: Publish (dry-run)
         if: ${{ inputs.dry-run }}


### PR DESCRIPTION
The project `.npmrc` sets `min-release-age=7` for install-time safety, but this also causes `npm audit signatures` to fail with `ETARGET` for dependencies published within the last 7 days (e.g., `fast-xml-builder@1.1.4`, `tar@7.5.12`).

This overrides the setting via `npm_config_min_release_age=0` env var for the audit step only. The age check is meant for install-time, not signature verification.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
