### PR TITLE
chore(agents): Skip confirmation and auto-reply on pr-resolve-outdated

### DIFF
--- a/.agents/commands/git/pr-resolve-outdated.md
+++ b/.agents/commands/git/pr-resolve-outdated.md
@@ -22,14 +22,14 @@ Do **NOT** touch comments from human reviewers.
 
 ### 2. Fetch all PR comments
 
-Fetch both review threads and regular issue comments in a single GraphQL query.
+Fetch both review threads and regular issue comments in a single GraphQL query. Use two independent cursor variables for pagination.
 
 ```bash
 gh api graphql -f query='
-query($cursor: String) {
+query($threadCursor: String, $commentCursor: String) {
   repository(owner: "OWNER", name: "REPO") {
     pullRequest(number: NUM) {
-      reviewThreads(first: 100, after: $cursor) {
+      reviewThreads(first: 100, after: $threadCursor) {
         pageInfo { hasNextPage endCursor }
         nodes {
           id
@@ -40,7 +40,7 @@ query($cursor: String) {
           }
         }
       }
-      comments(first: 100) {
+      comments(first: 100, after: $commentCursor) {
         pageInfo { hasNextPage endCursor }
         nodes {
           id
@@ -54,7 +54,7 @@ query($cursor: String) {
 }'
 ```
 
-If `pageInfo.hasNextPage` is `true`, paginate by passing the `endCursor` as the `$cursor` variable in subsequent requests. Repeat until all pages are fetched.
+Each connection (`reviewThreads`, `comments`) paginates independently. If either `pageInfo.hasNextPage` is `true`, pass its `endCursor` as the corresponding cursor variable (`$threadCursor` or `$commentCursor`) in subsequent requests. Repeat until both connections are fully fetched.
 
 ### 3. Classify each comment
 


### PR DESCRIPTION
Improve the `pr-resolve-outdated` agent command with two changes:

1. **Remove confirmation step** — The command now executes directly without waiting for user approval, logging a summary table for transparency instead.
2. **Auto-reply before resolving** — When resolving addressed bot review threads, a concise reply explaining why the thread is being resolved is posted before the resolve/minimize mutations. This keeps a clear audit trail on the PR.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
