### PR TITLE
feat(cli): Add --max-depth option to limit directory depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,7 @@ Instruction
 |--------|-------------|
 | `--include <patterns>` | Include only files matching these glob patterns (comma-separated, e.g., `"src/**/*.js,*.md"`) |
 | `-i, --ignore <patterns>` | Additional patterns to exclude (comma-separated, e.g., `"*.test.js,docs/**"`) |
+| `--max-depth <number>` | Only include files up to N directory levels deep (e.g., `--max-depth 2` includes files in root and one level of subdirectories) |
 | `--no-gitignore` | Don't use `.gitignore` rules for filtering files |
 | `--no-dot-ignore` | Don't use `.ignore` rules for filtering files |
 | `--no-default-patterns` | Don't apply built-in ignore patterns (`node_modules`, `.git`, build dirs, etc.) |
@@ -1344,6 +1345,7 @@ Here's an explanation of the configuration options:
 | Option                           | Description                                                                                                                  | Default                |
 |----------------------------------|------------------------------------------------------------------------------------------------------------------------------|------------------------|
 | `input.maxFileSize`              | Maximum file size in bytes to process. Files larger than this will be skipped                                                | `50000000`            |
+| `input.maxDepth`                 | Maximum directory depth to include. Files deeper than this level are excluded (e.g., `2` includes root and one subdirectory level) | `null`            |
 | `output.filePath`                | The name of the output file                                                                                                  | `"repomix-output.xml"` |
 | `output.style`                   | The style of the output (`xml`, `markdown`, `json`, `plain`)                                                                 | `"xml"`                |
 | `output.parsableStyle`           | Whether to escape the output based on the chosen style schema. Note that this can increase token count.                      | `false`                |

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -163,6 +163,9 @@ export const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
   if (options.include) {
     cliConfig.include = splitPatterns(options.include);
   }
+  if (options.maxDepth !== undefined) {
+    cliConfig.input = { ...cliConfig.input, maxDepth: options.maxDepth };
+  }
   if (options.ignore) {
     cliConfig.ignore = { customPatterns: splitPatterns(options.ignore) };
   }

--- a/src/cli/cliReport.ts
+++ b/src/cli/cliReport.ts
@@ -215,26 +215,49 @@ export const reportTopFiles = (
 export const reportSkippedFiles = (_rootDir: string, skippedFiles: SkippedFileInfo[]) => {
   const binaryContentFiles = skippedFiles.filter((file) => file.reason === 'binary-content');
 
-  if (binaryContentFiles.length === 0) {
-    return;
+  if (binaryContentFiles.length > 0) {
+    logger.log('📄 Binary Files Detected:');
+    logger.log(pc.dim('─────────────────────────'));
+
+    if (binaryContentFiles.length === 1) {
+      logger.log(pc.yellow('1 file detected as binary by content inspection:'));
+    } else {
+      logger.log(pc.yellow(`${binaryContentFiles.length} files detected as binary by content inspection:`));
+    }
+
+    binaryContentFiles.forEach((file, index) => {
+      const indexString = `${index + 1}.`.padEnd(3, ' ');
+      logger.log(`${indexString}${file.path}`);
+    });
+
+    logger.log(pc.yellow('\nThese files have been excluded from the output.'));
+    logger.log(pc.yellow('Please review these files if you expected them to contain text content.'));
   }
 
-  logger.log('📄 Binary Files Detected:');
-  logger.log(pc.dim('─────────────────────────'));
+  const encodingErrorFiles = skippedFiles.filter((file) => file.reason === 'encoding-error');
 
-  if (binaryContentFiles.length === 1) {
-    logger.log(pc.yellow('1 file detected as binary by content inspection:'));
-  } else {
-    logger.log(pc.yellow(`${binaryContentFiles.length} files detected as binary by content inspection:`));
+  if (encodingErrorFiles.length > 0) {
+    logger.log('⚠️  Encoding Error Files Detected:');
+    logger.log(pc.dim('──────────────────────────────────'));
+
+    if (encodingErrorFiles.length === 1) {
+      logger.log(pc.yellow('1 file skipped due to encoding errors (malformed or undecodable content):'));
+    } else {
+      logger.log(
+        pc.yellow(
+          `${encodingErrorFiles.length} files skipped due to encoding errors (malformed or undecodable content):`,
+        ),
+      );
+    }
+
+    encodingErrorFiles.forEach((file, index) => {
+      const indexString = `${index + 1}.`.padEnd(3, ' ');
+      logger.log(`${indexString}${file.path}`);
+    });
+
+    logger.log(pc.yellow('\nThese files have been excluded from the output.'));
+    logger.log(pc.yellow('Please check the file encoding or remove problematic characters.'));
   }
-
-  binaryContentFiles.forEach((file, index) => {
-    const indexString = `${index + 1}.`.padEnd(3, ' ');
-    logger.log(`${indexString}${file.path}`);
-  });
-
-  logger.log(pc.yellow('\nThese files have been excluded from the output.'));
-  logger.log(pc.yellow('Please review these files if you expected them to contain text content.'));
 };
 
 export const reportCompletion = () => {

--- a/src/cli/cliReport.ts
+++ b/src/cli/cliReport.ts
@@ -249,6 +249,12 @@ export const reportSkippedFiles = (_rootDir: string, skippedFiles: SkippedFileIn
   );
 
   const encodingErrorFiles = skippedFiles.filter((file) => file.reason === 'encoding-error');
+
+  // Add spacing when both sections are rendered
+  if (binaryContentFiles.length > 0 && encodingErrorFiles.length > 0) {
+    logger.log('');
+  }
+
   reportSkippedCategory(
     '⚠️  Encoding Error Files Detected:',
     '──────────────────────────────────',

--- a/src/cli/cliReport.ts
+++ b/src/cli/cliReport.ts
@@ -237,6 +237,14 @@ const reportSkippedCategory = (
   logger.log(pc.yellow(guidanceMessage));
 };
 
+/**
+ * Reports files that were skipped during packing.
+ *
+ * Only 'binary-content' and 'encoding-error' are surfaced to the user because
+ * they represent unexpected exclusions that the user should be aware of.
+ * 'binary-extension' and 'size-limit' are intentional automatic filters and
+ * do not require user attention.
+ */
 export const reportSkippedFiles = (_rootDir: string, skippedFiles: SkippedFileInfo[]) => {
   const binaryContentFiles = skippedFiles.filter((file) => file.reason === 'binary-content');
   reportSkippedCategory(

--- a/src/cli/cliReport.ts
+++ b/src/cli/cliReport.ts
@@ -212,52 +212,51 @@ export const reportTopFiles = (
   });
 };
 
+const reportSkippedCategory = (
+  title: string,
+  divider: string,
+  files: SkippedFileInfo[],
+  singularMessage: string,
+  pluralMessage: (count: number) => string,
+  guidanceMessage: string,
+): void => {
+  if (files.length === 0) {
+    return;
+  }
+
+  logger.log(title);
+  logger.log(pc.dim(divider));
+  logger.log(pc.yellow(files.length === 1 ? singularMessage : pluralMessage(files.length)));
+
+  for (const [index, file] of files.entries()) {
+    const indexString = `${index + 1}.`.padEnd(3, ' ');
+    logger.log(`${indexString}${file.path}`);
+  }
+
+  logger.log(pc.yellow('\nThese files have been excluded from the output.'));
+  logger.log(pc.yellow(guidanceMessage));
+};
+
 export const reportSkippedFiles = (_rootDir: string, skippedFiles: SkippedFileInfo[]) => {
   const binaryContentFiles = skippedFiles.filter((file) => file.reason === 'binary-content');
-
-  if (binaryContentFiles.length > 0) {
-    logger.log('📄 Binary Files Detected:');
-    logger.log(pc.dim('─────────────────────────'));
-
-    if (binaryContentFiles.length === 1) {
-      logger.log(pc.yellow('1 file detected as binary by content inspection:'));
-    } else {
-      logger.log(pc.yellow(`${binaryContentFiles.length} files detected as binary by content inspection:`));
-    }
-
-    binaryContentFiles.forEach((file, index) => {
-      const indexString = `${index + 1}.`.padEnd(3, ' ');
-      logger.log(`${indexString}${file.path}`);
-    });
-
-    logger.log(pc.yellow('\nThese files have been excluded from the output.'));
-    logger.log(pc.yellow('Please review these files if you expected them to contain text content.'));
-  }
+  reportSkippedCategory(
+    '📄 Binary Files Detected:',
+    '─────────────────────────',
+    binaryContentFiles,
+    '1 file detected as binary by content inspection:',
+    (count) => `${count} files detected as binary by content inspection:`,
+    'Please review these files if you expected them to contain text content.',
+  );
 
   const encodingErrorFiles = skippedFiles.filter((file) => file.reason === 'encoding-error');
-
-  if (encodingErrorFiles.length > 0) {
-    logger.log('⚠️  Encoding Error Files Detected:');
-    logger.log(pc.dim('──────────────────────────────────'));
-
-    if (encodingErrorFiles.length === 1) {
-      logger.log(pc.yellow('1 file skipped due to encoding errors (malformed or undecodable content):'));
-    } else {
-      logger.log(
-        pc.yellow(
-          `${encodingErrorFiles.length} files skipped due to encoding errors (malformed or undecodable content):`,
-        ),
-      );
-    }
-
-    encodingErrorFiles.forEach((file, index) => {
-      const indexString = `${index + 1}.`.padEnd(3, ' ');
-      logger.log(`${indexString}${file.path}`);
-    });
-
-    logger.log(pc.yellow('\nThese files have been excluded from the output.'));
-    logger.log(pc.yellow('Please check the file encoding or remove problematic characters.'));
-  }
+  reportSkippedCategory(
+    '⚠️  Encoding Error Files Detected:',
+    '──────────────────────────────────',
+    encodingErrorFiles,
+    '1 file skipped due to encoding errors (malformed or undecodable content):',
+    (count) => `${count} files skipped due to encoding errors (malformed or undecodable content):`,
+    'Please check the file encoding or remove problematic characters.',
+  );
 };
 
 export const reportCompletion = () => {

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -147,6 +147,16 @@ export const run = async () => {
         'Include only files matching these glob patterns (comma-separated, e.g., "src/**/*.js,*.md")',
       )
       .option('-i, --ignore <patterns>', 'Additional patterns to exclude (comma-separated, e.g., "*.test.js,docs/**")')
+      .option(
+        '--max-depth <number>',
+        'Only include files up to N directory levels deep (e.g., --max-depth 2 includes files in root and one level of subdirectories)',
+        (v: string) => {
+          if (!/^\d+$/.test(v) || Number(v) < 1) {
+            throw new RepomixError(`Invalid number for --max-depth: '${v}'. Must be a positive integer.`);
+          }
+          return Number(v);
+        },
+      )
       .option('--no-gitignore', "Don't use .gitignore rules for filtering files")
       .option('--no-dot-ignore', "Don't use .ignore rules for filtering files")
       .option('--no-default-patterns', "Don't apply built-in ignore patterns (node_modules, .git, build dirs, etc.)")

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -32,6 +32,7 @@ export interface CliOptions extends OptionValues {
   // Filter Options
   include?: string;
   ignore?: string;
+  maxDepth?: number;
   gitignore?: boolean;
   dotIgnore?: boolean;
   defaultPatterns?: boolean;

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -19,6 +19,7 @@ export const repomixConfigBaseSchema = z.object({
   input: z
     .object({
       maxFileSize: z.number().optional(),
+      maxDepth: z.number().int().min(1).optional(),
     })
     .optional(),
   output: z

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -207,6 +207,16 @@ export const searchFiles = async (
     const globbyElapsedTime = Date.now() - globbyStartTime;
     logger.debug(`[globby] Completed in ${globbyElapsedTime}ms, found ${filePaths.length} files`);
 
+    // Apply max depth filter if configured
+    if (config.input.maxDepth !== undefined) {
+      const maxDepth = config.input.maxDepth;
+      const beforeCount = filePaths.length;
+      // Depth is the number of path segments; a root-level file has depth 1
+      const filtered = filePaths.filter((p) => p.split('/').length <= maxDepth);
+      logger.debug(`[max-depth] Filtered from ${beforeCount} to ${filtered.length} files (maxDepth=${maxDepth})`);
+      filePaths.splice(0, filePaths.length, ...filtered);
+    }
+
     let emptyDirPaths: string[] = [];
     if (config.output.includeEmptyDirectories) {
       logger.debug('[empty dirs] Searching for empty directories...');

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -192,6 +192,9 @@ export const searchFiles = async (
     const filePaths = await globby(includePatterns, {
       ...createBaseGlobbyOptions(rootDir, config, adjustedIgnorePatterns, ignoreFilePatterns),
       onlyFiles: true,
+      // Limit traversal depth at the globby level to avoid scanning the full tree.
+      // Undefined leaves the default (unlimited).
+      ...(config.input.maxDepth !== undefined && { deep: config.input.maxDepth }),
     }).catch((error: unknown) => {
       // Handle EPERM errors specifically
       const code = (error as NodeJS.ErrnoException | { code?: string })?.code;
@@ -207,18 +210,6 @@ export const searchFiles = async (
     const globbyElapsedTime = Date.now() - globbyStartTime;
     logger.debug(`[globby] Completed in ${globbyElapsedTime}ms, found ${filePaths.length} files`);
 
-    // Apply max depth filter if configured
-    if (config.input.maxDepth !== undefined) {
-      const maxDepth = config.input.maxDepth;
-      const beforeCount = filePaths.length;
-      // Depth is the number of path segments; a root-level file has depth 1.
-      // Split on both '/' and '\' for cross-platform correctness.
-      const getPathDepth = (p: string) => p.split(/[\\/]/).filter(Boolean).length;
-      const filtered = filePaths.filter((p) => getPathDepth(p) <= maxDepth);
-      logger.debug(`[max-depth] Filtered from ${beforeCount} to ${filtered.length} files (maxDepth=${maxDepth})`);
-      filePaths.splice(0, filePaths.length, ...filtered);
-    }
-
     let emptyDirPaths: string[] = [];
     if (config.output.includeEmptyDirectories) {
       logger.debug('[empty dirs] Searching for empty directories...');
@@ -227,6 +218,8 @@ export const searchFiles = async (
       const directories = await globby(includePatterns, {
         ...createBaseGlobbyOptions(rootDir, config, adjustedIgnorePatterns, ignoreFilePatterns),
         onlyDirectories: true,
+        // Apply the same depth limit so empty-directory results stay consistent with file results.
+        ...(config.input.maxDepth !== undefined && { deep: config.input.maxDepth }),
       });
 
       const emptyDirElapsedTime = Date.now() - emptyDirStartTime;

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -211,8 +211,10 @@ export const searchFiles = async (
     if (config.input.maxDepth !== undefined) {
       const maxDepth = config.input.maxDepth;
       const beforeCount = filePaths.length;
-      // Depth is the number of path segments; a root-level file has depth 1
-      const filtered = filePaths.filter((p) => p.split('/').length <= maxDepth);
+      // Depth is the number of path segments; a root-level file has depth 1.
+      // Split on both '/' and '\' for cross-platform correctness.
+      const getPathDepth = (p: string) => p.split(/[\\/]/).filter(Boolean).length;
+      const filtered = filePaths.filter((p) => getPathDepth(p) <= maxDepth);
       logger.debug(`[max-depth] Filtered from ${beforeCount} to ${filtered.length} files (maxDepth=${maxDepth})`);
       filePaths.splice(0, filePaths.length, ...filtered);
     }

--- a/tests/cli/cliReport.binaryFiles.test.ts
+++ b/tests/cli/cliReport.binaryFiles.test.ts
@@ -10,11 +10,10 @@ describe('reportSkippedFiles', () => {
     vi.resetAllMocks();
   });
 
-  test('should not report anything when there are no binary-content files', () => {
+  test('should not report anything when only size-limit or binary-extension files are skipped', () => {
     const skippedFiles: SkippedFileInfo[] = [
       { path: 'large.txt', reason: 'size-limit' },
       { path: 'binary.bin', reason: 'binary-extension' },
-      { path: 'error.txt', reason: 'encoding-error' },
     ];
 
     reportSkippedFiles('/root', skippedFiles);

--- a/tests/cli/cliReport.test.ts
+++ b/tests/cli/cliReport.test.ts
@@ -1,6 +1,12 @@
 import path from 'node:path';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { reportCompletion, reportSecurityCheck, reportSummary, reportTopFiles } from '../../src/cli/cliReport.js';
+import {
+  reportCompletion,
+  reportSecurityCheck,
+  reportSkippedFiles,
+  reportSummary,
+  reportTopFiles,
+} from '../../src/cli/cliReport.js';
 import type { SuspiciousFileResult } from '../../src/core/security/securityCheck.js';
 import type { PackResult } from '../../src/index.js';
 import { logger } from '../../src/shared/logger.js';
@@ -319,6 +325,61 @@ describe('cliReport', () => {
       reportTopFiles({}, {}, 5, 0);
 
       expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Top 5 Files'));
+    });
+  });
+
+  describe('reportSkippedFiles', () => {
+    test('should not print anything when no files are skipped', () => {
+      reportSkippedFiles('/root', []);
+      expect(logger.log).not.toHaveBeenCalled();
+    });
+
+    test('should not print anything when only binary-extension files are skipped', () => {
+      reportSkippedFiles('/root', [{ path: 'image.png', reason: 'binary-extension' }]);
+      expect(logger.log).not.toHaveBeenCalled();
+    });
+
+    test('should report a single binary-content file', () => {
+      reportSkippedFiles('/root', [{ path: 'data.bin', reason: 'binary-content' }]);
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Binary Files Detected'));
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('1 file detected as binary'));
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('data.bin'));
+    });
+
+    test('should report multiple binary-content files', () => {
+      reportSkippedFiles('/root', [
+        { path: 'a.bin', reason: 'binary-content' },
+        { path: 'b.bin', reason: 'binary-content' },
+      ]);
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('2 files detected as binary'));
+    });
+
+    test('should report a single encoding-error file', () => {
+      reportSkippedFiles('/root', [{ path: 'broken.txt', reason: 'encoding-error' }]);
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Encoding Error Files Detected'));
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('1 file skipped due to encoding errors'));
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('broken.txt'));
+    });
+
+    test('should report multiple encoding-error files', () => {
+      reportSkippedFiles('/root', [
+        { path: 'corrupted.txt', reason: 'encoding-error' },
+        { path: 'malformed.json', reason: 'encoding-error' },
+      ]);
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('2 files skipped due to encoding errors'));
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('corrupted.txt'));
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('malformed.json'));
+    });
+
+    test('should report both binary-content and encoding-error files', () => {
+      reportSkippedFiles('/root', [
+        { path: 'data.bin', reason: 'binary-content' },
+        { path: 'broken.txt', reason: 'encoding-error' },
+      ]);
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Binary Files Detected'));
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Encoding Error Files Detected'));
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('data.bin'));
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('broken.txt'));
     });
   });
 

--- a/tests/cli/cliReport.test.ts
+++ b/tests/cli/cliReport.test.ts
@@ -356,7 +356,7 @@ describe('cliReport', () => {
       expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('malformed.json'));
     });
 
-    test('should report both binary-content and encoding-error files', () => {
+    test('should report both binary-content and encoding-error files with separator', () => {
       reportSkippedFiles('/root', [
         { path: 'data.bin', reason: 'binary-content' },
         { path: 'broken.txt', reason: 'encoding-error' },
@@ -365,6 +365,8 @@ describe('cliReport', () => {
       expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Encoding Error Files Detected'));
       expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('data.bin'));
       expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('broken.txt'));
+      // Empty line separator between sections
+      expect(logger.log).toHaveBeenCalledWith('');
     });
   });
 

--- a/tests/cli/cliReport.test.ts
+++ b/tests/cli/cliReport.test.ts
@@ -339,21 +339,6 @@ describe('cliReport', () => {
       expect(logger.log).not.toHaveBeenCalled();
     });
 
-    test('should report a single binary-content file', () => {
-      reportSkippedFiles('/root', [{ path: 'data.bin', reason: 'binary-content' }]);
-      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Binary Files Detected'));
-      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('1 file detected as binary'));
-      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('data.bin'));
-    });
-
-    test('should report multiple binary-content files', () => {
-      reportSkippedFiles('/root', [
-        { path: 'a.bin', reason: 'binary-content' },
-        { path: 'b.bin', reason: 'binary-content' },
-      ]);
-      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('2 files detected as binary'));
-    });
-
     test('should report a single encoding-error file', () => {
       reportSkippedFiles('/root', [{ path: 'broken.txt', reason: 'encoding-error' }]);
       expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Encoding Error Files Detected'));

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -911,64 +911,51 @@ node_modules
   });
 
   describe('maxDepth filter', () => {
-    test('should include all files when maxDepth is not set', async () => {
+    test('should not pass deep option to globby when maxDepth is not set', async () => {
       const mockConfig = createMockConfig();
-      const files = ['root.ts', 'src/a.ts', 'src/nested/b.ts', 'src/nested/deep/c.ts'];
-      vi.mocked(globby).mockResolvedValue(files);
+      vi.mocked(globby).mockResolvedValue(['root.ts', 'src/a.ts', 'src/nested/b.ts']);
 
-      const result = await searchFiles('/mock/root', mockConfig);
+      await searchFiles('/mock/root', mockConfig);
 
-      expect(result.filePaths).toHaveLength(4);
-      expect(result.filePaths).toContain('root.ts');
-      expect(result.filePaths).toContain('src/nested/deep/c.ts');
+      const globbyOptions = vi.mocked(globby).mock.calls[0][1] as Record<string, unknown>;
+      expect(globbyOptions.deep).toBeUndefined();
     });
 
-    test('should include only root-level files when maxDepth is 1', async () => {
-      const mockConfig = createMockConfig({ input: { maxDepth: 1 } });
-      const files = ['root.ts', 'src/a.ts', 'src/nested/b.ts'];
-      vi.mocked(globby).mockResolvedValue(files);
-
-      const result = await searchFiles('/mock/root', mockConfig);
-
-      expect(result.filePaths).toEqual(['root.ts']);
-    });
-
-    test('should include files up to specified depth', async () => {
+    test('should pass deep option to globby when maxDepth is set', async () => {
       const mockConfig = createMockConfig({ input: { maxDepth: 2 } });
-      const files = ['root.ts', 'src/a.ts', 'src/nested/b.ts', 'src/nested/deep/c.ts'];
-      vi.mocked(globby).mockResolvedValue(files);
+      // Mock returns only what globby would return at depth 2
+      vi.mocked(globby).mockResolvedValue(['root.ts', 'src/a.ts']);
 
       const result = await searchFiles('/mock/root', mockConfig);
 
-      // depth 1: root.ts (1 segment), depth 2: src/a.ts (2 segments)
-      expect(result.filePaths).toHaveLength(2);
+      const globbyOptions = vi.mocked(globby).mock.calls[0][1] as Record<string, unknown>;
+      expect(globbyOptions.deep).toBe(2);
       expect(result.filePaths).toContain('root.ts');
       expect(result.filePaths).toContain('src/a.ts');
-      expect(result.filePaths).not.toContain('src/nested/b.ts');
-      expect(result.filePaths).not.toContain('src/nested/deep/c.ts');
     });
 
-    test('should include all files when maxDepth is large', async () => {
-      const mockConfig = createMockConfig({ input: { maxDepth: 10 } });
-      const files = ['root.ts', 'src/a.ts', 'src/nested/b.ts', 'src/nested/deep/c.ts'];
-      vi.mocked(globby).mockResolvedValue(files);
+    test('should apply same deep option to empty-directory search', async () => {
+      const mockConfig = createMockConfig({
+        input: { maxDepth: 2 },
+        output: { includeEmptyDirectories: true },
+      });
 
-      const result = await searchFiles('/mock/root', mockConfig);
+      vi.mocked(globby).mockImplementation(async (_: unknown, options: unknown) => {
+        if ((options as Record<string, unknown>)?.onlyDirectories) {
+          return ['src'];
+        }
+        return ['root.ts', 'src/a.ts'];
+      });
+      vi.mocked(fs.readdir).mockResolvedValue([]);
 
-      expect(result.filePaths).toHaveLength(4);
-    });
+      await searchFiles('/mock/root', mockConfig);
 
-    test('should handle Windows-style backslash-separated paths correctly', async () => {
-      const mockConfig = createMockConfig({ input: { maxDepth: 2 } });
-      // Simulate globby returning Windows-style paths
-      const files = ['root.ts', 'src\\a.ts', 'src\\nested\\b.ts'];
-      vi.mocked(globby).mockResolvedValue(files);
-
-      const result = await searchFiles('/mock/root', mockConfig);
-
-      expect(result.filePaths).toContain('root.ts');
-      expect(result.filePaths).toContain('src\\a.ts');
-      expect(result.filePaths).not.toContain('src\\nested\\b.ts');
+      const calls = vi.mocked(globby).mock.calls;
+      // Both file and directory calls should have deep: 2
+      for (const call of calls) {
+        const opts = call[1] as Record<string, unknown>;
+        expect(opts.deep).toBe(2);
+      }
     });
   });
 

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -910,6 +910,55 @@ node_modules
     });
   });
 
+  describe('maxDepth filter', () => {
+    test('should include all files when maxDepth is not set', async () => {
+      const mockConfig = createMockConfig();
+      const files = ['root.ts', 'src/a.ts', 'src/nested/b.ts', 'src/nested/deep/c.ts'];
+      vi.mocked(globby).mockResolvedValue(files);
+
+      const result = await searchFiles('/mock/root', mockConfig);
+
+      expect(result.filePaths).toHaveLength(4);
+      expect(result.filePaths).toContain('root.ts');
+      expect(result.filePaths).toContain('src/nested/deep/c.ts');
+    });
+
+    test('should include only root-level files when maxDepth is 1', async () => {
+      const mockConfig = createMockConfig({ input: { maxDepth: 1 } });
+      const files = ['root.ts', 'src/a.ts', 'src/nested/b.ts'];
+      vi.mocked(globby).mockResolvedValue(files);
+
+      const result = await searchFiles('/mock/root', mockConfig);
+
+      expect(result.filePaths).toEqual(['root.ts']);
+    });
+
+    test('should include files up to specified depth', async () => {
+      const mockConfig = createMockConfig({ input: { maxDepth: 2 } });
+      const files = ['root.ts', 'src/a.ts', 'src/nested/b.ts', 'src/nested/deep/c.ts'];
+      vi.mocked(globby).mockResolvedValue(files);
+
+      const result = await searchFiles('/mock/root', mockConfig);
+
+      // depth 1: root.ts (1 segment), depth 2: src/a.ts (2 segments)
+      expect(result.filePaths).toHaveLength(2);
+      expect(result.filePaths).toContain('root.ts');
+      expect(result.filePaths).toContain('src/a.ts');
+      expect(result.filePaths).not.toContain('src/nested/b.ts');
+      expect(result.filePaths).not.toContain('src/nested/deep/c.ts');
+    });
+
+    test('should include all files when maxDepth is large', async () => {
+      const mockConfig = createMockConfig({ input: { maxDepth: 10 } });
+      const files = ['root.ts', 'src/a.ts', 'src/nested/b.ts', 'src/nested/deep/c.ts'];
+      vi.mocked(globby).mockResolvedValue(files);
+
+      const result = await searchFiles('/mock/root', mockConfig);
+
+      expect(result.filePaths).toHaveLength(4);
+    });
+  });
+
   describe('createBaseGlobbyOptions consistency', () => {
     test('should use consistent base options across all globby calls', async () => {
       const mockConfig = createMockConfig({

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -957,6 +957,19 @@ node_modules
 
       expect(result.filePaths).toHaveLength(4);
     });
+
+    test('should handle Windows-style backslash-separated paths correctly', async () => {
+      const mockConfig = createMockConfig({ input: { maxDepth: 2 } });
+      // Simulate globby returning Windows-style paths
+      const files = ['root.ts', 'src\\a.ts', 'src\\nested\\b.ts'];
+      vi.mocked(globby).mockResolvedValue(files);
+
+      const result = await searchFiles('/mock/root', mockConfig);
+
+      expect(result.filePaths).toContain('root.ts');
+      expect(result.filePaths).toContain('src\\a.ts');
+      expect(result.filePaths).not.toContain('src\\nested\\b.ts');
+    });
   });
 
   describe('createBaseGlobbyOptions consistency', () => {


### PR DESCRIPTION
Add a `--max-depth <number>` CLI option that limits which files are included based on their directory depth. A root-level file has depth 1, a file one directory deep has depth 2, and so on.

**Example:**
```bash
# Only include files in the root directory and one level of subdirectories
repomix --max-depth 2
```

## Changes

- `src/config/configSchema.ts` — add `maxDepth` field to `repomixConfigBaseSchema.input` (optional, positive integer)
- `src/cli/types.ts` — add `maxDepth?: number` to `CliOptions`
- `src/cli/cliRun.ts` — register `--max-depth <number>` under File Selection Options with input validation
- `src/cli/actions/defaultAction.ts` — map `options.maxDepth` to `cliConfig.input.maxDepth` in `buildCliConfig`
- `src/core/file/fileSearch.ts` — apply depth filter in `searchFiles` after globby returns results
- `tests/core/file/fileSearch.test.ts` — add tests for maxDepth filter behaviour

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
