### PR TITLE
ci(docker): Use native ARM runners instead of QEMU emulation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,11 +20,13 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build:
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -81,10 +83,11 @@ jobs:
 
       - name: Export digest
         if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "/tmp/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
         if: github.event_name != 'pull_request'
@@ -99,6 +102,9 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Download digests
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
@@ -134,5 +140,6 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
+          # shellcheck disable=SC2046
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf 'ghcr.io/yamadashy/repomix@sha256:%s ' *)


### PR DESCRIPTION
Use native ARM runners (`ubuntu-24.04-arm`) for Docker multi-platform builds instead of QEMU emulation on x86 runners.

**Changes:**
- Split single-job multi-platform build into per-architecture parallel jobs with native runners
- `linux/amd64`: `ubuntu-latest` (native x86_64)
- `linux/arm64`: `ubuntu-24.04-arm` (native ARM64, eliminates QEMU)
- `linux/arm/v7`: `ubuntu-24.04-arm` (QEMU only for armv7, lighter than x86→armv7)
- Add `merge` job to create multi-arch manifest from per-platform digests
- Scope GHA cache per platform for better cache isolation
- QEMU setup is now conditional (only for `linux/arm/v7`)

**Why:**
QEMU instruction-level emulation on x86 runners is extremely slow for ARM builds (10-22x slower than native). Native ARM runners are free for public repositories and 37% cheaper for private ones.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

> Note: Test/lint failures are pre-existing (`picospinner` package missing), unrelated to this CI-only change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
