### PR TITLE
perf(core): Pre-initialize security worker pool before file search

### DIFF
--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import type { RepomixConfigMerged } from '../config/configSchema.js';
 import { logMemoryUsage, withMemoryLogging } from '../shared/memoryUtils.js';
+import { getProcessConcurrency } from '../shared/processConcurrency.js';
 import type { RepomixProgressCallback } from '../shared/types.js';
 import { collectFiles, type SkippedFileInfo } from './file/fileCollect.js';
 import { sortPaths } from './file/filePathSort.js';
@@ -12,7 +13,7 @@ import { getGitDiffs } from './git/gitDiffHandle.js';
 import { getGitLogs } from './git/gitLogHandle.js';
 import { calculateMetrics, createMetricsTaskRunner } from './metrics/calculateMetrics.js';
 import { produceOutput } from './packager/produceOutput.js';
-import type { SuspiciousFileResult } from './security/securityCheck.js';
+import { createSecurityTaskRunner, type SuspiciousFileResult } from './security/securityCheck.js';
 import { validateFileSafety } from './security/validateFileSafety.js';
 import { packSkill } from './skill/packSkill.js';
 
@@ -41,6 +42,7 @@ const defaultDeps = {
   produceOutput,
   calculateMetrics,
   createMetricsTaskRunner,
+  createSecurityTaskRunner,
   sortPaths,
   getGitDiffs,
   getGitLogs,
@@ -68,6 +70,17 @@ export const pack = async (
   };
 
   logMemoryUsage('Pack - Start');
+
+  // Pre-initialize security worker pool before file search to overlap secretlint module
+  // loading (~150ms) with file search (~300ms). Same pattern as metrics worker pre-init.
+  // Tinypool creates workers lazily, so a generous task estimate only raises maxThreads.
+  const securityTaskRunner = config.security.enableSecurityCheck
+    ? deps.createSecurityTaskRunner(getProcessConcurrency() * 100)
+    : undefined;
+  // Trigger secretlint module loading in worker thread
+  const _securityWarmupPromise = securityTaskRunner
+    ?.run({ filePath: 'warmup.txt', content: '', type: 'file' })
+    .catch(() => null);
 
   progressCallback('Searching for files...');
   const filePathsByDir = await withMemoryLogging('Search Files', async () =>
@@ -123,7 +136,9 @@ export const pack = async (
     // Run security check and get filtered safe files
     const { safeFilePaths, safeRawFiles, suspiciousFilesResults, suspiciousGitDiffResults, suspiciousGitLogResults } =
       await withMemoryLogging('Security Check', () =>
-        deps.validateFileSafety(rawFiles, progressCallback, config, gitDiffResult, gitLogResult),
+        deps.validateFileSafety(rawFiles, progressCallback, config, gitDiffResult, gitLogResult, {
+          securityTaskRunner,
+        }),
       );
 
     // Process files (remove comments, etc.)
@@ -204,6 +219,6 @@ export const pack = async (
 
     return result;
   } finally {
-    await metricsTaskRunner.cleanup();
+    await Promise.all([metricsTaskRunner.cleanup(), securityTaskRunner?.cleanup()]);
   }
 };

--- a/src/core/security/securityCheck.ts
+++ b/src/core/security/securityCheck.ts
@@ -1,6 +1,6 @@
 import pc from 'picocolors';
 import { logger } from '../../shared/logger.js';
-import { initTaskRunner } from '../../shared/processConcurrency.js';
+import { initTaskRunner, type TaskRunner } from '../../shared/processConcurrency.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
 import type { RawFile } from '../file/fileTypes.js';
 import type { GitDiffResult } from '../git/gitDiffHandle.js';
@@ -13,15 +13,33 @@ export interface SuspiciousFileResult {
   type: SecurityCheckType;
 }
 
+/**
+ * Create a security task runner that can be pre-initialized to overlap
+ * secretlint module loading with other pipeline stages.
+ */
+export const createSecurityTaskRunner = (
+  numOfTasks: number,
+): TaskRunner<SecurityCheckTask, SuspiciousFileResult | null> => {
+  return initTaskRunner<SecurityCheckTask, SuspiciousFileResult | null>({
+    numOfTasks,
+    workerType: 'securityCheck',
+    runtime: 'worker_threads',
+  });
+};
+
+const defaultDeps = {
+  initTaskRunner,
+  taskRunner: undefined as TaskRunner<SecurityCheckTask, SuspiciousFileResult | null> | undefined,
+};
+
 export const runSecurityCheck = async (
   rawFiles: RawFile[],
   progressCallback: RepomixProgressCallback = () => {},
   gitDiffResult?: GitDiffResult,
   gitLogResult?: GitLogResult,
-  deps = {
-    initTaskRunner,
-  },
+  overrideDeps: Partial<typeof defaultDeps> = {},
 ): Promise<SuspiciousFileResult[]> => {
+  const deps = { ...defaultDeps, ...overrideDeps };
   const gitDiffTasks: SecurityCheckTask[] = [];
   const gitLogTasks: SecurityCheckTask[] = [];
 
@@ -55,11 +73,15 @@ export const runSecurityCheck = async (
     }
   }
 
-  const taskRunner = deps.initTaskRunner<SecurityCheckTask, SuspiciousFileResult | null>({
-    numOfTasks: rawFiles.length + gitDiffTasks.length + gitLogTasks.length,
-    workerType: 'securityCheck',
-    runtime: 'worker_threads',
-  });
+  // Use externally provided task runner if available (for pipeline pre-initialization),
+  // otherwise create one internally.
+  const taskRunner =
+    deps.taskRunner ??
+    deps.initTaskRunner<SecurityCheckTask, SuspiciousFileResult | null>({
+      numOfTasks: rawFiles.length + gitDiffTasks.length + gitLogTasks.length,
+      workerType: 'securityCheck',
+      runtime: 'worker_threads',
+    });
   const fileTasks = rawFiles.map(
     (file) =>
       ({
@@ -99,7 +121,9 @@ export const runSecurityCheck = async (
     logger.error('Error during security check:', error);
     throw error;
   } finally {
-    // Always cleanup worker pool
-    await taskRunner.cleanup();
+    // Only cleanup if we created the task runner internally
+    if (!deps.taskRunner) {
+      await taskRunner.cleanup();
+    }
   }
 };

--- a/src/core/security/validateFileSafety.ts
+++ b/src/core/security/validateFileSafety.ts
@@ -1,11 +1,13 @@
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
+import type { TaskRunner } from '../../shared/processConcurrency.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
 import type { RawFile } from '../file/fileTypes.js';
 import type { GitDiffResult } from '../git/gitDiffHandle.js';
 import type { GitLogResult } from '../git/gitLogHandle.js';
 import { filterOutUntrustedFiles } from './filterOutUntrustedFiles.js';
 import { runSecurityCheck, type SuspiciousFileResult } from './securityCheck.js';
+import type { SecurityCheckTask } from './workers/securityCheckWorker.js';
 
 // Marks which files are suspicious and which are safe
 // Returns Git diff results separately so they can be included in the output
@@ -16,18 +18,30 @@ export const validateFileSafety = async (
   config: RepomixConfigMerged,
   gitDiffResult?: GitDiffResult,
   gitLogResult?: GitLogResult,
-  deps = {
+  overrideDeps: Partial<{
+    runSecurityCheck: typeof runSecurityCheck;
+    filterOutUntrustedFiles: typeof filterOutUntrustedFiles;
+    securityTaskRunner: TaskRunner<SecurityCheckTask, SuspiciousFileResult | null>;
+  }> = {},
+) => {
+  const deps = {
     runSecurityCheck,
     filterOutUntrustedFiles,
-  },
-) => {
+    securityTaskRunner: undefined as TaskRunner<SecurityCheckTask, SuspiciousFileResult | null> | undefined,
+    ...overrideDeps,
+  };
+
   let suspiciousFilesResults: SuspiciousFileResult[] = [];
   let suspiciousGitDiffResults: SuspiciousFileResult[] = [];
   let suspiciousGitLogResults: SuspiciousFileResult[] = [];
 
   if (config.security.enableSecurityCheck) {
     progressCallback('Running security check...');
-    const allResults = await deps.runSecurityCheck(rawFiles, progressCallback, gitDiffResult, gitLogResult);
+    const allResults = deps.securityTaskRunner
+      ? await deps.runSecurityCheck(rawFiles, progressCallback, gitDiffResult, gitLogResult, {
+          taskRunner: deps.securityTaskRunner,
+        })
+      : await deps.runSecurityCheck(rawFiles, progressCallback, gitDiffResult, gitLogResult);
 
     // Separate Git diff and Git log results from regular file results
     suspiciousFilesResults = allResults.filter((result) => result.type === 'file');

--- a/tests/core/packager.test.ts
+++ b/tests/core/packager.test.ts
@@ -59,6 +59,10 @@ describe('packager', () => {
         run: vi.fn().mockResolvedValue(0),
         cleanup: vi.fn().mockResolvedValue(undefined),
       }),
+      createSecurityTaskRunner: vi.fn().mockReturnValue({
+        run: vi.fn().mockResolvedValue(null),
+        cleanup: vi.fn().mockResolvedValue(undefined),
+      }),
       calculateMetrics: vi.fn().mockResolvedValue({
         totalFiles: 2,
         totalCharacters: 11,
@@ -93,6 +97,7 @@ describe('packager', () => {
       mockConfig,
       undefined,
       undefined,
+      expect.objectContaining({ securityTaskRunner: expect.anything() }),
     );
     expect(mockDeps.processFiles).toHaveBeenCalledWith(mockSafeRawFiles, mockConfig, progressCallback);
     expect(mockDeps.produceOutput).toHaveBeenCalledWith(

--- a/tests/core/packager/diffsFunctionality.test.ts
+++ b/tests/core/packager/diffsFunctionality.test.ts
@@ -75,6 +75,10 @@ index 123..456 100644
       run: vi.fn().mockResolvedValue(0),
       cleanup: vi.fn().mockResolvedValue(undefined),
     });
+    const mockCreateSecurityTaskRunner = vi.fn().mockReturnValue({
+      run: vi.fn().mockResolvedValue(null),
+      cleanup: vi.fn().mockResolvedValue(undefined),
+    });
 
     // Config with diffs disabled
     if (mockConfig.output.git) {
@@ -89,6 +93,7 @@ index 123..456 100644
       produceOutput: mockProduceOutput,
       calculateMetrics: mockCalculateMetrics,
       createMetricsTaskRunner: mockCreateMetricsTaskRunner,
+      createSecurityTaskRunner: mockCreateSecurityTaskRunner,
       sortPaths: mockSortPaths,
     });
 
@@ -130,6 +135,10 @@ index 123..456 100644
       run: vi.fn().mockResolvedValue(0),
       cleanup: vi.fn().mockResolvedValue(undefined),
     });
+    const mockCreateSecurityTaskRunner = vi.fn().mockReturnValue({
+      run: vi.fn().mockResolvedValue(null),
+      cleanup: vi.fn().mockResolvedValue(undefined),
+    });
 
     // Config with diffs enabled
     if (mockConfig.output.git) {
@@ -144,6 +153,7 @@ index 123..456 100644
       produceOutput: mockProduceOutput,
       calculateMetrics: mockCalculateMetrics,
       createMetricsTaskRunner: mockCreateMetricsTaskRunner,
+      createSecurityTaskRunner: mockCreateSecurityTaskRunner,
       sortPaths: mockSortPaths,
     });
 

--- a/tests/core/packager/splitOutput.test.ts
+++ b/tests/core/packager/splitOutput.test.ts
@@ -59,6 +59,10 @@ describe('packager split output', () => {
         run: vi.fn().mockResolvedValue(0),
         cleanup: vi.fn().mockResolvedValue(undefined),
       }),
+      createSecurityTaskRunner: vi.fn().mockReturnValue({
+        run: vi.fn().mockResolvedValue(null),
+        cleanup: vi.fn().mockResolvedValue(undefined),
+      }),
     });
 
     expect(produceOutput).toHaveBeenCalledWith(

--- a/tests/integration-tests/packager.test.ts
+++ b/tests/integration-tests/packager.test.ts
@@ -119,6 +119,10 @@ describe.runIf(!isWindows)('packager integration', () => {
           run: async () => 0,
           cleanup: async () => {},
         }),
+        createSecurityTaskRunner: () => ({
+          run: async () => null,
+          cleanup: async () => {},
+        }),
         calculateMetrics: async (
           processedFiles,
           _output,


### PR DESCRIPTION
## Summary

- Pre-initialize the security worker pool (secretlint) before file search to overlap module loading (~150ms) with file search (~300ms), following the same pattern used for the metrics worker pool (tiktoken WASM pre-loading)
- Add `createSecurityTaskRunner` factory in `securityCheck.ts` and refactor `runSecurityCheck` to accept an external `TaskRunner` via the `overrideDeps` spread pattern
- Thread the pre-initialized `TaskRunner` through `validateFileSafety` → `runSecurityCheck`, with cleanup handled in the packager's `finally` block

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
