### PR TITLE
perf(website): Compress streaming pack responses with per-line gzip flush

### DIFF
--- a/website/server/src/actions/packAction.ts
+++ b/website/server/src/actions/packAction.ts
@@ -132,9 +132,19 @@ export const packAction = async (c: Context) => {
 
   return stream(c, async (s) => {
     const gzip = zlib.createGzip();
-    const pendingWrites: Promise<unknown>[] = [];
+    // Required: without an 'error' listener, a zlib error would crash the
+    // Node process via unhandled EventEmitter error.
+    gzip.on('error', (err) => {
+      logError('Gzip compression error', err instanceof Error ? err : new Error(String(err)), {
+        requestId,
+      });
+    });
+
+    // Serialize downstream writes via a promise chain so each compressed chunk
+    // is awaited before the next, bounding memory under slow-client backpressure.
+    let writeChain: Promise<unknown> = Promise.resolve();
     gzip.on('data', (chunk: Buffer) => {
-      pendingWrites.push(s.write(chunk));
+      writeChain = writeChain.then(() => s.write(chunk));
     });
 
     const writeLine = async (data: unknown) => {
@@ -142,10 +152,12 @@ export const packAction = async (c: Context) => {
       await new Promise<void>((resolve, reject) => {
         gzip.write(line, (err) => (err ? reject(err) : resolve()));
       });
+      // zlib flush callback signature is () => void; errors surface via the
+      // 'error' event listener registered above.
       await new Promise<void>((resolve) => {
         gzip.flush(zlib.constants.Z_SYNC_FLUSH, () => resolve());
       });
-      await Promise.all(pendingWrites.splice(0));
+      await writeChain;
     };
 
     try {
@@ -222,7 +234,7 @@ export const packAction = async (c: Context) => {
       await writeLine({ type: 'error', message: appError.message });
     } finally {
       await new Promise<void>((resolve) => gzip.end(() => resolve()));
-      await Promise.all(pendingWrites.splice(0));
+      await writeChain;
     }
   });
 };

--- a/website/server/src/actions/packAction.ts
+++ b/website/server/src/actions/packAction.ts
@@ -1,3 +1,4 @@
+import zlib from 'node:zlib';
 import type { Context } from 'hono';
 import { stream } from 'hono/streaming';
 import { isValidRemoteValue } from 'repomix';
@@ -119,14 +120,32 @@ export const packAction = async (c: Context) => {
   const requestId = c.get('requestId');
   const clientInfo = getClientInfo(c);
 
-  // Skip compression for streaming response to ensure real-time progress delivery
-  // (compress middleware skips when Content-Encoding is already set)
-  c.header('Content-Encoding', 'identity');
+  // Stream NDJSON with per-line gzip flush. Bypasses hono/compress (which uses
+  // Web CompressionStream and cannot flush mid-stream) by pre-setting
+  // Content-Encoding, and uses Node zlib with Z_SYNC_FLUSH after every write
+  // so progress events reach the client immediately while the large final
+  // result still benefits from compression.
+  c.header('Content-Type', 'application/x-ndjson; charset=utf-8');
+  c.header('Content-Encoding', 'gzip');
+  c.header('Cache-Control', 'no-cache, no-transform');
+  c.header('X-Accel-Buffering', 'no');
 
-  // Stream progress events and result via NDJSON using Hono's stream helper
   return stream(c, async (s) => {
+    const gzip = zlib.createGzip();
+    const pendingWrites: Promise<unknown>[] = [];
+    gzip.on('data', (chunk: Buffer) => {
+      pendingWrites.push(s.write(chunk));
+    });
+
     const writeLine = async (data: unknown) => {
-      await s.write(`${JSON.stringify(data)}\n`);
+      const line = `${JSON.stringify(data)}\n`;
+      await new Promise<void>((resolve, reject) => {
+        gzip.write(line, (err) => (err ? reject(err) : resolve()));
+      });
+      await new Promise<void>((resolve) => {
+        gzip.flush(zlib.constants.Z_SYNC_FLUSH, () => resolve());
+      });
+      await Promise.all(pendingWrites.splice(0));
     };
 
     try {
@@ -201,6 +220,9 @@ export const packAction = async (c: Context) => {
       const appError = handlePackError(error);
 
       await writeLine({ type: 'error', message: appError.message });
+    } finally {
+      await new Promise<void>((resolve) => gzip.end(() => resolve()));
+      await Promise.all(pendingWrites.splice(0));
     }
   });
 };


### PR DESCRIPTION
## Summary

The `/api/pack` endpoint streams NDJSON progress events followed by a large final result (the packed repository content). It was sending `Content-Encoding: identity` to bypass `hono/compress`, because the middleware's underlying Web `CompressionStream` has no mid-stream flush API and would buffer progress events, breaking real-time UX.

Verified via Chrome DevTools response headers that Cloudflare does **not** auto-compress the stream either (`content-encoding: identity` passes straight through), so the full result payload — up to ~100MB of text content — was traveling uncompressed on the wire.

This PR brings back compression without sacrificing real-time progress delivery:

- Use Node's `zlib.createGzip()` directly inside the `stream()` handler and call `gzip.flush(Z_SYNC_FLUSH)` after every NDJSON line. This produces a single continuous gzip stream whose intermediate sync-flush markers let the client decompress each line immediately. Same technique Express's `compression` middleware uses for SSE.
- Set `Content-Type: application/x-ndjson; charset=utf-8` (was `text/plain`).
- Set `Cache-Control: no-cache, no-transform` to guarantee Cloudflare passes the gzipped chunked stream through untouched.
- Set `X-Accel-Buffering: no` as defense-in-depth against other proxies that might buffer.
- `finally` block ensures `gzip.end()` runs on both success and error paths so no data is left buffered.

The global `app.use(compress())` in `website/server/src/index.ts` is left alone — this change is scoped to the one streaming endpoint; other routes continue to benefit from the standard compress middleware.

The browser client (`website/client/components/api/client.ts`) needs no changes: `fetch()` auto-decodes `Content-Encoding: gzip` before exposing the `ReadableStream`, so the existing NDJSON parser works unchanged.

### Expected impact

- **Progress events (small, ~50-100 bytes each, ~5-10 per request)**: negligible size change. Latency should be indistinguishable from before since each line is immediately flushed via `Z_SYNC_FLUSH`.
- **Final result**: packed repositories are text (XML / Markdown / plain), which gzip compresses very well — typically 3-5x smaller on the wire. Large repos will see the biggest wins.

## Test plan

- [ ] `npm run lint` in `website/server`
- [ ] `npm run test` in `website/server`
- [ ] `cd website/server && npm run dev`, then pack a small repo via the web UI at `repomix.com` (or local client) and verify:
  - [ ] Response headers show `content-encoding: gzip` and `content-type: application/x-ndjson; charset=utf-8`
  - [ ] Progress events still appear in real time in the UI (no visible batching delay)
  - [ ] Final result renders correctly (gzip decoded cleanly by the browser)
- [ ] Pack a large repo (e.g. `vuejs/vue` or similar) and compare the Network tab's `Transferred` vs `Resource` size columns to confirm meaningful byte savings
- [ ] Test through the production Cloudflare path to confirm gzip passes through untouched (`cf-cache-status`, no `cf-polished` re-encoding surprises)
- [ ] Trigger an error path (e.g. invalid URL) and verify the `{type:"error"}` NDJSON line is still delivered and the gzip stream terminates cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
