### PR TITLE
perf(core): Replace localeCompare with case-insensitive comparison in output split

### DIFF
--- a/src/core/output/outputSplit.ts
+++ b/src/core/output/outputSplit.ts
@@ -58,7 +58,11 @@ export const buildOutputSplitGroups = (processedFiles: ProcessedFile[], allFileP
     }
   }
 
-  return [...groupsByRootEntry.values()].sort((a, b) => a.rootEntry.localeCompare(b.rootEntry));
+  return [...groupsByRootEntry.values()].sort((a, b) => {
+    const aLower = a.rootEntry.toLowerCase();
+    const bLower = b.rootEntry.toLowerCase();
+    return aLower < bLower ? -1 : aLower > bLower ? 1 : 0;
+  });
 };
 
 export const buildSplitOutputFilePath = (baseFilePath: string, partIndex: number): string => {


### PR DESCRIPTION
`localeCompare` is slower than simple case-insensitive string comparison for sorting. This replaces it with a faster alternative in the output split path.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
