### PR TITLE
perf(core): Optimize chunk merging and avoid redundant string split in grep tool

### DIFF
--- a/src/core/treeSitter/parseFile.ts
+++ b/src/core/treeSitter/parseFile.ts
@@ -155,20 +155,32 @@ const mergeAdjacentChunks = (chunks: CapturedChunk[]): CapturedChunk[] => {
     return chunks;
   }
 
-  const merged: CapturedChunk[] = [chunks[0]];
+  const merged: CapturedChunk[] = [];
+  // Use array accumulation instead of string += to avoid O(k²) copying.
+  // Each += creates a new string copying all previous content; accumulating
+  // content parts and joining once is O(k) total.
+  let contentParts: string[] = [chunks[0].content];
+  let startRow = chunks[0].startRow;
+  let endRow = chunks[0].endRow;
 
   for (let i = 1; i < chunks.length; i++) {
     const current = chunks[i];
-    const previous = merged[merged.length - 1];
 
-    // Merge the current chunk with the previous one
-    if (previous.endRow + 1 === current.startRow) {
-      previous.content += `\n${current.content}`;
-      previous.endRow = current.endRow;
+    if (endRow + 1 === current.startRow) {
+      // Adjacent: accumulate content part
+      contentParts.push(current.content);
+      endRow = current.endRow;
     } else {
-      merged.push(current);
+      // Gap: finalize previous merged chunk and start a new one
+      merged.push({ content: contentParts.join('\n'), startRow, endRow });
+      contentParts = [current.content];
+      startRow = current.startRow;
+      endRow = current.endRow;
     }
   }
+
+  // Finalize the last merged chunk
+  merged.push({ content: contentParts.join('\n'), startRow, endRow });
 
   return merged;
 };

--- a/src/mcp/tools/grepRepomixOutputTool.ts
+++ b/src/mcp/tools/grepRepomixOutputTool.ts
@@ -209,7 +209,20 @@ export const searchInContent = (
     createRegexPattern,
   },
 ): SearchMatch[] => {
-  const lines = content.split('\n');
+  return searchInLines(content.split('\n'), options, deps);
+};
+
+/**
+ * Search for pattern matches in pre-split lines.
+ * Avoids redundant content.split('\n') when the caller already has the lines array.
+ */
+export const searchInLines = (
+  lines: string[],
+  options: SearchOptions,
+  deps = {
+    createRegexPattern,
+  },
+): SearchMatch[] => {
   const regex = deps.createRegexPattern(options.pattern, options.ignoreCase);
 
   const matches: SearchMatch[] = [];
@@ -267,18 +280,20 @@ export const formatSearchResults = (
 };
 
 /**
- * Perform grep-like search on content
+ * Perform grep-like search on content.
+ * Splits content into lines once and reuses the array for both search and formatting,
+ * avoiding a redundant O(n) split on large output files (3-5MB).
  */
 export const performGrepSearch = (
   content: string,
   options: SearchOptions,
   deps = {
-    searchInContent,
+    searchInLines,
     formatSearchResults,
   },
 ): SearchResult => {
-  const matches = deps.searchInContent(content, options);
   const lines = content.split('\n');
+  const matches = deps.searchInLines(lines, options);
   const formattedOutput = deps.formatSearchResults(lines, matches, options.beforeLines, options.afterLines);
 
   return {

--- a/tests/mcp/tools/grepRepomixOutputTool.test.ts
+++ b/tests/mcp/tools/grepRepomixOutputTool.test.ts
@@ -368,17 +368,17 @@ describe('grepRepomixOutputTool', () => {
     });
 
     it('should use dependency injection for search functions', () => {
-      const mockSearchInContent = vi.fn().mockReturnValue([]);
+      const mockSearchInLines = vi.fn().mockReturnValue([]);
       const mockFormatSearchResults = vi.fn().mockReturnValue(['formatted']);
       const content = 'test content';
       const options = { pattern: 'test', contextLines: 0, beforeLines: 0, afterLines: 0, ignoreCase: false };
 
       const result = performGrepSearch(content, options, {
-        searchInContent: mockSearchInContent,
+        searchInLines: mockSearchInLines,
         formatSearchResults: mockFormatSearchResults,
       });
 
-      expect(mockSearchInContent).toHaveBeenCalledWith(content, options);
+      expect(mockSearchInLines).toHaveBeenCalledWith(['test content'], options);
       expect(mockFormatSearchResults).toHaveBeenCalledWith(['test content'], [], 0, 0);
       expect(result.formattedOutput).toEqual(['formatted']);
     });


### PR DESCRIPTION
## Summary

Performance optimizations for string operations in tree-sitter parsing and MCP grep tool.

### Changes

- **Optimize `mergeAdjacentChunks`** (`parseFile.ts`): Replace `string +=` concatenation with array accumulation + `join(
)` to avoid O(k²) string copying when merging adjacent code chunks.
- **Avoid redundant `content.split(
)`** (`grepRepomixOutputTool.ts`): Extract `searchInLines` function that accepts pre-split lines array. `performGrepSearch` now splits content once and reuses the array for both search and formatting, avoiding a redundant O(n) split on large output files (3-5MB).

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`