### PR TITLE
fix(file): Apply **/folder/** expansion after trailing slash removal

### DIFF
--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -79,17 +79,19 @@ export const escapeGlobPattern = (pattern: string): string => {
  * @returns The normalized pattern
  */
 export const normalizeGlobPattern = (pattern: string): string => {
+  let normalized = pattern;
+
   // Remove trailing slash but preserve patterns that end with "**/"
-  if (pattern.endsWith('/') && !pattern.endsWith('**/')) {
-    return pattern.slice(0, -1);
+  if (normalized.endsWith('/') && !normalized.endsWith('**/')) {
+    normalized = normalized.slice(0, -1);
   }
 
   // Convert **/folder to **/folder/** for consistent ignore pattern behavior
-  if (pattern.startsWith('**/') && !pattern.includes('/**')) {
-    return `${pattern}/**`;
+  if (normalized.startsWith('**/') && !normalized.includes('/**')) {
+    return `${normalized}/**`;
   }
 
-  return pattern;
+  return normalized;
 };
 
 // Get all file paths considering the config

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -811,6 +811,14 @@ node_modules
     test('should not convert patterns that already have /**/*', () => {
       expect(normalizeGlobPattern('**/folder/**/*')).toBe('**/folder/**/*');
     });
+
+    test('should normalize **/folder/ with trailing slash to **/folder/**', () => {
+      expect(normalizeGlobPattern('**/bin/')).toBe('**/bin/**');
+    });
+
+    test('should normalize **/nested/folder/ with trailing slash to **/nested/folder/**', () => {
+      expect(normalizeGlobPattern('**/nested/folder/')).toBe('**/nested/folder/**');
+    });
   });
 
   describe('searchFiles path validation', () => {


### PR DESCRIPTION
`normalizeGlobPattern` has two sequential normalization steps:

1. Remove trailing slash (`**/bin/` → `**/bin`)
2. Expand `**/folder` to `**/folder/**`

The first step used an early `return`, so step 2 never ran for patterns like `**/bin/`. This meant `**/bin/` became `**/bin` instead of `**/bin/**`, and files inside matching directories were not ignored.

This contradicts the function's documented intent (added in #453) to make `**/folder`, `**/folder/`, and `**/folder/**/*` behave identically.

**Before:** `normalizeGlobPattern('**/bin/')` → `'**/bin'`
**After:** `normalizeGlobPattern('**/bin/')` → `'**/bin/**'`

The fix replaces the early `return` with a local variable so both steps apply sequentially. Two regression tests added.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
