### PR TITLE
perf(security): Cache secretlint config in worker to avoid repeated creation

### DIFF
--- a/src/core/security/workers/securityCheckWorker.ts
+++ b/src/core/security/workers/securityCheckWorker.ts
@@ -22,8 +22,17 @@ export interface SuspiciousFileResult {
   type: SecurityCheckType;
 }
 
+// Cache secretlint config at module level — config is stateless and identical for every task
+let cachedConfig: SecretLintCoreConfig | null = null;
+const getCachedConfig = (): SecretLintCoreConfig => {
+  if (!cachedConfig) {
+    cachedConfig = createSecretLintConfig();
+  }
+  return cachedConfig;
+};
+
 export default async ({ filePath, content, type }: SecurityCheckTask) => {
-  const config = createSecretLintConfig();
+  const config = getCachedConfig();
 
   try {
     const processStartAt = process.hrtime.bigint();


### PR DESCRIPTION
The secretlint config is stateless and identical for every security check task, but was being recreated on every call. This caches it at module level using a lazy getter to avoid redundant object allocation on each invocation.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
