### PR TITLE
perf(security): Reduce security worker threads to minimize CPU contention

### DIFF
--- a/src/core/security/securityCheck.ts
+++ b/src/core/security/securityCheck.ts
@@ -55,10 +55,14 @@ export const runSecurityCheck = async (
     }
   }
 
+  // Cap security worker pool to 1 thread to minimize CPU contention with the metrics
+  // worker pool. Security runs concurrently with file processing and completes well before
+  // metrics calculation, so extra threads only compete for CPU without improving throughput.
   const taskRunner = deps.initTaskRunner<SecurityCheckTask, SuspiciousFileResult | null>({
     numOfTasks: rawFiles.length + gitDiffTasks.length + gitLogTasks.length,
     workerType: 'securityCheck',
     runtime: 'worker_threads',
+    maxThreads: 1,
   });
   const fileTasks = rawFiles.map(
     (file) =>

--- a/src/shared/processConcurrency.ts
+++ b/src/shared/processConcurrency.ts
@@ -12,6 +12,7 @@ export interface WorkerOptions {
   numOfTasks: number;
   workerType: WorkerType;
   runtime: WorkerRuntime;
+  maxThreads?: number;
 }
 
 /**
@@ -62,8 +63,9 @@ export const getWorkerThreadCount = (numOfTasks: number): { minThreads: number; 
 };
 
 export const createWorkerPool = (options: WorkerOptions): Tinypool => {
-  const { numOfTasks, workerType, runtime = 'child_process' } = options;
-  const { minThreads, maxThreads } = getWorkerThreadCount(numOfTasks);
+  const { numOfTasks, workerType, runtime = 'child_process', maxThreads: maxThreadsOverride } = options;
+  const { minThreads, maxThreads: autoMaxThreads } = getWorkerThreadCount(numOfTasks);
+  const maxThreads = maxThreadsOverride != null ? Math.max(1, maxThreadsOverride) : autoMaxThreads;
 
   // Get worker path - uses unified worker in bundled env, individual files otherwise
   const workerPath = getWorkerPath(workerType);

--- a/tests/shared/processConcurrency.test.ts
+++ b/tests/shared/processConcurrency.test.ts
@@ -130,6 +130,26 @@ describe('processConcurrency', () => {
       });
       expect(tinypool).toBeDefined();
     });
+
+    it('should respect maxThreads override when provided', () => {
+      createWorkerPool({ numOfTasks: 500, workerType: 'securityCheck', runtime: 'worker_threads', maxThreads: 1 });
+
+      expect(Tinypool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          maxThreads: 1,
+        }),
+      );
+    });
+
+    it('should clamp maxThreads override to minimum of 1', () => {
+      createWorkerPool({ numOfTasks: 500, workerType: 'securityCheck', runtime: 'worker_threads', maxThreads: 0 });
+
+      expect(Tinypool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          maxThreads: 1,
+        }),
+      );
+    });
   });
 
   describe('initTaskRunner', () => {


### PR DESCRIPTION
## Summary

- Add `maxThreads` option to `WorkerOptions` interface, allowing callers to explicitly cap worker thread count
- Cap security check worker pool to 1 thread to eliminate CPU contention with the metrics worker pool

### Background

Security check runs concurrently with file processing in the pipeline and completes well before metrics calculation begins. Previously, the security worker pool spawned threads based on task count (up to CPU core count), competing for CPU cores with the later metrics workers. On a 4-core machine, 4 security + 4 metrics threads caused ~140ms of CPU contention that inflated the metrics phase.

With 1 security thread, security still finishes before metrics while eliminating contention entirely.

### Design

Rather than indirectly controlling thread count by capping `numOfTasks` (which depends on the internal `TASKS_PER_THREAD` constant), this PR adds an explicit `maxThreads` override to `WorkerOptions`. This makes the intent clear and is resilient to future changes in the thread calculation logic.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
