### PR TITLE
ci(perf): Track perf/auto-perf-tuning benchmarks on separate gh-pages page

### DIFF
--- a/.github/workflows/perf-benchmark-history.yml
+++ b/.github/workflows/perf-benchmark-history.yml
@@ -2,7 +2,7 @@ name: Performance Benchmark History
 
 on:
   push:
-    branches: [main]
+    branches: [main, perf/auto-perf-tuning]
     paths-ignore:
       - 'website/**'
       - '*.md'
@@ -115,7 +115,8 @@ jobs:
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
         with:
-          name: Repomix Performance
+          name: ${{ github.ref == 'refs/heads/main' && 'Repomix Performance' || 'Repomix Performance (auto-perf-tuning)' }}
+          benchmark-data-dir-path: ${{ github.ref == 'refs/heads/main' && 'dev/bench' || 'dev/bench/auto-perf-tuning' }}
           tool: customSmallerIsBetter
           output-file-path: combined-bench-result.json
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Trigger the performance benchmark history workflow on pushes to `perf/auto-perf-tuning` in addition to `main`.
- Publish `perf/auto-perf-tuning` results to a dedicated `dev/bench/auto-perf-tuning/` directory on `gh-pages` so it renders as an independent page — `main`'s existing dashboard at `dev/bench/` stays untouched.
- Branch on `github.ref` for both `name` and `benchmark-data-dir-path` passed to `benchmark-action/github-action-benchmark`.

### Resulting URLs

- `main`: https://yamadashy.github.io/repomix/dev/bench/ (unchanged)
- `perf/auto-perf-tuning`: https://yamadashy.github.io/repomix/dev/bench/auto-perf-tuning/ (new, auto-created on first run)

### Why a separate page

`perf/auto-perf-tuning` is an experimental branch that gets force-pushed, so mixing its commits into `main`'s historical chart would make the timeline hard to read. Isolating it into its own data directory keeps the two histories completely independent — the data files (`data.js`) do not share state, so neither branch's runs can disturb the other's chart.

## Checklist

- [x] Run \`npm run test\` (1102 tests passed)
- [x] Run \`npm run lint\` (no new warnings/errors from this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
