### PR TITLE
perf(cli): Pre-create metrics worker pool before pack() for earlier BPE warmup

### DIFF
--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -8,11 +8,13 @@ import {
   repomixConfigCliSchema,
 } from '../../config/configSchema.js';
 import { readFilePathsFromStdin } from '../../core/file/fileStdin.js';
+import { createMetricsTaskRunner } from '../../core/metrics/calculateMetrics.js';
 import { type PackResult, pack } from '../../core/packager.js';
 import { generateDefaultSkillName } from '../../core/skill/skillUtils.js';
 import { RepomixError, rethrowValidationErrorIfZodError } from '../../shared/errorHandle.js';
 import { logger } from '../../shared/logger.js';
 import { splitPatterns } from '../../shared/patternUtils.js';
+import { getProcessConcurrency } from '../../shared/processConcurrency.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
 import { reportResults } from '../cliReport.js';
 import { Spinner } from '../cliSpinner.js';
@@ -101,6 +103,12 @@ export const runDefaultAction = async (
     logger.trace(`Read ${stdinFilePaths.length} file paths from stdin`);
   }
 
+  // Pre-create the metrics worker pool so gpt-tokenizer BPE data loading
+  // (~150ms in worker threads) overlaps with spinner setup and early pack()
+  // stages (file search/collection). This gives workers ~60ms more warmup time
+  // compared to creating the pool inside pack(), reducing the warmup wait.
+  const earlyMetricsRunner = createMetricsTaskRunner(getProcessConcurrency() * 100, config.tokenCount.encoding);
+
   // Run pack() directly in the main process instead of spawning a child process.
   // The child process startup cost (~250ms for Node.js init + module re-loading) was
   // pure overhead since the spinner and pack ran in the same child process anyway.
@@ -128,7 +136,14 @@ export const runDefaultAction = async (
       }
     };
 
-    packResult = await pack(targetPaths, config, handleProgress, {}, stdinFilePaths, packOptions);
+    packResult = await pack(
+      targetPaths,
+      config,
+      handleProgress,
+      { createMetricsTaskRunner: () => earlyMetricsRunner },
+      stdinFilePaths,
+      packOptions,
+    );
 
     spinner.succeed('Packing completed successfully!');
   } catch (error) {

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -142,7 +142,7 @@ describe('defaultAction', () => {
       [process.cwd()],
       expect.any(Object),
       expect.any(Function),
-      {},
+      expect.objectContaining({ createMetricsTaskRunner: expect.any(Function) }),
       ['test1.txt', 'test2.txt'],
       expect.any(Object),
     );


### PR DESCRIPTION
## Summary

- Move metrics runner creation from inside pack() to CLI entry point (defaultAction)
- BPE warmup overlaps with spinner setup and early pack() stages

Cherry-picked from ccc68c2d (PR #1428)

## Test plan

- [x] All tests passing
- [x] Build clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
