### PR TITLE
fix(fileSearch): Enable case-sensitive matching to prevent BUILD file false positives

### DIFF
--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -316,6 +316,7 @@ const createBaseGlobbyOptions = (
   absolute: false,
   dot: true,
   followSymbolicLinks: false,
+  caseSensitiveMatch: true,
 });
 
 export const getIgnoreFilePatterns = async (config: RepomixConfigMerged): Promise<string[]> => {

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -1027,7 +1027,7 @@ node_modules
       }
     });
 
-    test('should use case-sensitive matching to prevent false positives on case-insensitive file systems', async () => {
+    test('should pass caseSensitiveMatch: true to all globby calls', async () => {
       // This test verifies that caseSensitiveMatch: true is set to fix issue #980
       // where BUILD files (used by pants build tool) were incorrectly ignored
       // on macOS due to the default 'build/**' pattern matching 'BUILD' files

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -290,6 +290,7 @@ node_modules
           absolute: false,
           dot: true,
           followSymbolicLinks: false,
+          caseSensitiveMatch: true,
         }),
       );
     });
@@ -949,6 +950,7 @@ node_modules
           absolute: false,
           dot: true,
           followSymbolicLinks: false,
+          caseSensitiveMatch: true,
         });
 
         // Each call should have either onlyFiles or onlyDirectories, but not both
@@ -1022,6 +1024,33 @@ node_modules
 
         const ignorePatterns = options.ignore as string[];
         expect(ignorePatterns).toEqual(expect.arrayContaining(customPatterns));
+      }
+    });
+
+    test('should use case-sensitive matching to prevent false positives on case-insensitive file systems', async () => {
+      // This test verifies that caseSensitiveMatch: true is set to fix issue #980
+      // where BUILD files (used by pants build tool) were incorrectly ignored
+      // on macOS due to the default 'build/**' pattern matching 'BUILD' files
+      const mockConfig = createMockConfig({
+        include: ['**/*'],
+        ignore: {
+          useGitignore: false,
+          useDefaultPatterns: true,
+          customPatterns: [],
+        },
+      });
+
+      vi.mocked(globby).mockResolvedValue(['BUILD', 'src/BUILD', 'build/output.js']);
+
+      await searchFiles('/test/root', mockConfig);
+
+      // Verify caseSensitiveMatch is passed to globby
+      const calls = vi.mocked(globby).mock.calls;
+      for (const call of calls) {
+        const options = call[1];
+        expect(options).toBeDefined();
+        if (!options) continue;
+        expect(options.caseSensitiveMatch).toBe(true);
       }
     });
   });


### PR DESCRIPTION
## Summary

On case-insensitive file systems (macOS), the default `build/**` ignore pattern incorrectly matched `BUILD` files used by the [pants build tool](https://www.pantsbuild.org/).

## Problem

- Repomix has `build/**` in default ignore patterns
- macOS uses a case-insensitive file system by default (HFS+/APFS)
- The `BUILD` files were matched by `build/**` pattern
- Users had to disable all default patterns as a workaround

## Solution

Set `caseSensitiveMatch: true` in globby options to ensure ignore patterns are matched case-sensitively. This prevents `build/**` from matching `BUILD` files.

## Changes

- Added `caseSensitiveMatch: true` to `createBaseGlobbyOptions()` in `src/core/file/fileSearch.ts`
- Updated tests to verify the new option is passed to globby
- Added new test case specifically for case-sensitive matching

## Testing

- All 47 fileSearch tests pass
- Linting passes

Fixes #980
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
