### PR TITLE
perf(core): Cache empty directory paths to avoid redundant file search

### DIFF
--- a/src/core/output/outputGenerate.ts
+++ b/src/core/output/outputGenerate.ts
@@ -258,6 +258,7 @@ export const generateOutput = async (
   gitDiffResult: GitDiffResult | undefined = undefined,
   gitLogResult: GitLogResult | undefined = undefined,
   filePathsByRoot?: FilesByRoot[],
+  emptyDirPaths?: string[],
   deps = {
     buildOutputGeneratorContext,
     generateHandlebarOutput,
@@ -277,6 +278,7 @@ export const generateOutput = async (
     gitDiffResult,
     gitLogResult,
     filePathsByRoot,
+    emptyDirPaths,
   );
   const renderContext = createRenderContext(outputGeneratorContext);
 
@@ -303,6 +305,7 @@ export const buildOutputGeneratorContext = async (
   gitDiffResult: GitDiffResult | undefined = undefined,
   gitLogResult: GitLogResult | undefined = undefined,
   filePathsByRoot?: FilesByRoot[],
+  emptyDirPaths?: string[],
   deps = {
     listDirectories,
     listFiles,
@@ -356,16 +359,21 @@ export const buildOutputGeneratorContext = async (
       );
     }
   } else if (config.output.directoryStructure && config.output.includeEmptyDirectories) {
-    // Default behavior: include empty directories only
-    try {
-      const results = await Promise.all(rootDirs.map((rootDir) => deps.searchFiles(rootDir, config)));
-      const merged = results.flatMap((r) => r.emptyDirPaths);
-      directoryPathsForTree = [...new Set(merged)].sort();
-    } catch (error) {
-      throw new RepomixError(
-        `Failed to search for empty directories: ${error instanceof Error ? error.message : String(error)}`,
-        error instanceof Error ? { cause: error } : undefined,
-      );
+    // Reuse pre-computed emptyDirPaths from the initial searchFiles call when available,
+    // avoiding a redundant full directory scan.
+    if (emptyDirPaths) {
+      directoryPathsForTree = emptyDirPaths;
+    } else {
+      try {
+        const results = await Promise.all(rootDirs.map((rootDir) => deps.searchFiles(rootDir, config)));
+        const merged = results.flatMap((r) => r.emptyDirPaths);
+        directoryPathsForTree = [...new Set(merged)].sort();
+      } catch (error) {
+        throw new RepomixError(
+          `Failed to search for empty directories: ${error instanceof Error ? error.message : String(error)}`,
+          error instanceof Error ? { cause: error } : undefined,
+        );
+      }
     }
   }
 

--- a/src/core/output/outputSplit.ts
+++ b/src/core/output/outputSplit.ts
@@ -101,6 +101,7 @@ const renderGroups = async (
   gitDiffResult: GitDiffResult | undefined,
   gitLogResult: GitLogResult | undefined,
   filePathsByRoot: FilesByRoot[] | undefined,
+  emptyDirPaths: string[] | undefined,
   generateOutput: GenerateOutputFn,
 ): Promise<string> => {
   const chunkProcessedFiles = groupsToRender.flatMap((g) => g.processedFiles);
@@ -115,6 +116,7 @@ const renderGroups = async (
     partIndex === 1 ? gitDiffResult : undefined,
     partIndex === 1 ? gitLogResult : undefined,
     filePathsByRoot,
+    emptyDirPaths,
   );
 };
 
@@ -128,6 +130,7 @@ export const generateSplitOutputParts = async ({
   gitLogResult,
   progressCallback,
   filePathsByRoot,
+  emptyDirPaths,
   deps,
 }: {
   rootDirs: string[];
@@ -139,6 +142,7 @@ export const generateSplitOutputParts = async ({
   gitLogResult: GitLogResult | undefined;
   progressCallback: RepomixProgressCallback;
   filePathsByRoot?: FilesByRoot[];
+  emptyDirPaths?: string[];
   deps: {
     generateOutput: GenerateOutputFn;
   };
@@ -178,6 +182,7 @@ export const generateSplitOutputParts = async ({
       gitDiffResult,
       gitLogResult,
       filePathsByRoot,
+      emptyDirPaths,
       deps.generateOutput,
     );
     const nextBytes = getUtf8ByteLength(nextContent);
@@ -215,6 +220,7 @@ export const generateSplitOutputParts = async ({
       gitDiffResult,
       gitLogResult,
       filePathsByRoot,
+      emptyDirPaths,
       deps.generateOutput,
     );
     const singleGroupBytes = getUtf8ByteLength(singleGroupContent);

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -70,22 +70,28 @@ export const pack = async (
   logMemoryUsage('Pack - Start');
 
   progressCallback('Searching for files...');
-  const filePathsByDir = await withMemoryLogging('Search Files', async () =>
+  const searchResultsByDir = await withMemoryLogging('Search Files', async () =>
     Promise.all(
-      rootDirs.map(async (rootDir) => ({
-        rootDir,
-        filePaths: (await deps.searchFiles(rootDir, config, explicitFiles)).filePaths,
-      })),
+      rootDirs.map(async (rootDir) => {
+        const result = await deps.searchFiles(rootDir, config, explicitFiles);
+        return { rootDir, filePaths: result.filePaths, emptyDirPaths: result.emptyDirPaths };
+      }),
     ),
   );
 
+  // Deduplicate and sort empty directory paths for reuse during output generation,
+  // avoiding a redundant searchFiles call in buildOutputGeneratorContext.
+  const emptyDirPaths = config.output.includeEmptyDirectories
+    ? [...new Set(searchResultsByDir.flatMap((r) => r.emptyDirPaths))].sort()
+    : undefined;
+
   // Sort file paths
   progressCallback('Sorting files...');
-  const allFilePaths = filePathsByDir.flatMap(({ filePaths }) => filePaths);
+  const allFilePaths = searchResultsByDir.flatMap(({ filePaths }) => filePaths);
   const sortedFilePaths = deps.sortPaths(allFilePaths);
 
   // Regroup sorted file paths by rootDir using Set for O(1) membership checks
-  const filePathSetByDir = new Map(filePathsByDir.map(({ rootDir, filePaths }) => [rootDir, new Set(filePaths)]));
+  const filePathSetByDir = new Map(searchResultsByDir.map(({ rootDir, filePaths }) => [rootDir, new Set(filePaths)]));
   const sortedFilePathsByDir = rootDirs.map((rootDir) => ({
     rootDir,
     filePaths: sortedFilePaths.filter((filePath) => filePathSetByDir.get(rootDir)?.has(filePath) ?? false),
@@ -194,6 +200,7 @@ export const pack = async (
       gitLogResult,
       progressCallback,
       filePathsByRoot,
+      emptyDirPaths,
     );
 
     const outputForMetricsPromise = outputPromise.then((r) => r.outputForMetrics);

--- a/src/core/packager/produceOutput.ts
+++ b/src/core/packager/produceOutput.ts
@@ -30,6 +30,7 @@ export const produceOutput = async (
   gitLogResult: GitLogResult | undefined,
   progressCallback: RepomixProgressCallback,
   filePathsByRoot?: FilesByRoot[],
+  emptyDirPaths?: string[],
   overrideDeps: Partial<typeof defaultDeps> = {},
 ): Promise<ProduceOutputResult> => {
   const deps = { ...defaultDeps, ...overrideDeps };
@@ -47,6 +48,7 @@ export const produceOutput = async (
       gitLogResult,
       progressCallback,
       filePathsByRoot,
+      emptyDirPaths,
       deps,
     );
   }
@@ -60,6 +62,7 @@ export const produceOutput = async (
     gitLogResult,
     progressCallback,
     filePathsByRoot,
+    emptyDirPaths,
     deps,
   );
 };
@@ -74,6 +77,7 @@ const generateAndWriteSplitOutput = async (
   gitLogResult: GitLogResult | undefined,
   progressCallback: RepomixProgressCallback,
   filePathsByRoot: FilesByRoot[] | undefined,
+  emptyDirPaths: string[] | undefined,
   deps: typeof defaultDeps,
 ): Promise<ProduceOutputResult> => {
   const parts = await withMemoryLogging('Generate Split Output', async () => {
@@ -87,6 +91,7 @@ const generateAndWriteSplitOutput = async (
       gitLogResult,
       progressCallback,
       filePathsByRoot,
+      emptyDirPaths,
       deps: {
         generateOutput: deps.generateOutput,
       },
@@ -125,10 +130,20 @@ const generateAndWriteSingleOutput = async (
   gitLogResult: GitLogResult | undefined,
   progressCallback: RepomixProgressCallback,
   filePathsByRoot: FilesByRoot[] | undefined,
+  emptyDirPaths: string[] | undefined,
   deps: typeof defaultDeps,
 ): Promise<ProduceOutputResult> => {
   const output = await withMemoryLogging('Generate Output', () =>
-    deps.generateOutput(rootDirs, config, processedFiles, allFilePaths, gitDiffResult, gitLogResult, filePathsByRoot),
+    deps.generateOutput(
+      rootDirs,
+      config,
+      processedFiles,
+      allFilePaths,
+      gitDiffResult,
+      gitLogResult,
+      filePathsByRoot,
+      emptyDirPaths,
+    ),
   );
 
   progressCallback('Writing output file...');

--- a/tests/core/output/diffsInOutput.test.ts
+++ b/tests/core/output/diffsInOutput.test.ts
@@ -131,6 +131,7 @@ index 123..456 100644
       gitDiffResult,
       undefined,
       undefined,
+      undefined,
       {
         buildOutputGeneratorContext: mockBuildOutputGeneratorContext,
         generateHandlebarOutput: mockGenerateHandlebarOutput,
@@ -202,6 +203,7 @@ index 123..456 100644
       processedFiles,
       ['file1.js'],
       gitDiffResult,
+      undefined,
       undefined,
       undefined,
       {

--- a/tests/core/output/flagFullDirectoryStructure.test.ts
+++ b/tests/core/output/flagFullDirectoryStructure.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import type { RepomixConfigMerged } from '../../../src/config/configSchema.js';
 import type { ProcessedFile } from '../../../src/core/file/fileTypes.js';
 import { buildOutputGeneratorContext } from '../../../src/core/output/outputGenerate.js';
@@ -72,6 +72,7 @@ describe('includeFullDirectoryStructure flag', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
       deps,
     );
 
@@ -105,6 +106,7 @@ describe('includeFullDirectoryStructure flag', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
       deps,
     );
 
@@ -115,5 +117,108 @@ describe('includeFullDirectoryStructure flag', () => {
     // Should include the file-derived structure
     expect(ctx.treeString).toContain('src');
     expect(ctx.treeString).toContain('index.ts');
+  });
+});
+
+describe('includeEmptyDirectories with pre-computed emptyDirPaths', () => {
+  const createEmptyDirConfig = (overrides: Partial<RepomixConfigMerged> = {}): RepomixConfigMerged => ({
+    cwd: '/repo',
+    input: { maxFileSize: 1024 * 1024 },
+    output: {
+      filePath: 'repomix-output.json',
+      style: 'json',
+      parsableStyle: false,
+      headerText: undefined,
+      instructionFilePath: undefined,
+      fileSummary: true,
+      directoryStructure: true,
+      files: true,
+      removeComments: false,
+      removeEmptyLines: false,
+      compress: false,
+      topFilesLength: 5,
+      showLineNumbers: false,
+      truncateBase64: false,
+      copyToClipboard: false,
+      includeEmptyDirectories: true,
+      includeFullDirectoryStructure: false,
+      tokenCountTree: false,
+      git: {
+        sortByChanges: false,
+        sortByChangesMaxCommits: 10,
+        includeDiffs: false,
+        includeLogs: false,
+        includeLogsCount: 5,
+      },
+    },
+    include: [],
+    ignore: {
+      useGitignore: true,
+      useDotIgnore: true,
+      useDefaultPatterns: true,
+      customPatterns: [],
+    },
+    security: { enableSecurityCheck: true },
+    tokenCount: { encoding: 'cl100k_base' },
+    ...overrides,
+  });
+
+  test('uses pre-computed emptyDirPaths and skips searchFiles call', async () => {
+    const config = createEmptyDirConfig();
+    const processedFiles: ProcessedFile[] = [{ path: 'src/index.ts', content: 'export const a = 1;\n' }];
+    const allFilePaths = processedFiles.map((f) => f.path);
+    const preComputedEmptyDirs = ['empty-dir'];
+
+    const deps = {
+      listDirectories: vi.fn(),
+      listFiles: vi.fn(),
+      searchFiles: vi.fn().mockResolvedValue({ filePaths: allFilePaths, emptyDirPaths: ['should-not-use'] }),
+    };
+
+    const ctx = await buildOutputGeneratorContext(
+      ['/repo'],
+      config,
+      allFilePaths,
+      processedFiles,
+      undefined,
+      undefined,
+      undefined,
+      preComputedEmptyDirs,
+      deps,
+    );
+
+    // searchFiles should NOT be called when emptyDirPaths is provided
+    expect(deps.searchFiles).not.toHaveBeenCalled();
+    // The pre-computed empty dir should appear in the tree
+    expect(ctx.treeString).toContain('empty-dir');
+  });
+
+  test('falls back to searchFiles when emptyDirPaths is not provided', async () => {
+    const config = createEmptyDirConfig();
+    const processedFiles: ProcessedFile[] = [{ path: 'src/index.ts', content: 'export const a = 1;\n' }];
+    const allFilePaths = processedFiles.map((f) => f.path);
+
+    const deps = {
+      listDirectories: vi.fn(),
+      listFiles: vi.fn(),
+      searchFiles: vi.fn().mockResolvedValue({ filePaths: allFilePaths, emptyDirPaths: ['fallback-empty-dir'] }),
+    };
+
+    const ctx = await buildOutputGeneratorContext(
+      ['/repo'],
+      config,
+      allFilePaths,
+      processedFiles,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      deps,
+    );
+
+    // searchFiles SHOULD be called as fallback
+    expect(deps.searchFiles).toHaveBeenCalledWith('/repo', config);
+    // The fallback empty dir should appear in the tree
+    expect(ctx.treeString).toContain('fallback-empty-dir');
   });
 });

--- a/tests/core/output/outputGenerate.test.ts
+++ b/tests/core/output/outputGenerate.test.ts
@@ -58,6 +58,7 @@ describe('outputGenerate', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
       mockDeps,
     );
 
@@ -67,6 +68,7 @@ describe('outputGenerate', () => {
       mockConfig,
       [],
       sortedFiles,
+      undefined,
       undefined,
       undefined,
       undefined,

--- a/tests/core/output/outputGenerateDiffs.test.ts
+++ b/tests/core/output/outputGenerateDiffs.test.ts
@@ -88,6 +88,7 @@ describe('Output Generation with Diffs', () => {
       gitDiffResult,
       undefined,
       undefined,
+      undefined,
       mockDeps,
     );
 
@@ -120,6 +121,7 @@ describe('Output Generation with Diffs', () => {
       mockConfig,
       mockProcessedFiles,
       allFilePaths,
+      undefined,
       undefined,
       undefined,
       undefined,
@@ -158,6 +160,7 @@ describe('Output Generation with Diffs', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
       mockDeps,
     );
 
@@ -190,6 +193,7 @@ describe('Output Generation with Diffs', () => {
       mockConfig,
       mockProcessedFiles,
       allFilePaths,
+      undefined,
       undefined,
       undefined,
       undefined,
@@ -235,6 +239,7 @@ describe('Output Generation with Diffs', () => {
       mockConfig,
       mockProcessedFiles,
       allFilePaths,
+      undefined,
       undefined,
       undefined,
       undefined,

--- a/tests/core/packager.test.ts
+++ b/tests/core/packager.test.ts
@@ -100,6 +100,7 @@ describe('packager', () => {
       undefined,
       progressCallback,
       [{ rootLabel: 'root', files: mockFilePaths }],
+      undefined,
     );
     expect(mockDeps.calculateMetrics).toHaveBeenCalledWith(
       mockProcessedFiles,

--- a/tests/core/packager/produceOutput.test.ts
+++ b/tests/core/packager/produceOutput.test.ts
@@ -26,6 +26,7 @@ describe('produceOutput', () => {
         undefined,
         progressCallback,
         undefined,
+        undefined,
         mockDeps,
       );
 
@@ -34,6 +35,7 @@ describe('produceOutput', () => {
         mockConfig,
         processedFiles,
         allFilePaths,
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -61,6 +63,7 @@ describe('produceOutput', () => {
         gitLogResult as Parameters<typeof produceOutput>[5],
         vi.fn(),
         undefined,
+        undefined,
         mockDeps,
       );
 
@@ -72,6 +75,7 @@ describe('produceOutput', () => {
         gitDiffResult,
         gitLogResult,
         undefined,
+        undefined,
       );
     });
 
@@ -80,7 +84,18 @@ describe('produceOutput', () => {
       const mockConfig = createMockConfig();
       const progressCallback = vi.fn();
 
-      await produceOutput(['/root'], mockConfig, [], [], undefined, undefined, progressCallback, undefined, mockDeps);
+      await produceOutput(
+        ['/root'],
+        mockConfig,
+        [],
+        [],
+        undefined,
+        undefined,
+        progressCallback,
+        undefined,
+        undefined,
+        mockDeps,
+      );
 
       expect(progressCallback).toHaveBeenCalledWith('Writing output file...');
     });
@@ -116,6 +131,7 @@ describe('produceOutput', () => {
         undefined,
         progressCallback,
         undefined,
+        undefined,
         mockDeps,
       );
 
@@ -134,7 +150,18 @@ describe('produceOutput', () => {
       });
       const progressCallback = vi.fn();
 
-      await produceOutput(['/root'], mockConfig, [], [], undefined, undefined, progressCallback, undefined, mockDeps);
+      await produceOutput(
+        ['/root'],
+        mockConfig,
+        [],
+        [],
+        undefined,
+        undefined,
+        progressCallback,
+        undefined,
+        undefined,
+        mockDeps,
+      );
 
       expect(progressCallback).toHaveBeenCalledWith('Writing output files...');
     });
@@ -148,7 +175,7 @@ describe('produceOutput', () => {
         },
       });
 
-      await produceOutput(['/root'], mockConfig, [], [], undefined, undefined, vi.fn(), undefined, mockDeps);
+      await produceOutput(['/root'], mockConfig, [], [], undefined, undefined, vi.fn(), undefined, undefined, mockDeps);
 
       expect(mockDeps.copyToClipboardIfEnabled).not.toHaveBeenCalled();
     });

--- a/tests/core/packager/splitOutput.test.ts
+++ b/tests/core/packager/splitOutput.test.ts
@@ -70,6 +70,7 @@ describe('packager split output', () => {
       undefined,
       expect.any(Function),
       [{ rootLabel: 'root', files: allFilePaths }],
+      undefined,
     );
 
     expect(calculateMetrics).toHaveBeenCalledWith(


### PR DESCRIPTION
<!-- Please include a summary of the changes -->

When `includeEmptyDirectories` is enabled, `buildOutputGeneratorContext` called `searchFiles` a second time just to obtain `emptyDirPaths` — despite these already being computed during the initial file search in `packager`. This PR eliminates the redundant search by threading the pre-computed paths through the output pipeline.

### Changes

- **Cache `emptyDirPaths` from initial search**: Thread pre-computed paths through the pipeline (`packager` → `produceOutput` → `generateOutput`/`outputSplit` → `buildOutputGeneratorContext`), skipping the redundant `searchFiles` call
- **Guard with `includeEmptyDirectories` check**: Skip `emptyDirPaths` dedup/sort when the feature is disabled (the common case), avoiding unnecessary allocations
- **Fix split output path**: `emptyDirPaths` was not being passed through to `generateSplitOutputParts` — now it is

### Pipeline flow

```
searchFiles (returns filePaths + emptyDirPaths)
  → packager (dedup + sort once, only when includeEmptyDirectories is enabled)
  → produceOutput → generateOutput / outputSplit
  → buildOutputGeneratorContext (uses cached paths, skips redundant search)
```

### Benchmark

Local benchmark (repomix on itself, `includeEmptyDirectories: true`, 10 runs):

| | Mean ± σ |
|---|---|
| main | 696.6ms ± 4.2ms |
| this PR | 637.1ms ± 2.6ms |
| **Improvement** | **~60ms (~8.5%)** |

Note: CI benchmark shows no change because the improvement only applies when `includeEmptyDirectories` is enabled.

## Checklist

- [x] Run `npm run test` (1100 tests pass)
- [x] Run `npm run lint` (clean)