### PR TITLE
chore(agents): Set reviewer agents to use Sonnet model

### DIFF
--- a/.agents/agents/reviewer-code-quality.md
+++ b/.agents/agents/reviewer-code-quality.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 description: Review code changes for bugs, logic errors, edge cases, and code smells
 ---
 

--- a/.agents/agents/reviewer-conventions.md
+++ b/.agents/agents/reviewer-conventions.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 description: Review code changes for adherence to project conventions, naming, and structure
 ---
 

--- a/.agents/agents/reviewer-holistic.md
+++ b/.agents/agents/reviewer-holistic.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 description: Review code changes for overall design concerns, side effects, integration risks, and user impact
 ---
 

--- a/.agents/agents/reviewer-performance.md
+++ b/.agents/agents/reviewer-performance.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 description: Review code changes for performance inefficiencies and resource issues
 ---
 

--- a/.agents/agents/reviewer-security.md
+++ b/.agents/agents/reviewer-security.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 description: Review code changes for security vulnerabilities and unsafe patterns
 ---
 

--- a/.agents/agents/reviewer-test-coverage.md
+++ b/.agents/agents/reviewer-test-coverage.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 description: Review code changes for missing tests, untested edge cases, and test quality
 ---
 


### PR DESCRIPTION
Add `model: sonnet` frontmatter to all 6 reviewer agent definitions to use Sonnet instead of the default model for code reviews.

**Affected agents:**
- `reviewer-code-quality`
- `reviewer-conventions`
- `reviewer-holistic`
- `reviewer-performance`
- `reviewer-security`
- `reviewer-test-coverage`

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

> No code changes — agent config only, so tests and lint are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
