### PR TITLE
feat(website): Stream pack progress events via SSE

### DIFF
--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -13,6 +13,7 @@ import { generateDefaultSkillName } from '../../core/skill/skillUtils.js';
 import { RepomixError, rethrowValidationErrorIfZodError } from '../../shared/errorHandle.js';
 import { logger } from '../../shared/logger.js';
 import { splitPatterns } from '../../shared/patternUtils.js';
+import type { RepomixProgressCallback } from '../../shared/types.js';
 import { reportResults } from '../cliReport.js';
 import { Spinner } from '../cliSpinner.js';
 import { promptSkillLocation, resolveAndPrepareSkillDir } from '../prompts/skillPrompts.js';
@@ -28,6 +29,7 @@ export const runDefaultAction = async (
   directories: string[],
   cwd: string,
   cliOptions: CliOptions,
+  progressCallback?: RepomixProgressCallback,
 ): Promise<DefaultActionRunnerResult> => {
   logger.trace('Loaded CLI options:', cliOptions);
 
@@ -113,16 +115,12 @@ export const runDefaultAction = async (
 
     const targetPaths = stdinFilePaths ? [cwd] : directories.map((directory) => path.resolve(cwd, directory));
 
-    packResult = await pack(
-      targetPaths,
-      config,
-      (message) => {
-        spinner.update(message);
-      },
-      {},
-      stdinFilePaths,
-      packOptions,
-    );
+    const handleProgress: RepomixProgressCallback = (message) => {
+      spinner.update(message);
+      progressCallback?.(message);
+    };
+
+    packResult = await pack(targetPaths, config, handleProgress, {}, stdinFilePaths, packOptions);
 
     spinner.succeed('Packing completed successfully!');
   } catch (error) {

--- a/website/client/components/Home/TryIt.vue
+++ b/website/client/components/Home/TryIt.vue
@@ -97,6 +97,7 @@
           :repository-url="inputRepositoryUrl"
           :pack-options="packOptions"
           :progress-stage="progressStage"
+          :progress-message="progressMessage"
           @repack="handleRepack"
         />
       </div>
@@ -138,6 +139,7 @@ const {
   result,
   hasExecuted,
   progressStage,
+  progressMessage,
 
   // Computed
   isSubmitValid,

--- a/website/client/components/Home/TryItLoading.vue
+++ b/website/client/components/Home/TryItLoading.vue
@@ -4,6 +4,7 @@ import type { PackProgressStage } from '../api/client';
 
 interface Props {
   stage?: PackProgressStage | null;
+  message?: string | null;
 }
 
 const props = defineProps<Props>();
@@ -17,6 +18,9 @@ const stageMessages: Record<PackProgressStage, string> = {
 };
 
 const displayMessage = computed(() => {
+  if (props.message) {
+    return props.message;
+  }
   if (props.stage && stageMessages[props.stage]) {
     return stageMessages[props.stage];
   }

--- a/website/client/components/Home/TryItResult.vue
+++ b/website/client/components/Home/TryItResult.vue
@@ -17,6 +17,7 @@ interface Props {
   repositoryUrl?: string;
   packOptions?: PackOptions;
   progressStage?: PackProgressStage | null;
+  progressMessage?: string | null;
 }
 
 interface Emits {
@@ -52,7 +53,7 @@ const handleRepack = (selectedFiles: FileInfo[]) => {
 <template>
   <div class="result-viewer">
     <template v-if="loading && !result">
-      <TryItLoading :stage="progressStage" />
+      <TryItLoading :stage="progressStage" :message="progressMessage" />
       <SupportMessage />
     </template>
     <TryItResultErrorContent

--- a/website/client/components/api/client.ts
+++ b/website/client/components/api/client.ts
@@ -64,7 +64,7 @@ export class ApiError extends Error {
 export type PackProgressStage = 'cache-check' | 'cloning' | 'repository-fetch' | 'extracting' | 'processing';
 
 export interface PackStreamCallbacks {
-  onProgress?: (stage: PackProgressStage) => void;
+  onProgress?: (stage: PackProgressStage, message?: string) => void;
   signal?: AbortSignal;
 }
 
@@ -74,6 +74,7 @@ const API_BASE_URL = import.meta.env.PROD ? 'https://api.repomix.com' : 'http://
 interface ProgressEvent {
   type: 'progress';
   stage: PackProgressStage;
+  message?: string;
 }
 
 interface ResultEvent {
@@ -137,7 +138,7 @@ export async function packRepository(request: PackRequest, callbacks?: PackStrea
 
         const event = JSON.parse(line) as StreamEvent;
         if (event.type === 'progress') {
-          callbacks?.onProgress?.(event.stage);
+          callbacks?.onProgress?.(event.stage, event.message);
         } else if (event.type === 'result') {
           result = event.data;
         } else if (event.type === 'error') {

--- a/website/client/components/utils/requestHandlers.ts
+++ b/website/client/components/utils/requestHandlers.ts
@@ -6,7 +6,7 @@ interface RequestHandlerOptions {
   onSuccess?: (result: PackResult) => void;
   onError?: (error: string) => void;
   onAbort?: (message: string) => void;
-  onProgress?: (stage: PackProgressStage) => void;
+  onProgress?: (stage: PackProgressStage, message?: string) => void;
   signal?: AbortSignal;
   file?: File;
 }

--- a/website/client/composables/usePackRequest.ts
+++ b/website/client/composables/usePackRequest.ts
@@ -25,6 +25,7 @@ export function usePackRequest() {
   const result = ref<PackResult | null>(null);
   const hasExecuted = ref(false);
   const progressStage = ref<PackProgressStage | null>(null);
+  const progressMessage = ref<string | null>(null);
 
   // Request controller for cancellation
   let requestController: AbortController | null = null;
@@ -73,6 +74,7 @@ export function usePackRequest() {
     result.value = null;
     hasExecuted.value = true;
     progressStage.value = null;
+    progressMessage.value = null;
     inputRepositoryUrl.value = inputUrl.value;
 
     // Set up automatic timeout
@@ -95,8 +97,9 @@ export function usePackRequest() {
             error.value = message;
             errorType.value = 'warning';
           },
-          onProgress: (stage) => {
+          onProgress: (stage, message) => {
             progressStage.value = stage;
+            progressMessage.value = message ?? null;
           },
           signal: requestController.signal,
           file: mode.value === 'file' || mode.value === 'folder' ? uploadedFile.value || undefined : undefined,
@@ -181,6 +184,7 @@ export function usePackRequest() {
     result,
     hasExecuted,
     progressStage,
+    progressMessage,
 
     // Computed
     isSubmitValid,

--- a/website/server/src/actions/packAction.ts
+++ b/website/server/src/actions/packAction.ts
@@ -130,8 +130,8 @@ export const packAction = async (c: Context) => {
     };
 
     try {
-      const sendProgress = async (stage: PackProgressStage) => {
-        await writeLine({ type: 'progress', stage });
+      const sendProgress = async (stage: PackProgressStage, message?: string) => {
+        await writeLine({ type: 'progress', stage, ...(message && { message }) });
       };
 
       const startTime = Date.now();

--- a/website/server/src/domains/pack/processZipFile.ts
+++ b/website/server/src/domains/pack/processZipFile.ts
@@ -68,7 +68,10 @@ export async function processZipFile(
 
     // Execute default action on the extracted directory
     await onProgress?.('processing');
-    const result = await runDefaultAction([tempDirPath], tempDirPath, cliOptions);
+    const packProgressCallback = (message: string) => {
+      onProgress?.('processing', message);
+    };
+    const result = await runDefaultAction([tempDirPath], tempDirPath, cliOptions, packProgressCallback);
     await copyOutputToCurrentDirectory(tempDirPath, process.cwd(), result.config.output.filePath);
     const { packResult } = result;
 

--- a/website/server/src/domains/pack/remoteRepo.ts
+++ b/website/server/src/domains/pack/remoteRepo.ts
@@ -88,7 +88,10 @@ export async function processRemoteRepo(
 
     // Process the cloned repository
     await onProgress?.('processing');
-    const result = await runDefaultAction([tempDirPath], tempDirPath, cliOptions);
+    const packProgressCallback = (message: string) => {
+      onProgress?.('processing', message);
+    };
+    const result = await runDefaultAction([tempDirPath], tempDirPath, cliOptions, packProgressCallback);
     await copyOutputToCurrentDirectory(tempDirPath, process.cwd(), result.config.output.filePath);
     const { packResult } = result;
 

--- a/website/server/src/types.ts
+++ b/website/server/src/types.ts
@@ -53,4 +53,4 @@ export interface ErrorResponse {
 // Progress streaming types
 export type PackProgressStage = 'cache-check' | 'cloning' | 'repository-fetch' | 'extracting' | 'processing';
 
-export type PackProgressCallback = (stage: PackProgressStage) => void | Promise<void>;
+export type PackProgressCallback = (stage: PackProgressStage, message?: string) => void | Promise<void>;


### PR DESCRIPTION
Replace the single JSON response from the pack endpoint with SSE streaming to provide real-time progress updates during repository packing.

### Server-side
- Add `PackProgressStage` and `PackProgressCallback` types
- `packAction` now uses Hono's `streamSSE` to stream progress events and the final result
- `processRemoteRepo` reports `cache-check` and `repository-fetch` stages
- `processZipFile` reports `extracting` and `processing` stages
- Validation errors still return regular JSON responses (before streaming starts)

### Client-side
- `client.ts` parses SSE stream with `parseSSEChunk` utility, supports `onProgress` callback
- `usePackRequest` composable tracks `progressStage` reactive state
- `TryItLoading.vue` displays stage-specific messages:
  - Checking cache...
  - Fetching repository...
  - Extracting files...
  - Processing files...

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
