### PR TITLE
perf(core): Skip binary files during GitHub archive tar extraction

### DIFF
--- a/src/core/git/archiveEntryFilter.ts
+++ b/src/core/git/archiveEntryFilter.ts
@@ -1,0 +1,26 @@
+import isBinaryPath from 'is-binary-path';
+import { logger } from '../../shared/logger.js';
+
+/**
+ * Creates a filter function for tar extraction that skips binary files.
+ * The filter is called with the raw tar entry path (before strip is applied),
+ * so we manually remove the leading segment (e.g. "repo-branch/") before checking.
+ */
+export const createArchiveEntryFilter = (deps = { isBinaryPath }) => {
+  return (entryPath: string): boolean => {
+    // Remove the leading directory segment that tar's strip:1 would remove
+    const strippedPath = entryPath.replace(/^[^/]+\//, '');
+
+    if (!strippedPath) {
+      // Root directory entry — always allow
+      return true;
+    }
+
+    if (deps.isBinaryPath(strippedPath)) {
+      logger.trace(`Skipping binary file in archive: ${strippedPath}`);
+      return false;
+    }
+
+    return true;
+  };
+};

--- a/src/core/git/gitHubArchive.ts
+++ b/src/core/git/gitHubArchive.ts
@@ -4,6 +4,7 @@ import * as zlib from 'node:zlib';
 import { extract as tarExtract } from 'tar';
 import { RepomixError } from '../../shared/errorHandle.js';
 import { logger } from '../../shared/logger.js';
+import { createArchiveEntryFilter } from './archiveEntryFilter.js';
 import {
   buildGitHubArchiveUrl,
   buildGitHubMasterArchiveUrl,
@@ -31,6 +32,7 @@ export interface ArchiveDownloadDeps {
   Transform: typeof Transform;
   tarExtract: typeof tarExtract;
   createGunzip: typeof zlib.createGunzip;
+  createArchiveEntryFilter: typeof createArchiveEntryFilter;
 }
 
 const defaultDeps: ArchiveDownloadDeps = {
@@ -39,6 +41,7 @@ const defaultDeps: ArchiveDownloadDeps = {
   Transform,
   tarExtract,
   createGunzip: zlib.createGunzip,
+  createArchiveEntryFilter,
 };
 
 /**
@@ -164,9 +167,12 @@ const downloadAndExtractArchive = async (
 
     // Stream: HTTP response -> progress tracking -> gunzip -> tar extract to disk
     // strip: 1 removes the top-level "repo-branch/" directory from archive paths
+    // filter: skips binary files (e.g. images, fonts, executables) to avoid unnecessary disk I/O
+    const entryFilter = deps.createArchiveEntryFilter();
     const extractStream = deps.tarExtract({
       cwd: targetDirectory,
       strip: 1,
+      filter: (entryPath: string) => entryFilter(entryPath),
     });
     const gunzipStream = deps.createGunzip();
 

--- a/tests/core/git/archiveEntryFilter.test.ts
+++ b/tests/core/git/archiveEntryFilter.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test, vi } from 'vitest';
+import { createArchiveEntryFilter } from '../../../src/core/git/archiveEntryFilter.js';
+
+vi.mock('../../../src/shared/logger');
+
+describe('archiveEntryFilter', () => {
+  describe('createArchiveEntryFilter', () => {
+    test('should allow text files', () => {
+      const filter = createArchiveEntryFilter();
+      expect(filter('repo-main/src/index.ts')).toBe(true);
+      expect(filter('repo-main/README.md')).toBe(true);
+      expect(filter('repo-main/package.json')).toBe(true);
+    });
+
+    test('should skip binary image files', () => {
+      const filter = createArchiveEntryFilter();
+      expect(filter('repo-main/assets/logo.png')).toBe(false);
+      expect(filter('repo-main/images/photo.jpg')).toBe(false);
+      expect(filter('repo-main/icon.gif')).toBe(false);
+    });
+
+    test('should skip font files', () => {
+      const filter = createArchiveEntryFilter();
+      expect(filter('repo-main/fonts/inter.woff2')).toBe(false);
+      expect(filter('repo-main/fonts/roboto.woff')).toBe(false);
+      expect(filter('repo-main/fonts/arial.ttf')).toBe(false);
+    });
+
+    test('should skip archive and executable files', () => {
+      const filter = createArchiveEntryFilter();
+      expect(filter('repo-main/dist/app.exe')).toBe(false);
+      expect(filter('repo-main/vendor/lib.zip')).toBe(false);
+    });
+
+    test('should allow root directory entry', () => {
+      const filter = createArchiveEntryFilter();
+      expect(filter('repo-main/')).toBe(true);
+    });
+
+    test('should handle nested directory paths', () => {
+      const filter = createArchiveEntryFilter();
+      expect(filter('repo-main/src/components/Button.tsx')).toBe(true);
+      expect(filter('repo-main/src/assets/icons/arrow.png')).toBe(false);
+    });
+
+    test('should strip leading segment correctly for various repo name formats', () => {
+      const filter = createArchiveEntryFilter();
+      // Different repository name formats in tar archives
+      expect(filter('yamadashy-repomix-abc123/src/index.ts')).toBe(true);
+      expect(filter('yamadashy-repomix-abc123/logo.png')).toBe(false);
+    });
+
+    test('should use injected isBinaryPath dependency', () => {
+      const mockIsBinaryPath = vi.fn().mockReturnValue(true);
+      const filter = createArchiveEntryFilter({ isBinaryPath: mockIsBinaryPath });
+
+      const result = filter('repo-main/src/index.ts');
+
+      expect(result).toBe(false);
+      expect(mockIsBinaryPath).toHaveBeenCalledWith('src/index.ts');
+    });
+
+    test('should pass stripped path to isBinaryPath', () => {
+      const mockIsBinaryPath = vi.fn().mockReturnValue(false);
+      const filter = createArchiveEntryFilter({ isBinaryPath: mockIsBinaryPath });
+
+      filter('repo-main/src/deep/file.ts');
+
+      expect(mockIsBinaryPath).toHaveBeenCalledWith('src/deep/file.ts');
+    });
+  });
+});

--- a/tests/core/git/gitHubArchive.test.ts
+++ b/tests/core/git/gitHubArchive.test.ts
@@ -3,6 +3,7 @@ import type { pipeline as pipelineType } from 'node:stream/promises';
 import type * as zlib from 'node:zlib';
 import type { extract as tarExtractType } from 'tar';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { createArchiveEntryFilter as createArchiveEntryFilterType } from '../../../src/core/git/archiveEntryFilter.js';
 import {
   type ArchiveDownloadOptions,
   downloadGitHubArchive,
@@ -22,6 +23,7 @@ interface MockDeps {
   Transform: typeof Transform;
   tarExtract: typeof tarExtractType;
   createGunzip: typeof zlib.createGunzip;
+  createArchiveEntryFilter: typeof createArchiveEntryFilterType;
 }
 
 // Simple test data
@@ -32,6 +34,7 @@ describe('gitHubArchive', () => {
   let mockPipeline: ReturnType<typeof vi.fn<typeof pipelineType>>;
   let mockTarExtract: ReturnType<typeof vi.fn<typeof tarExtractType>>;
   let mockCreateGunzip: ReturnType<typeof vi.fn<typeof zlib.createGunzip>>;
+  let mockCreateArchiveEntryFilter: ReturnType<typeof vi.fn<typeof createArchiveEntryFilterType>>;
   let mockDeps: MockDeps;
 
   beforeEach(() => {
@@ -53,6 +56,7 @@ describe('gitHubArchive', () => {
         },
       }) as unknown as ReturnType<typeof zlib.createGunzip>,
     );
+    mockCreateArchiveEntryFilter = vi.fn<typeof createArchiveEntryFilterType>().mockReturnValue(() => true);
 
     mockDeps = {
       fetch: mockFetch,
@@ -60,6 +64,7 @@ describe('gitHubArchive', () => {
       Transform,
       tarExtract: mockTarExtract as unknown as typeof tarExtractType,
       createGunzip: mockCreateGunzip as unknown as typeof zlib.createGunzip,
+      createArchiveEntryFilter: mockCreateArchiveEntryFilter,
     };
   });
 
@@ -104,10 +109,11 @@ describe('gitHubArchive', () => {
         }),
       );
 
-      // Verify tar extract was called with correct options
+      // Verify tar extract was called with correct options including filter
       expect(mockTarExtract).toHaveBeenCalledWith({
         cwd: mockTargetDirectory,
         strip: 1,
+        filter: expect.any(Function),
       });
 
       // Verify streaming pipeline was used


### PR DESCRIPTION
Skip binary files (images, fonts, executables, archives, etc.) during GitHub archive tar extraction by checking file extensions with `isBinaryPath` before writing to disk.

```
Before: HTTP → gunzip → tar extract (all files) → globby → readFile → isBinaryPath exclusion
After:  HTTP → gunzip → tar extract (skip binary) → globby → readFile
```

This avoids unnecessary disk I/O for files that would be excluded later in `readRawFile` anyway. Particularly effective for repositories with many binary assets.

### Changes
- **`src/core/git/archiveEntryFilter.ts`** — New module. Creates a filter function that strips the leading tar segment (`repo-branch/`) and checks `isBinaryPath`
- **`src/core/git/gitHubArchive.ts`** — Added `createArchiveEntryFilter` to deps and passes `filter` option to `tarExtract`
- **`tests/core/git/archiveEntryFilter.test.ts`** — 9 test cases covering text files, images, fonts, executables, root entries, nested paths, and DI
- **`tests/core/git/gitHubArchive.test.ts`** — Updated mock deps and assertions for the new filter

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
