### PR TITLE
perf(core): Lazy-load strip-comments to reduce worker startup time

### DIFF
--- a/src/core/file/fileManipulate.ts
+++ b/src/core/file/fileManipulate.ts
@@ -1,10 +1,20 @@
 import path from 'node:path';
-import strip from '@repomix/strip-comments';
 
 export interface FileManipulator {
   removeComments(content: string): string;
   removeEmptyLines(content: string): string;
 }
+
+// Lazy-load @repomix/strip-comments — only needed when --remove-comments is enabled (non-default).
+// This avoids importing the module (~8ms) on every run. Cached after first load.
+let _strip: ((input: string, options?: { language?: string; preserveNewlines?: boolean }) => string) | undefined;
+
+export const ensureStripCommentsLoaded = async (): Promise<void> => {
+  if (!_strip) {
+    const mod = await import('@repomix/strip-comments');
+    _strip = mod.default;
+  }
+};
 
 const rtrimLines = (content: string): string =>
   content
@@ -34,7 +44,10 @@ class StripCommentsManipulator extends BaseManipulator {
   }
 
   removeComments(content: string): string {
-    const result = strip(content, {
+    if (!_strip) {
+      throw new Error('strip-comments not loaded. Call ensureStripCommentsLoaded() first.');
+    }
+    const result = _strip(content, {
       language: this.language,
       preserveNewlines: true,
     });

--- a/src/core/file/fileProcessContent.ts
+++ b/src/core/file/fileProcessContent.ts
@@ -1,7 +1,7 @@
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
 import { parseFile } from '../treeSitter/parseFile.js';
-import { getFileManipulator } from './fileManipulate.js';
+import { ensureStripCommentsLoaded, getFileManipulator } from './fileManipulate.js';
 import type { RawFile } from './fileTypes.js';
 import { truncateBase64Content } from './truncateBase64.js';
 
@@ -30,6 +30,7 @@ export const processContent = async (rawFile: RawFile, config: RepomixConfigMerg
   }
 
   if (manipulator && config.output.removeComments) {
+    await ensureStripCommentsLoaded();
     processedContent = manipulator.removeComments(processedContent);
   }
 

--- a/tests/core/file/fileManipulate.test.ts
+++ b/tests/core/file/fileManipulate.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, test } from 'vitest';
-import { getFileManipulator } from '../../../src/core/file/fileManipulate.js';
+import { beforeAll, describe, expect, test } from 'vitest';
+import { ensureStripCommentsLoaded, getFileManipulator } from '../../../src/core/file/fileManipulate.js';
 
 describe('fileManipulate', () => {
+  // Load strip-comments before running tests (lazy-loaded in production)
+  beforeAll(async () => {
+    await ensureStripCommentsLoaded();
+  });
   const testCases = [
     {
       name: 'C comment removal',


### PR DESCRIPTION
## Summary

Cherry-picked (partial) from #1295. Defers loading `@repomix/strip-comments` from module initialization to first use, reducing worker startup time.

### Changes

- **Lazy-load @repomix/strip-comments** (`fileManipulate.ts`): Replace static import with a dynamic import pattern. The module (~8ms to load) is only needed when `--remove-comments` is enabled (non-default). Export `ensureStripCommentsLoaded()` for callers to pre-load before calling `removeComments()`.
- **Pre-load before use** (`fileProcessContent.ts`): Call `await ensureStripCommentsLoaded()` before using `manipulator.removeComments()` to ensure the module is available.
- **Update tests** (`fileManipulate.test.ts`): Add `beforeAll` hook to pre-load strip-comments before test execution.

### Excluded from this cherry-pick
- `fileRead.ts`: Lazy-loading of `is-binary-path` and `isbinaryfile` (depends on prior commits that restructured file reading logic)

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
