### PR TITLE
perf(server): Switch cache compression from deflate to Brotli

### DIFF
--- a/website/server/src/domains/pack/utils/cache.ts
+++ b/website/server/src/domains/pack/utils/cache.ts
@@ -8,7 +8,6 @@ const decompressAsync = promisify(zlib.brotliDecompress);
 // Balanced speed/ratio for in-memory cache
 const BROTLI_QUALITY = 4;
 
-
 interface CacheEntry {
   value: Uint8Array; // Compressed data
   timestamp: number;


### PR DESCRIPTION
Switch the in-memory cache compression algorithm from deflate to Brotli (quality level 4) to reduce memory footprint on Cloud Run.

### Benchmark results (308KB input)

| Method | Size | Speed | vs deflate |
|---|---|---|---|
| deflate (default) | 6.6 KB | 0.62 ms | — |
| **brotli q=4** | **4.1 KB** | **0.28 ms** | **38% smaller, 2x faster** |
| brotli q=11 | 3.5 KB | 14.30 ms | 48% smaller, 23x slower |

Brotli q=4 provides the best balance: better compression than deflate while actually being faster.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
