### PR TITLE
chore(agents): Improve CLAUDE.md clarity and conciseness

### DIFF
--- a/.agents/rules/base.md
+++ b/.agents/rules/base.md
@@ -5,7 +5,7 @@ alwaysApply: true
 
 # Repomix
 
-A tool that packs repository contents into a single AI-friendly file. Supports XML, Markdown, and plain text output formats.
+A tool that packs repository contents into a single AI-friendly file. Supports XML, Markdown, JSON, and plain text output formats.
 
 Refer to `README.md` for full project overview and `CONTRIBUTING.md` for contribution procedures.
 

--- a/.agents/rules/base.md
+++ b/.agents/rules/base.md
@@ -56,7 +56,7 @@ repomix/
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/) with scope: `type(scope): Description`
 
-```
+```text
 feat(cli): Add new --no-progress flag
 fix(security): Handle special characters in file paths
 docs(website): Update installation guide

--- a/.agents/rules/base.md
+++ b/.agents/rules/base.md
@@ -41,7 +41,7 @@ repomix/
 
 # Coding Guidelines
 
-- Follow the Airbnb JavaScript Style Guide
+- Follow the project's coding standards enforced by Biome (`biome.json`)
 - Maintain feature-based directory structure and avoid dependencies between features
 - Split files exceeding 250 lines into multiple files based on functionality
 - Add comments in English where non-obvious logic exists

--- a/.agents/rules/base.md
+++ b/.agents/rules/base.md
@@ -1,22 +1,15 @@
 ---
 description: Core project guidelines for the Repomix codebase. Apply these rules when working on any code, documentation, or configuration files within the Repomix project.
 alwaysApply: true
-inclusion: always
 ---
 
-# Repomix Project Structure and Overview
+# Repomix
 
-This document provides a structural overview of the Repomix project, designed to aid AI code assistants (like Copilot) in understanding the codebase.
+A tool that packs repository contents into a single AI-friendly file. Supports XML, Markdown, and plain text output formats.
 
-Please refer to `README.md` for a complete and up-to-date project overview, and `CONTRIBUTING.md` for implementation guidelines and contribution procedures.
-
-## Project Overview
-
-Repomix is a tool that packs the contents of a software repository into a single file, making it easier for AI systems to analyze and process the codebase. It supports various output formats (XML, Markdown, or plain text), ignores files based on configurable patterns, and performs security checks to exclude potentially sensitive information.
+Refer to `README.md` for full project overview and `CONTRIBUTING.md` for contribution procedures.
 
 ## Directory Structure
-
-The project is organized into the following directories:
 
 ```
 repomix/
@@ -48,12 +41,12 @@ repomix/
 
 # Coding Guidelines
 
-- The assistant shall follow the Airbnb JavaScript Style Guide.
-- The assistant shall maintain feature-based directory structure and avoid dependencies between features.
-- If a file exceeds 250 lines, then the assistant shall split it into multiple files based on functionality.
-- Where non-obvious logic exists, the assistant shall add comments in English to clarify.
-- When implementing new features, the assistant shall provide corresponding unit tests.
-- When implementation is complete, the assistant shall verify changes by running:
+- Follow the Airbnb JavaScript Style Guide
+- Maintain feature-based directory structure and avoid dependencies between features
+- Split files exceeding 250 lines into multiple files based on functionality
+- Add comments in English where non-obvious logic exists
+- Provide corresponding unit tests for new features
+- Verify changes by running:
   ```bash
   npm run lint  # Ensure code style compliance
   npm run test  # Verify all tests pass
@@ -61,77 +54,48 @@ repomix/
 
 ## Commit Messages
 
-- The assistant shall follow the [Conventional Commits](https://www.conventionalcommits.org/) specification for all commit messages.
-- The assistant shall always include a scope in commit messages.
-- The assistant shall use the format: `type(scope): Description`
-  ```
-  # Examples:
-  feat(cli): Add new --no-progress flag
-  fix(security): Handle special characters in file paths
-  docs(website): Update installation guide
-  style(website): Update GitHub sponsor button color
-  refactor(core): Split packager into smaller modules
-  test(cli): Add tests for new CLI options
-  ```
-- The assistant shall use types: feat, fix, docs, style, refactor, test, chore, etc.
-- The assistant shall use scope to indicate the affected part of the codebase (cli, core, website, security, etc.).
-- The assistant shall write description in clear, concise present tense starting with a capital letter.
+Follow [Conventional Commits](https://www.conventionalcommits.org/) with scope: `type(scope): Description`
 
-### Commit Body Guidelines
+```
+feat(cli): Add new --no-progress flag
+fix(security): Handle special characters in file paths
+docs(website): Update installation guide
+refactor(core): Split packager into smaller modules
+test(cli): Add tests for new CLI options
+```
 
-- When writing commit body, the assistant shall follow the `contextual-commit` skill (`.claude/skills/contextual-commit/SKILL.md`).
+- Types: feat, fix, docs, style, refactor, test, chore, etc.
+- Scope: affected area (cli, core, website, security, etc.)
+- Description: clear, concise present tense starting with a capital letter
+- Commit body: follow the `contextual-commit` skill (`.claude/skills/contextual-commit/SKILL.md`)
 
 ## Pull Request Guidelines
 
-- When creating a pull request, the assistant shall follow the template:
-  ```md
-  <!-- Please include a summary of the changes -->
-
-  ## Checklist
-
-  - [ ] Run `npm run test`
-  - [ ] Run `npm run lint`
-  ```
-- When creating a pull request, the assistant shall include a clear summary of the changes at the top.
-- Where related issues exist, the assistant shall reference them using `#issue-number`.
-
-## PR Review Guidelines
-
-When reviewing pull requests, the assistant shall provide thoughtful feedback on the following topics:
-- Code quality and best practices
-- Potential bugs or issues
-- Suggestions for improvements
-- Overall architecture and design decisions
+- Follow the template at `.github/pull_request_template.md`
+- Include a clear summary of changes at the top
+- Reference related issues using `#issue-number`
 
 ## Dependencies and Testing
 
-- The assistant shall inject dependencies through a deps object parameter for testability.
-- Example:
-  ```typescript
-  export const functionName = async (
-    param1: Type1,
-    param2: Type2,
-    deps = {
-      defaultFunction1,
-      defaultFunction2,
-    }
-  ) => {
-    // Use deps.defaultFunction1() instead of direct call
-  };
-  ```
-- When writing tests, the assistant shall mock dependencies by passing test doubles through deps object.
-- If dependency injection is not feasible, then the assistant shall use vi.mock().
+Inject dependencies through a `deps` object parameter for testability:
 
-## Generate Comprehensive Output
+```typescript
+export const functionName = async (
+  param1: Type1,
+  param2: Type2,
+  deps = {
+    defaultFunction1,
+    defaultFunction2,
+  }
+) => {
+  // Use deps.defaultFunction1() instead of direct call
+};
+```
 
-- The assistant shall include all content without abbreviation, unless specified otherwise.
-- The assistant shall optimize for handling large codebases while maintaining output quality.
+- Mock dependencies by passing test doubles through the deps object
+- Use `vi.mock()` only when dependency injection is not feasible
 
-# GitHub Release Note Guidelines
+## Output Generation
 
-- When writing release notes, the assistant shall reference issues or PRs using gh command to verify content:
-  ```bash
-  gh issue view <issue-number>  # For checking issue content
-  gh pr view <pr-number>        # For checking PR content
-  ```
-- When writing release notes, the assistant shall retrieve and reference the latest release notes from `.github/releases/` as they contain past release examples.
+- Include all content without abbreviation, unless specified otherwise
+- Optimize for handling large codebases while maintaining output quality


### PR DESCRIPTION
Simplify project guidelines by removing verbose phrasing, reducing redundancy, and removing rarely-used sections.

- Remove "The assistant shall" prefix from all guidelines for conciseness
- Simplify project overview and commit message sections
- Replace inline PR template with file reference
- Remove PR review and release note guidelines
- Remove non-standard `inclusion` frontmatter field

138 lines → 101 lines (27% reduction) while preserving all essential content.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
