### PR TITLE
feat(server): Add GitHub repository size check before processing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,10 @@ export {
   isExplicitRemoteUrl,
   isValidRemoteValue,
   isValidShorthand,
+  parseGitHubRepoInfo,
   parseRemoteValue,
 } from './core/git/gitRemoteParse.js';
+export type { GitHubRepoInfo } from './core/git/gitRemoteParse.js';
 
 // Security
 export { runSecurityCheck } from './core/security/securityCheck.js';

--- a/website/server/src/domains/pack/remoteRepo.ts
+++ b/website/server/src/domains/pack/remoteRepo.ts
@@ -5,6 +5,7 @@ import type { PackOptions, PackResult } from '../../types.js';
 import { AppError } from '../../utils/errorHandler.js';
 import { logMemoryUsage } from '../../utils/logger.js';
 import { generateCacheKey } from './utils/cache.js';
+import { checkGitHubRepoSize } from './utils/gitHubRepoSize.js';
 import { cache } from './utils/sharedInstance.js';
 
 export async function processRemoteRepo(repoUrl: string, format: string, options: PackOptions): Promise<PackResult> {
@@ -20,6 +21,9 @@ export async function processRemoteRepo(repoUrl: string, format: string, options
   if (cachedResult) {
     return cachedResult;
   }
+
+  // Check repository size before processing
+  await checkGitHubRepoSize(repoUrl);
 
   const outputFilePath = `repomix-output-${randomUUID()}.txt`;
 

--- a/website/server/src/domains/pack/utils/gitHubRepoSize.ts
+++ b/website/server/src/domains/pack/utils/gitHubRepoSize.ts
@@ -1,0 +1,70 @@
+import { type GitHubRepoInfo, parseGitHubRepoInfo } from 'repomix';
+import { AppError } from '../../../utils/errorHandler.js';
+
+// Maximum repository size allowed for processing (in KB, as returned by GitHub API)
+const MAX_REPO_SIZE_KB = 500 * 1024; // 500MB
+
+// Timeout for GitHub API requests (in milliseconds)
+const GITHUB_API_TIMEOUT_MS = 10_000;
+
+interface GitHubRepoResponse {
+  size: number; // Repository size in KB
+}
+
+/**
+ * Fetches repository size from GitHub API.
+ * Returns the size in KB, or null if the request fails.
+ */
+const fetchGitHubRepoSize = async (repoInfo: GitHubRepoInfo): Promise<number | null> => {
+  const url = `https://api.github.com/repos/${encodeURIComponent(repoInfo.owner)}/${encodeURIComponent(repoInfo.repo)}`;
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Accept: 'application/vnd.github.v3+json',
+        'User-Agent': 'Repomix',
+      },
+      signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = (await response.json()) as GitHubRepoResponse;
+    return data.size;
+  } catch {
+    // If the API request fails, allow processing to continue
+    return null;
+  }
+};
+
+const formatSizeMB = (sizeKB: number): string => {
+  return `${(sizeKB / 1024).toFixed(1)}MB`;
+};
+
+/**
+ * Checks if a GitHub repository exceeds the maximum allowed size.
+ * Throws an AppError if the repository is too large.
+ * Silently allows processing if the size cannot be determined (non-GitHub repos, API errors).
+ */
+export const checkGitHubRepoSize = async (repoUrl: string): Promise<void> => {
+  const repoInfo = parseGitHubRepoInfo(repoUrl);
+  if (!repoInfo) {
+    // Not a GitHub repository, skip size check
+    return;
+  }
+
+  const sizeKB = await fetchGitHubRepoSize(repoInfo);
+  if (sizeKB == null) {
+    // Could not determine size, allow processing to continue
+    return;
+  }
+
+  if (sizeKB > MAX_REPO_SIZE_KB) {
+    throw new AppError(
+      `Repository is too large to process. The repository size is ${formatSizeMB(sizeKB)}, but the maximum allowed size is ${formatSizeMB(MAX_REPO_SIZE_KB)}.`,
+      422,
+    );
+  }
+};

--- a/website/server/src/domains/pack/utils/gitHubRepoSize.ts
+++ b/website/server/src/domains/pack/utils/gitHubRepoSize.ts
@@ -19,11 +19,18 @@ const fetchGitHubRepoSize = async (repoInfo: GitHubRepoInfo): Promise<number | n
   const url = `https://api.github.com/repos/${encodeURIComponent(repoInfo.owner)}/${encodeURIComponent(repoInfo.repo)}`;
 
   try {
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github.v3+json',
+      'User-Agent': 'Repomix',
+    };
+
+    const token = process.env.GITHUB_TOKEN;
+    if (token) {
+      headers.Authorization = `token ${token}`;
+    }
+
     const response = await fetch(url, {
-      headers: {
-        Accept: 'application/vnd.github.v3+json',
-        'User-Agent': 'Repomix',
-      },
+      headers,
       signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
     });
 

--- a/website/server/src/domains/pack/utils/gitHubRepoSize.ts
+++ b/website/server/src/domains/pack/utils/gitHubRepoSize.ts
@@ -24,7 +24,7 @@ const fetchGitHubRepoSize = async (repoInfo: GitHubRepoInfo): Promise<number | n
       'User-Agent': 'Repomix',
     };
 
-    const token = process.env.GITHUB_TOKEN;
+    const token = process.env.GITHUB_TOKEN_REPO_SIZE_CHECK;
     if (token) {
       headers.Authorization = `token ${token}`;
     }


### PR DESCRIPTION
Add a pre-download size check for GitHub repositories to prevent processing oversized repos that would exhaust server resources.

- Query GitHub API (`/repos/{owner}/{repo}`) to get repository size before downloading
- Reject repositories exceeding 500MB with a 422 error and a clear message
- Fail open: if the API is unreachable or the repo is non-GitHub, processing continues normally
- Run the check after cache lookup to avoid unnecessary API calls
- Export `parseGitHubRepoInfo` and `GitHubRepoInfo` from the repomix package for server-side URL parsing

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
