### PR TITLE
fix(ci): Set git user for gh-pages branch creation

### DIFF
--- a/.github/workflows/perf-benchmark-history.yml
+++ b/.github/workflows/perf-benchmark-history.yml
@@ -121,6 +121,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if ! git ls-remote --heads origin gh-pages | grep -q gh-pages; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git switch --orphan gh-pages
             git commit --allow-empty -m "Initial gh-pages branch for benchmark data"
             git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"


### PR DESCRIPTION
Fix the benchmark history workflow failing on first run — `persist-credentials: false` removes git identity, causing `git commit --allow-empty` to fail with "empty ident name not allowed".

Configure `github-actions[bot]` as the committer for the initial gh-pages branch creation.

Fixes: https://github.com/yamadashy/repomix/actions/runs/23657899976/job/68920391211

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
