### PR TITLE
ci(perf): Add benchmark history tracking with github-action-benchmark

### DIFF
--- a/.github/workflows/perf-benchmark-history.yml
+++ b/.github/workflows/perf-benchmark-history.yml
@@ -112,14 +112,18 @@ jobs:
     permissions:
       contents: write
     steps:
-      # persist-credentials is left enabled (default) because auto-push needs it to push to gh-pages
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Ensure gh-pages branch exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if ! git ls-remote --heads origin gh-pages | grep -q gh-pages; then
             git switch --orphan gh-pages
             git commit --allow-empty -m "Initial gh-pages branch for benchmark data"
+            git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
             git push origin gh-pages
             git switch -
           fi

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -3,8 +3,6 @@ rules:
     ignore:
       # git-auto-commit-action requires persist-credentials for pushing
       - schema-update.yml
-      # github-action-benchmark auto-push requires persist-credentials for pushing to gh-pages
-      - perf-benchmark-history.yml
   secrets-outside-env:
     ignore:
       # These workflows use repository-level secrets without dedicated environments,


### PR DESCRIPTION
Add a new CI workflow (`perf-benchmark-history.yml`) that tracks repomix pack performance over time using [github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark).

### What it does

- Runs on every push to `main`
- Measures repomix pack time across Ubuntu / macOS / Windows (same benchmark as `perf-benchmark.yml`)
- Stores results on `gh-pages` branch with auto-generated Chart.js performance charts
- Alerts via commit comment on 30%+ regression

### How it works alongside existing CI

| Workflow | Trigger | Purpose |
|---|---|---|
| `perf-benchmark.yml` | PR | Direct comparison of PR vs main |
| `perf-benchmark-history.yml` | push to main | Historical trend tracking + charts |

### Setup required

Enable GitHub Pages with `gh-pages` branch as source to view charts at `https://<owner>.github.io/repomix/dev/bench/`

The `gh-pages` branch is created automatically on first run.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
