### PR TITLE
perf(core): Lazy-load jschardet and iconv-lite in fileRead

### DIFF
--- a/src/core/file/fileRead.ts
+++ b/src/core/file/fileRead.ts
@@ -6,13 +6,15 @@ import { logger } from '../../shared/logger.js';
 // Lazy-load encoding detection libraries to avoid their ~25ms combined import cost.
 // The fast UTF-8 path (covers ~99% of source code files) never needs these;
 // they are only loaded when a file fails UTF-8 decoding.
-let _jschardet: typeof import('jschardet') | undefined;
-let _iconv: typeof import('iconv-lite') | undefined;
-const getEncodingDeps = async () => {
-  if (!_jschardet || !_iconv) {
-    [_jschardet, _iconv] = await Promise.all([import('jschardet'), import('iconv-lite')]);
-  }
-  return { jschardet: _jschardet, iconv: _iconv };
+// Caching the Promise (not the resolved values) guarantees exactly one import
+// regardless of how many concurrent calls hit the slow path.
+let _encodingDepsPromise: Promise<{ jschardet: typeof import('jschardet'); iconv: typeof import('iconv-lite') }>;
+const getEncodingDeps = () => {
+  _encodingDepsPromise ??= Promise.all([import('jschardet'), import('iconv-lite')]).then(([jschardet, iconv]) => ({
+    jschardet,
+    iconv,
+  }));
+  return _encodingDepsPromise;
 };
 
 export type FileSkipReason = 'binary-extension' | 'binary-content' | 'size-limit' | 'encoding-error';


### PR DESCRIPTION
Defer importing `jschardet` and `iconv-lite` until first encounter of a non-UTF-8 file. The fast UTF-8 path (covers ~99% of source code files) never needs these libraries, saving ~25ms of combined import cost at startup.

Extracted from #1377. Pure performance optimization with no functional changes.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
