### PR TITLE
ci: Enable Codecov Test Analytics and update badge token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           node-version-file: .tool-versions
           cache: npm
       - run: npm ci
-      - run: npm run test-coverage -- --reporter=verbose
+      - run: npm run test-coverage -- --reporter=verbose --reporter=junit --outputFile.junit=./test-report.junit.xml
         env:
           CI_OS: ${{ runner.os }}
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -147,6 +147,12 @@ jobs:
         with:
           fail_ci_if_error: true
           directory: ./coverage
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        if: ${{ !cancelled() }}
+        with:
+          files: ./test-report.junit.xml
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ website/server/.compile-cache/
 
 # Test coverage
 coverage/
+test-report.junit.xml
 
 # Temporary files
 *.tmp

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 [![npm](https://img.shields.io/npm/v/repomix.svg?maxAge=1000)](https://www.npmjs.com/package/repomix)
 [![npm](https://img.shields.io/npm/d18m/repomix)](https://www.npmjs.com/package/repomix)
 [![Actions Status](https://github.com/yamadashy/repomix/actions/workflows/ci.yml/badge.svg)](https://github.com/yamadashy/repomix/actions?query=workflow%3A"ci")
-[![codecov](https://codecov.io/github/yamadashy/repomix/graph/badge.svg)](https://codecov.io/github/yamadashy/repomix)
+[![codecov](https://codecov.io/github/yamadashy/repomix/graph/badge.svg?token=PYQHD2SSHX)](https://codecov.io/github/yamadashy/repomix)
 [![Sponsors](https://img.shields.io/github/sponsors/yamadashy?logo=github)](https://github.com/sponsors/yamadashy)
 [![Discord](https://badgen.net/discord/online-members/wNYzTwZFku?icon=discord&label=discord)](https://discord.gg/wNYzTwZFku)
 


### PR DESCRIPTION
## Summary

- Add JUnit XML reporting to the `test-coverage` job and upload results via `codecov/test-results-action@v1.2.1`. This enables Codecov **Test Analytics** — test run times, failure rates, flaky test detection, and PR comments with failed-test summaries.
- Update the README Codecov badge URL to include the graph token, following Codecov's new recommended badge format.

## Details

**`.github/workflows/ci.yml`** (`test-coverage` job)
- Vitest now additionally emits JUnit XML: `--reporter=junit --outputFile.junit=./test-report.junit.xml`
- New step uploads JUnit results to Codecov using `codecov/test-results-action` (pinned by SHA to v1.2.1), with `if: !cancelled()` so results upload even when tests fail — which is precisely when Test Analytics is most useful.
- Reuses the existing `CODECOV_TOKEN` secret.

**`.gitignore`**
- Added `test-report.junit.xml` so local runs don't leave stray artifacts.

**`README.md`**
- Badge URL updated to `badge.svg?token=PYQHD2SSHX`. The graph token is a read-only token specifically intended to be embedded in public READMEs, distinct from the upload `CODECOV_TOKEN`.

## Checklist

- [x] Run `npm run test` (1102 passed)
- [x] Run `npm run lint` (only pre-existing warnings unrelated to this PR)

## Test plan

- [ ] After merge, verify a new run appears under the Codecov **Tests** tab
- [ ] Verify the Codecov badge in README renders correctly with the token parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
