### PR TITLE
perf(core): Parallelize sortByChanges git log with file collection

### DIFF
--- a/src/core/output/outputSort.ts
+++ b/src/core/output/outputSort.ts
@@ -113,6 +113,25 @@ export const sortOutputFiles = async (
   return sortFilesByChangeCounts(files, fileChangeCounts);
 };
 
+/**
+ * Pre-fetch file change counts from git log into the module-level cache.
+ * Call this early in the pipeline (fire-and-forget) to overlap with other
+ * I/O-bound work. When sortOutputFiles runs later, it will find the result
+ * already cached and skip the git subprocess.
+ */
+export const prefetchFileChangeCounts = async (
+  config: RepomixConfigMerged,
+  deps: SortDeps = {
+    getFileChangeCount,
+    isGitInstalled,
+  },
+): Promise<void> => {
+  if (!config.output.git?.sortByChanges) {
+    return;
+  }
+  await getFileChangeCounts(config.cwd, config.output.git?.sortByChangesMaxCommits, deps);
+};
+
 const sortFilesByChangeCounts = (files: ProcessedFile[], fileChangeCounts: Record<string, number>): ProcessedFile[] => {
   // Sort files by change count (files with more changes go to the bottom)
   return [...files].sort((a, b) => {

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -11,6 +11,7 @@ import type { ProcessedFile } from './file/fileTypes.js';
 import { getGitDiffs } from './git/gitDiffHandle.js';
 import { getGitLogs } from './git/gitLogHandle.js';
 import { calculateMetrics, createMetricsTaskRunner } from './metrics/calculateMetrics.js';
+import { prefetchFileChangeCounts } from './output/outputSort.js';
 import { produceOutput } from './packager/produceOutput.js';
 import type { SuspiciousFileResult } from './security/securityCheck.js';
 import { validateFileSafety } from './security/validateFileSafety.js';
@@ -45,6 +46,7 @@ const defaultDeps = {
   getGitDiffs,
   getGitLogs,
   packSkill,
+  prefetchFileChangeCounts,
 };
 
 export interface PackOptions {
@@ -105,10 +107,11 @@ export const pack = async (
   );
 
   try {
-    // Run file collection and git operations in parallel since they are independent:
+    // Run file collection, git operations, and sort pre-fetch in parallel since they are independent:
     // - collectFiles reads file contents from disk
     // - getGitDiffs/getGitLogs spawn git subprocesses
-    // Neither depends on the other's results.
+    // - prefetchFileChangeCounts warms the module-level cache so sortOutputFiles
+    //   (called later inside generateOutput) finds the result already cached
     progressCallback('Collecting files...');
     const [collectResults, gitDiffResult, gitLogResult] = await Promise.all([
       withMemoryLogging(
@@ -122,6 +125,7 @@ export const pack = async (
       ),
       deps.getGitDiffs(rootDirs, config),
       deps.getGitLogs(rootDirs, config),
+      deps.prefetchFileChangeCounts(config),
     ]);
 
     const rawFiles = collectResults.flatMap((curr) => curr.rawFiles);

--- a/tests/core/packager.test.ts
+++ b/tests/core/packager.test.ts
@@ -73,6 +73,7 @@ describe('packager', () => {
         gitDiffTokenCount: 0,
         gitLogTokenCount: 0,
       }),
+      prefetchFileChangeCounts: vi.fn().mockResolvedValue(null),
     };
 
     const mockConfig = createMockConfig();

--- a/tests/core/packager/diffsFunctionality.test.ts
+++ b/tests/core/packager/diffsFunctionality.test.ts
@@ -93,6 +93,7 @@ index 123..456 100644
       calculateMetrics: mockCalculateMetrics,
       createMetricsTaskRunner: mockCreateMetricsTaskRunner,
       sortPaths: mockSortPaths,
+      prefetchFileChangeCounts: vi.fn().mockResolvedValue(null),
     });
 
     // Should not call getWorkTreeDiff
@@ -151,6 +152,7 @@ index 123..456 100644
       calculateMetrics: mockCalculateMetrics,
       createMetricsTaskRunner: mockCreateMetricsTaskRunner,
       sortPaths: mockSortPaths,
+      prefetchFileChangeCounts: vi.fn().mockResolvedValue(null),
     });
 
     // Check gitDiffTokenCount in the result

--- a/tests/core/packager/splitOutput.test.ts
+++ b/tests/core/packager/splitOutput.test.ts
@@ -53,6 +53,7 @@ describe('packager split output', () => {
       }),
       getGitDiffs: vi.fn().mockResolvedValue(undefined),
       getGitLogs: vi.fn().mockResolvedValue(undefined),
+      prefetchFileChangeCounts: vi.fn().mockResolvedValue(null),
       produceOutput,
       calculateMetrics,
       createMetricsTaskRunner: vi.fn().mockReturnValue({


### PR DESCRIPTION
## Summary

- Pre-fetch file change counts via `prefetchFileChangeCounts` in the existing Promise.all alongside collectFiles/getGitDiffs/getGitLogs
- `sortOutputFiles` finds the result already cached and skips the blocking git subprocess

Cherry-picked from e587f6af (PR #1428)

## Test plan

- [x] All tests passing
- [x] Build clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
