### PR TITLE
perf(core): Reduce metrics IPC overhead with adaptive batch sizing

### DIFF
--- a/src/core/metrics/calculateOutputMetrics.ts
+++ b/src/core/metrics/calculateOutputMetrics.ts
@@ -2,10 +2,11 @@ import { logger } from '../../shared/logger.js';
 import { type MetricsTaskRunner, runTokenCount } from './metricsWorkerRunner.js';
 import type { TokenEncoding } from './TokenCounter.js';
 
-// Target ~200K characters per chunk to balance tokenization throughput and worker round-trip overhead.
-// Benchmarks show 200K is the sweet spot: fewer round-trips than 100K with enough chunks
-// for good parallelism across available threads (e.g., 20 chunks for a 4M character output).
-const TARGET_CHARS_PER_CHUNK = 200_000;
+// Target ~500K characters per chunk to balance tokenization throughput and worker round-trip overhead.
+// Larger chunks reduce per-batch IPC scheduling overhead (~1ms per round-trip). For a 4MB output
+// this produces ~8 chunks — still enough for good parallelism across 4 worker threads while
+// cutting round-trips by more than half compared to 200K chunks (~20 round-trips).
+const TARGET_CHARS_PER_CHUNK = 500_000;
 const MIN_CONTENT_LENGTH_FOR_PARALLEL = 1_000_000; // 1MB
 
 export const calculateOutputMetrics = async (

--- a/src/core/metrics/calculateSelectiveFileMetrics.ts
+++ b/src/core/metrics/calculateSelectiveFileMetrics.ts
@@ -6,15 +6,19 @@ import { type MetricsTaskRunner, runBatchTokenCount } from './metricsWorkerRunne
 import type { TokenEncoding } from './TokenCounter.js';
 import type { FileMetrics } from './workers/types.js';
 
-// Batch size for grouping files into worker tasks to reduce IPC overhead.
+// Batch sizes for grouping files into worker tasks to reduce IPC overhead.
 // Each batch is sent as a single message to a worker thread, avoiding
-// per-file round-trip costs (~0.5ms each) that dominate when processing many files.
-// A size of 10 keeps individual worker tasks small so that workers become available sooner,
-// enabling overlap between file metrics and output generation.
-// When tokenCountTree is disabled, metrics only processes a small number of top files
-// (e.g., topFilesLength * 10 = 50 by default), so a smaller batch size avoids
-// a single batch monopolizing one worker.
-const METRICS_BATCH_SIZE = 10;
+// per-file round-trip costs (~0.5-1ms each) that dominate when processing many files.
+//
+// When processing many files (tokenCountTree enabled), larger batches significantly
+// reduce the total number of IPC round-trips (e.g., 1000 files: 20 batches of 50 vs
+// 100 batches of 10), saving ~80ms of scheduling overhead on a typical 4-core machine.
+//
+// When processing few files (tokenCountTree disabled, only top files), smaller batches
+// ensure work is distributed across available workers rather than monopolizing one.
+const METRICS_BATCH_SIZE_SMALL = 10;
+const METRICS_BATCH_SIZE_LARGE = 50;
+const LARGE_BATCH_THRESHOLD = 100;
 
 export const calculateSelectiveFileMetrics = async (
   processedFiles: ProcessedFile[],
@@ -34,10 +38,13 @@ export const calculateSelectiveFileMetrics = async (
     const startTime = process.hrtime.bigint();
     logger.trace(`Starting selective metrics calculation for ${filesToProcess.length} files using worker pool`);
 
-    // Split files into batches to reduce IPC round-trips
+    // Split files into batches to reduce IPC round-trips.
+    // Use larger batches when processing many files to minimize scheduling overhead.
+    const batchSize =
+      filesToProcess.length > LARGE_BATCH_THRESHOLD ? METRICS_BATCH_SIZE_LARGE : METRICS_BATCH_SIZE_SMALL;
     const batches: ProcessedFile[][] = [];
-    for (let i = 0; i < filesToProcess.length; i += METRICS_BATCH_SIZE) {
-      batches.push(filesToProcess.slice(i, i + METRICS_BATCH_SIZE));
+    for (let i = 0; i < filesToProcess.length; i += batchSize) {
+      batches.push(filesToProcess.slice(i, i + batchSize));
     }
 
     logger.trace(`Split ${filesToProcess.length} files into ${batches.length} batches for token counting`);

--- a/tests/core/metrics/calculateOutputMetrics.test.ts
+++ b/tests/core/metrics/calculateOutputMetrics.test.ts
@@ -173,13 +173,13 @@ describe('calculateOutputMetrics', () => {
       }),
     });
 
-    // With TARGET_CHARS_PER_CHUNK=200_000, 1.1M character content should produce 6 chunks
+    // With TARGET_CHARS_PER_CHUNK=500_000, 1.1M character content should produce 3 chunks
     const chunkSizes = processedChunks.map((chunk) => chunk.length);
 
-    expect(processedChunks.length).toBe(6);
+    expect(processedChunks.length).toBe(3);
     // All chunks except the last should be exactly TARGET_CHARS_PER_CHUNK
     for (let i = 0; i < chunkSizes.length - 1; i++) {
-      expect(chunkSizes[i]).toBe(200_000);
+      expect(chunkSizes[i]).toBe(500_000);
     }
     expect(processedChunks.join('')).toBe(content); // All content should be processed
   });

--- a/tests/core/metrics/calculateSelectiveFileMetrics.test.ts
+++ b/tests/core/metrics/calculateSelectiveFileMetrics.test.ts
@@ -60,6 +60,67 @@ describe('calculateSelectiveFileMetrics', () => {
     ]);
   });
 
+  it('should use larger batches for more than 100 files', async () => {
+    // Generate 150 files to trigger the large batch path (>100 files → batch size 50)
+    const fileCount = 150;
+    const processedFiles: ProcessedFile[] = Array.from({ length: fileCount }, (_, i) => ({
+      path: `file${i}.txt`,
+      content: 'test',
+    }));
+    const targetFilePaths = processedFiles.map((f) => f.path);
+
+    let batchCount = 0;
+    const taskRunner: MetricsTaskRunner = {
+      run: async (task: MetricsWorkerTask) => {
+        batchCount++;
+        if ('items' in task) {
+          const batchTask = task as TokenCountBatchTask;
+          return batchTask.items.map(() => 1);
+        }
+        return 1;
+      },
+      cleanup: async () => {},
+    };
+
+    const result = await calculateSelectiveFileMetrics(processedFiles, targetFilePaths, 'o200k_base', vi.fn(), {
+      taskRunner,
+    });
+
+    expect(result).toHaveLength(fileCount);
+    // With batch size 50 for >100 files: ceil(150/50) = 3 batches
+    expect(batchCount).toBe(3);
+  });
+
+  it('should use smaller batches for 100 or fewer files', async () => {
+    const fileCount = 100;
+    const processedFiles: ProcessedFile[] = Array.from({ length: fileCount }, (_, i) => ({
+      path: `file${i}.txt`,
+      content: 'test',
+    }));
+    const targetFilePaths = processedFiles.map((f) => f.path);
+
+    let batchCount = 0;
+    const taskRunner: MetricsTaskRunner = {
+      run: async (task: MetricsWorkerTask) => {
+        batchCount++;
+        if ('items' in task) {
+          const batchTask = task as TokenCountBatchTask;
+          return batchTask.items.map(() => 1);
+        }
+        return 1;
+      },
+      cleanup: async () => {},
+    };
+
+    const result = await calculateSelectiveFileMetrics(processedFiles, targetFilePaths, 'o200k_base', vi.fn(), {
+      taskRunner,
+    });
+
+    expect(result).toHaveLength(fileCount);
+    // With batch size 10 for <=100 files: ceil(100/10) = 10 batches
+    expect(batchCount).toBe(10);
+  });
+
   it('should return empty array when no target files match', async () => {
     const processedFiles: ProcessedFile[] = [{ path: 'file1.txt', content: 'a'.repeat(100) }];
     const targetFilePaths = ['nonexistent.txt'];


### PR DESCRIPTION
## Summary

- Increase batch sizes from 10 to 50 for large repos (>100 files)
- Increase output chunk size from 200K to 500K chars
- Reduces IPC round-trips from 100 to 20 for a 1000-file repo

Cherry-picked from 3c981392 (PR #1428)

## Test plan

- [x] All tests passing
- [x] Build clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
