### PR TITLE
fix(ignore): use case-sensitive matching for ignore patterns

### DIFF
--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -316,6 +316,7 @@ const createBaseGlobbyOptions = (
   absolute: false,
   dot: true,
   followSymbolicLinks: false,
+  caseSensitiveMatch: true,
 });
 
 export const getIgnoreFilePatterns = async (config: RepomixConfigMerged): Promise<string[]> => {

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -911,6 +911,32 @@ node_modules
   });
 
   describe('createBaseGlobbyOptions consistency', () => {
+    test('should use case-sensitive matching for ignore patterns', async () => {
+      // This test verifies that caseSensitiveMatch: true is set to prevent
+      // incorrect matches on case-insensitive file systems (e.g., macOS).
+      // See issue #980: BUILD files incorrectly ignored due to 'build/**' pattern
+      const mockConfig = createMockConfig({
+        include: ['**/*'],
+        ignore: {
+          useGitignore: false,
+          useDefaultPatterns: true, // Enable default patterns which include 'build/**'
+          customPatterns: [],
+        },
+      });
+
+      vi.mocked(globby).mockResolvedValue(['BUILD', 'src/BUILD', 'build/output.js']);
+
+      await searchFiles('/test/root', mockConfig);
+
+      const call = vi.mocked(globby).mock.calls[0];
+      const options = call[1];
+
+      expect(options).toBeDefined();
+      if (options) {
+        expect(options.caseSensitiveMatch).toBe(true);
+      }
+    });
+
     test('should use consistent base options across all globby calls', async () => {
       const mockConfig = createMockConfig({
         include: ['**/*.ts'],


### PR DESCRIPTION
## Summary

This PR fixes issue #980 where `BUILD` files (used by the [Pants build tool](https://www.pantsbuild.org/)) are incorrectly ignored on case-insensitive file systems like macOS (HFS+/APFS).

## Problem

The default ignore pattern `build/**` was matching `BUILD` files due to globby's default case-insensitive matching behavior on macOS. Users of Pants couldn't include their `BUILD` configuration files in repomix output without disabling all default patterns.

## Solution

Set `caseSensitiveMatch: true` in the `createBaseGlobbyOptions` function. This ensures ignore patterns match literally and consistently across all operating systems, regardless of file system case sensitivity.

### Why this approach?

From the options discussed in #980:

1. **`caseSensitiveMatch: true`** (this PR) - Simple, explicit, and ensures consistent behavior across platforms
2. Changing the `build/**` pattern - Would require careful consideration of all possible directory names
3. Adding `!BUILD` to a "never ignore" list - Adds complexity and doesn't address the root cause

While this does diverge slightly from gitignore's behavior (which respects `core.ignorecase`), repomix is a standalone tool that should have predictable, cross-platform behavior. The change ensures that `build/**` ignores the `build` directory but not `BUILD` files, as originally intended.

## Changes

- Added `caseSensitiveMatch: true` to `createBaseGlobbyOptions()` in `src/core/file/fileSearch.ts`
- Added test case to verify case-sensitive matching is enabled

## Testing

- All 1103 existing tests pass
- Added new test verifying `caseSensitiveMatch: true` is set in globby options

Closes #980
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
