### PR TITLE
perf(core): Parallelize git diff and git log operations

### DIFF
--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -112,13 +112,12 @@ export const pack = async (
     const rawFiles = collectResults.flatMap((curr) => curr.rawFiles);
     const allSkippedFiles = collectResults.flatMap((curr) => curr.skippedFiles);
 
-    // Get git diffs if enabled - run this before security check
-    progressCallback('Getting git diffs...');
-    const gitDiffResult = await deps.getGitDiffs(rootDirs, config);
-
-    // Get git logs if enabled - run this before security check
-    progressCallback('Getting git logs...');
-    const gitLogResult = await deps.getGitLogs(rootDirs, config);
+    // Get git diffs and logs in parallel - both are independent I/O operations
+    progressCallback('Getting git info...');
+    const [gitDiffResult, gitLogResult] = await Promise.all([
+      deps.getGitDiffs(rootDirs, config),
+      deps.getGitLogs(rootDirs, config),
+    ]);
 
     // Run security check and get filtered safe files
     const { safeFilePaths, safeRawFiles, suspiciousFilesResults, suspiciousGitDiffResults, suspiciousGitLogResults } =


### PR DESCRIPTION
`getGitDiffs` and `getGitLogs` are independent I/O operations that were awaited sequentially. Running them concurrently via `Promise.all` reduces wall-clock time when both git diffs and git logs are enabled.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
