### PR TITLE
feat(cli): Add --watch flag for automatic re-packing on file changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,9 @@ Instruction
 | `--skill-output <path>` | Specify skill output directory path directly (skips location prompt) |
 | `-f, --force` | Skip all confirmation prompts (e.g., skill directory overwrite) |
 
+#### Watch Mode
+- `-w, --watch`: Watch for file changes and automatically re-pack. Debounces rapid changes (300ms) and logs a timestamp on each rebuild. Stop with `Ctrl+C`.
+
 #### Examples
 
 ```bash
@@ -708,6 +711,10 @@ repomix --remote https://github.com/user/repo/commit/836abcd7335137228ad77feb286
 
 # Remote repository with shorthand
 repomix --remote user/repo
+
+# Watch mode — automatically re-pack on file changes
+repomix --watch
+repomix -w --include "src/**/*.ts"
 ```
 
 ### Updating Repomix

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@repomix/tree-sitter-wasms": "^0.1.16",
         "@secretlint/core": "^11.5.0",
         "@secretlint/secretlint-rule-preset-recommend": "^11.4.1",
+        "chokidar": "^5.0.0",
         "commander": "^14.0.3",
         "fast-xml-builder": "^1.1.4",
         "git-url-parse": "^16.1.0",
@@ -2529,6 +2530,21 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -4276,6 +4292,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/require-from-string": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@repomix/tree-sitter-wasms": "^0.1.16",
     "@secretlint/core": "^11.5.0",
     "@secretlint/secretlint-rule-preset-recommend": "^11.4.1",
+    "chokidar": "^5.0.0",
     "commander": "^14.0.3",
     "fast-xml-builder": "^1.1.4",
     "git-url-parse": "^16.1.0",

--- a/src/cli/actions/watchAction.ts
+++ b/src/cli/actions/watchAction.ts
@@ -209,19 +209,25 @@ export const runWatchAction = async (
     process.removeListener('SIGINT', onSigint);
     process.removeListener('SIGTERM', onSigterm);
 
+    // Use separate try/catch blocks so activeRebuildPromise is always awaited
+    // even if watcher.close() fails
     try {
-      // Close watcher before resolving so callers don't see
-      // runWatchAction() resolve until shutdown is truly finished
       await watcher.close();
-      // Wait for any in-flight rebuild to complete before resolving
+    } catch (error) {
+      logger.error('Error closing watcher:', error);
+    }
+
+    try {
       if (activeRebuildPromise) {
         await activeRebuildPromise;
       }
-    } finally {
-      // Always settle the keep-alive promise, even if watcher.close() or rebuild throws
-      cleanupDone = true;
-      cleanupResolve?.();
+    } catch (error) {
+      logger.error('Error waiting for rebuild to complete:', error);
     }
+
+    // Always settle the keep-alive promise
+    cleanupDone = true;
+    cleanupResolve?.();
   };
 
   const onSigint = () => {

--- a/src/cli/actions/watchAction.ts
+++ b/src/cli/actions/watchAction.ts
@@ -130,11 +130,21 @@ export const runWatchAction = async (
   let shuttingDown = false;
 
   const scheduleRebuild = () => {
+    // Guard: don't schedule new work if shutdown has been initiated
+    if (shuttingDown) {
+      return;
+    }
+
     if (debounceTimer !== null) {
       clearTimeout(debounceTimer);
     }
     debounceTimer = setTimeout(async () => {
       debounceTimer = null;
+
+      // Re-check shutdown in case it was initiated while timer was pending
+      if (shuttingDown) {
+        return;
+      }
 
       if (isRebuilding) {
         pendingRebuild = true;
@@ -168,50 +178,58 @@ export const runWatchAction = async (
   watcher.on('add', scheduleRebuild);
   watcher.on('unlink', scheduleRebuild);
 
-  // Graceful shutdown — named handlers so they can be removed on cleanup
-  let keepAliveResolve: (() => void) | null = null;
+  // Graceful shutdown — shared cleanup promise that both signal and SIGINT/SIGTERM paths await
+  let cleanupResolve: (() => void) | null = null;
+  let cleanupStarted = false;
+  let cleanupDone = false;
 
   const cleanup = async () => {
+    // Prevent multiple cleanup calls
+    if (cleanupStarted) {
+      return;
+    }
+    cleanupStarted = true;
     shuttingDown = true;
+
     if (debounceTimer !== null) {
       clearTimeout(debounceTimer);
     }
     process.removeListener('SIGINT', onSigint);
     process.removeListener('SIGTERM', onSigterm);
-    // Close watcher before resolving keepAlive so callers don't see
+    // Close watcher before resolving so callers don't see
     // runWatchAction() resolve until shutdown is truly finished
     await watcher.close();
-    keepAliveResolve?.();
+    cleanupDone = true;
+    cleanupResolve?.();
   };
 
-  const onSigint = async () => {
-    await cleanup();
+  const onSigint = () => {
+    cleanup();
   };
-  const onSigterm = async () => {
-    await cleanup();
+  const onSigterm = () => {
+    cleanup();
   };
 
   if (resolvedDeps.signal) {
-    resolvedDeps.signal.addEventListener('abort', () => {
+    // Register abort listener with { once: true } to avoid duplicate calls
+    resolvedDeps.signal.addEventListener('abort', () => cleanup(), { once: true });
+
+    // Handle race condition: signal may already be aborted before listener was registered
+    if (resolvedDeps.signal.aborted) {
       cleanup();
-    });
+    }
   } else {
     process.on('SIGINT', onSigint);
     process.on('SIGTERM', onSigterm);
   }
 
-  // Keep alive — wait until signal is aborted (in tests) or cleanup resolves the promise
-  if (resolvedDeps.signal) {
-    await new Promise<void>((resolve) => {
-      if (resolvedDeps.signal?.aborted) {
-        resolve();
-        return;
-      }
-      resolvedDeps.signal?.addEventListener('abort', () => resolve());
-    });
-  } else {
-    await new Promise<void>((resolve) => {
-      keepAliveResolve = resolve;
-    });
-  }
+  // Keep alive — wait until cleanup is fully complete (including watcher.close())
+  // Check cleanupDone first in case cleanup finished before we got here
+  await new Promise<void>((resolve) => {
+    if (cleanupDone) {
+      resolve();
+      return;
+    }
+    cleanupResolve = resolve;
+  });
 };

--- a/src/cli/actions/watchAction.ts
+++ b/src/cli/actions/watchAction.ts
@@ -126,12 +126,15 @@ export const runWatchAction = async (
   watcher.on('unlink', scheduleRebuild);
 
   // Graceful shutdown — named handlers so they can be removed on cleanup
+  let keepAliveResolve: (() => void) | null = null;
+
   const cleanup = async () => {
     if (debounceTimer !== null) {
       clearTimeout(debounceTimer);
     }
     process.removeListener('SIGINT', onSigint);
     process.removeListener('SIGTERM', onSigterm);
+    keepAliveResolve?.();
     await watcher.close();
   };
 
@@ -151,7 +154,7 @@ export const runWatchAction = async (
     process.on('SIGTERM', onSigterm);
   }
 
-  // Keep alive — wait until signal is aborted (in tests) or process exits
+  // Keep alive — wait until signal is aborted (in tests) or cleanup resolves the promise
   if (resolvedDeps.signal) {
     await new Promise<void>((resolve) => {
       if (resolvedDeps.signal?.aborted) {
@@ -161,7 +164,8 @@ export const runWatchAction = async (
       resolvedDeps.signal?.addEventListener('abort', () => resolve());
     });
   } else {
-    // In production, keep the process alive indefinitely
-    await new Promise<void>(() => {});
+    await new Promise<void>((resolve) => {
+      keepAliveResolve = resolve;
+    });
   }
 };

--- a/src/cli/actions/watchAction.ts
+++ b/src/cli/actions/watchAction.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import process from 'node:process';
 import type { ChokidarOptions, FSWatcher } from 'chokidar';
 import pc from 'picocolors';
 import { loadFileConfig, mergeConfigs } from '../../config/configLoad.js';
@@ -74,19 +75,18 @@ export const runWatchAction = async (
   // Run initial pack
   const packResult = await runPack(targetPaths, config, cliOptions);
   reportResults(cwd, packResult, config, cliOptions);
-  logger.log(pc.dim('Watching for changes...'));
+  logger.log(pc.dim(`\nWatching ${packResult.safeFilePaths.length} files for changes... (Ctrl+C to stop)\n`));
 
-  // Resolve safeFilePaths against the first target path for watching
-  const rootDir = targetPaths[0];
-  const absoluteWatchPaths = packResult.safeFilePaths.map((filePath) => path.resolve(rootDir, filePath));
-
-  // Set up chokidar watcher
-  const watcher = resolvedDeps.watch(absoluteWatchPaths, {
+  // Watch target directories instead of individual files so new files are detected
+  const watcher = resolvedDeps.watch(targetPaths, {
     ignoreInitial: true,
     awaitWriteFinish: { stabilityThreshold: 100 },
+    ignored: config.output.filePath ? path.resolve(cwd, config.output.filePath) : undefined,
   });
 
-  // Debounced rebuild
+  // Rebuild guard — prevents concurrent packs and queues a follow-up if changes arrive mid-pack
+  let isRebuilding = false;
+  let pendingRebuild = false;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   const scheduleRebuild = () => {
@@ -95,6 +95,13 @@ export const runWatchAction = async (
     }
     debounceTimer = setTimeout(async () => {
       debounceTimer = null;
+
+      if (isRebuilding) {
+        pendingRebuild = true;
+        return;
+      }
+
+      isRebuilding = true;
       try {
         const result = await runPack(targetPaths, config, cliOptions);
         reportResults(cwd, result, config, cliOptions);
@@ -104,6 +111,12 @@ export const runWatchAction = async (
         logger.log(pc.dim('Watching for changes...'));
       } catch (error) {
         logger.error('Watch rebuild failed:', error);
+      } finally {
+        isRebuilding = false;
+        if (pendingRebuild) {
+          pendingRebuild = false;
+          scheduleRebuild();
+        }
       }
     }, 300);
   };
@@ -112,12 +125,21 @@ export const runWatchAction = async (
   watcher.on('add', scheduleRebuild);
   watcher.on('unlink', scheduleRebuild);
 
-  // Graceful shutdown
+  // Graceful shutdown — named handlers so they can be removed on cleanup
   const cleanup = async () => {
     if (debounceTimer !== null) {
       clearTimeout(debounceTimer);
     }
+    process.removeListener('SIGINT', onSigint);
+    process.removeListener('SIGTERM', onSigterm);
     await watcher.close();
+  };
+
+  const onSigint = async () => {
+    await cleanup();
+  };
+  const onSigterm = async () => {
+    await cleanup();
   };
 
   if (resolvedDeps.signal) {
@@ -125,14 +147,8 @@ export const runWatchAction = async (
       cleanup();
     });
   } else {
-    process.on('SIGINT', async () => {
-      await cleanup();
-      process.exit(0);
-    });
-    process.on('SIGTERM', async () => {
-      await cleanup();
-      process.exit(0);
-    });
+    process.on('SIGINT', onSigint);
+    process.on('SIGTERM', onSigterm);
   }
 
   // Keep alive — wait until signal is aborted (in tests) or process exits

--- a/src/cli/actions/watchAction.ts
+++ b/src/cli/actions/watchAction.ts
@@ -4,6 +4,7 @@ import type { ChokidarOptions, FSWatcher } from 'chokidar';
 import pc from 'picocolors';
 import { loadFileConfig, mergeConfigs } from '../../config/configLoad.js';
 import type { RepomixConfigCli, RepomixConfigFile, RepomixConfigMerged } from '../../config/configSchema.js';
+import { defaultIgnoreList } from '../../config/defaultIgnore.js';
 import { type PackResult, pack } from '../../core/packager.js';
 import { logger } from '../../shared/logger.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
@@ -46,13 +47,49 @@ const runPack = async (
   }
 };
 
+/**
+ * Builds ignore patterns for chokidar based on the packer's ignore configuration.
+ * This ensures watch mode ignores the same files/directories as the packer.
+ */
+const buildWatchIgnorePatterns = (cwd: string, config: RepomixConfigMerged): (string | RegExp)[] => {
+  const patterns: (string | RegExp)[] = [];
+
+  // Add default ignore patterns if enabled
+  if (config.ignore.useDefaultPatterns) {
+    for (const pattern of defaultIgnoreList) {
+      patterns.push(pattern);
+    }
+  }
+
+  // Add custom ignore patterns
+  if (config.ignore.customPatterns) {
+    for (const pattern of config.ignore.customPatterns) {
+      patterns.push(pattern);
+    }
+  }
+
+  // Add the output file path
+  if (config.output.filePath) {
+    patterns.push(path.resolve(cwd, config.output.filePath));
+  }
+
+  return patterns;
+};
+
 export const runWatchAction = async (
   directories: string[],
   cwd: string,
   cliOptions: CliOptions,
   deps?: Partial<WatchDeps>,
 ): Promise<void> => {
-  const resolvedDeps: WatchDeps = { ...(await resolveDefaultDeps()), ...deps };
+  // Early-return guard: if the signal is already aborted, do no work
+  // Must check before any await to prevent race conditions
+  if (deps?.signal?.aborted) {
+    return;
+  }
+
+  // Only load chokidar if no watch function is provided (enables faster tests)
+  const resolvedDeps: WatchDeps = deps?.watch ? (deps as WatchDeps) : { ...(await resolveDefaultDeps()), ...deps };
 
   logger.trace('Watch mode: loaded CLI options:', cliOptions);
 
@@ -78,16 +115,19 @@ export const runWatchAction = async (
   logger.log(pc.dim(`\nWatching ${packResult.safeFilePaths.length} files for changes... (Ctrl+C to stop)\n`));
 
   // Watch target directories instead of individual files so new files are detected
+  // Apply the same ignore patterns the packer uses to avoid unnecessary rebuilds
+  const watchIgnorePatterns = buildWatchIgnorePatterns(cwd, config);
   const watcher = resolvedDeps.watch(targetPaths, {
     ignoreInitial: true,
     awaitWriteFinish: { stabilityThreshold: 100 },
-    ignored: config.output.filePath ? path.resolve(cwd, config.output.filePath) : undefined,
+    ignored: watchIgnorePatterns,
   });
 
   // Rebuild guard — prevents concurrent packs and queues a follow-up if changes arrive mid-pack
   let isRebuilding = false;
   let pendingRebuild = false;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let shuttingDown = false;
 
   const scheduleRebuild = () => {
     if (debounceTimer !== null) {
@@ -113,7 +153,10 @@ export const runWatchAction = async (
         logger.error('Watch rebuild failed:', error);
       } finally {
         isRebuilding = false;
-        if (pendingRebuild) {
+        // Check if shutdown has been initiated before draining pendingRebuild
+        if (shuttingDown) {
+          pendingRebuild = false;
+        } else if (pendingRebuild) {
           pendingRebuild = false;
           scheduleRebuild();
         }
@@ -129,13 +172,16 @@ export const runWatchAction = async (
   let keepAliveResolve: (() => void) | null = null;
 
   const cleanup = async () => {
+    shuttingDown = true;
     if (debounceTimer !== null) {
       clearTimeout(debounceTimer);
     }
     process.removeListener('SIGINT', onSigint);
     process.removeListener('SIGTERM', onSigterm);
-    keepAliveResolve?.();
+    // Close watcher before resolving keepAlive so callers don't see
+    // runWatchAction() resolve until shutdown is truly finished
     await watcher.close();
+    keepAliveResolve?.();
   };
 
   const onSigint = async () => {

--- a/src/cli/actions/watchAction.ts
+++ b/src/cli/actions/watchAction.ts
@@ -123,11 +123,17 @@ export const runWatchAction = async (
     ignored: watchIgnorePatterns,
   });
 
+  // Handle watcher errors (EMFILE, EACCES, EPERM, etc.) to prevent uncaught exceptions
+  watcher.on('error', (error) => {
+    logger.error('File watcher error:', error);
+  });
+
   // Rebuild guard — prevents concurrent packs and queues a follow-up if changes arrive mid-pack
   let isRebuilding = false;
   let pendingRebuild = false;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let shuttingDown = false;
+  let activeRebuildPromise: Promise<void> | null = null;
 
   const scheduleRebuild = () => {
     // Guard: don't schedule new work if shutdown has been initiated
@@ -152,25 +158,30 @@ export const runWatchAction = async (
       }
 
       isRebuilding = true;
-      try {
-        const result = await runPack(targetPaths, config, cliOptions);
-        reportResults(cwd, result, config, cliOptions);
-        const now = new Date();
-        const timestamp = now.toLocaleTimeString('en-GB', { hour12: false });
-        logger.success(`Rebuilt at ${timestamp}`);
-        logger.log(pc.dim('Watching for changes...'));
-      } catch (error) {
-        logger.error('Watch rebuild failed:', error);
-      } finally {
-        isRebuilding = false;
-        // Check if shutdown has been initiated before draining pendingRebuild
-        if (shuttingDown) {
-          pendingRebuild = false;
-        } else if (pendingRebuild) {
-          pendingRebuild = false;
-          scheduleRebuild();
+      const rebuildWork = async () => {
+        try {
+          const result = await runPack(targetPaths, config, cliOptions);
+          reportResults(cwd, result, config, cliOptions);
+          const now = new Date();
+          const timestamp = now.toLocaleTimeString('en-GB', { hour12: false });
+          logger.success(`Rebuilt at ${timestamp}`);
+          logger.log(pc.dim('Watching for changes...'));
+        } catch (error) {
+          logger.error('Watch rebuild failed:', error);
+        } finally {
+          isRebuilding = false;
+          activeRebuildPromise = null;
+          // Check if shutdown has been initiated before draining pendingRebuild
+          if (shuttingDown) {
+            pendingRebuild = false;
+          } else if (pendingRebuild) {
+            pendingRebuild = false;
+            scheduleRebuild();
+          }
         }
-      }
+      };
+      activeRebuildPromise = rebuildWork();
+      await activeRebuildPromise;
     }, 300);
   };
 
@@ -194,13 +205,23 @@ export const runWatchAction = async (
     if (debounceTimer !== null) {
       clearTimeout(debounceTimer);
     }
+    pendingRebuild = false;
     process.removeListener('SIGINT', onSigint);
     process.removeListener('SIGTERM', onSigterm);
-    // Close watcher before resolving so callers don't see
-    // runWatchAction() resolve until shutdown is truly finished
-    await watcher.close();
-    cleanupDone = true;
-    cleanupResolve?.();
+
+    try {
+      // Close watcher before resolving so callers don't see
+      // runWatchAction() resolve until shutdown is truly finished
+      await watcher.close();
+      // Wait for any in-flight rebuild to complete before resolving
+      if (activeRebuildPromise) {
+        await activeRebuildPromise;
+      }
+    } finally {
+      // Always settle the keep-alive promise, even if watcher.close() or rebuild throws
+      cleanupDone = true;
+      cleanupResolve?.();
+    }
   };
 
   const onSigint = () => {

--- a/src/cli/actions/watchAction.ts
+++ b/src/cli/actions/watchAction.ts
@@ -1,0 +1,151 @@
+import path from 'node:path';
+import type { ChokidarOptions, FSWatcher } from 'chokidar';
+import pc from 'picocolors';
+import { loadFileConfig, mergeConfigs } from '../../config/configLoad.js';
+import type { RepomixConfigCli, RepomixConfigFile, RepomixConfigMerged } from '../../config/configSchema.js';
+import { type PackResult, pack } from '../../core/packager.js';
+import { logger } from '../../shared/logger.js';
+import type { RepomixProgressCallback } from '../../shared/types.js';
+import { reportResults } from '../cliReport.js';
+import { Spinner } from '../cliSpinner.js';
+import type { CliOptions } from '../types.js';
+import { buildCliConfig } from './defaultAction.js';
+import { runMigrationAction } from './migrationAction.js';
+
+export interface WatchDeps {
+  watch: (paths: string | string[], options?: ChokidarOptions) => FSWatcher;
+  signal?: AbortSignal;
+}
+
+const resolveDefaultDeps = async (): Promise<WatchDeps> => {
+  // Lazy-load chokidar so it is only imported when --watch is actually used
+  const chokidar = await import('chokidar');
+  return { watch: chokidar.watch };
+};
+
+const runPack = async (
+  targetPaths: string[],
+  config: RepomixConfigMerged,
+  cliOptions: CliOptions,
+): Promise<PackResult> => {
+  const spinner = new Spinner('Packing...', cliOptions);
+  spinner.start();
+
+  try {
+    const handleProgress: RepomixProgressCallback = (message) => {
+      spinner.update(message);
+    };
+
+    const packResult = await pack(targetPaths, config, handleProgress);
+    spinner.succeed('Packing completed successfully!');
+    return packResult;
+  } catch (error) {
+    spinner.fail('Error during packing');
+    throw error;
+  }
+};
+
+export const runWatchAction = async (
+  directories: string[],
+  cwd: string,
+  cliOptions: CliOptions,
+  deps?: Partial<WatchDeps>,
+): Promise<void> => {
+  const resolvedDeps: WatchDeps = { ...(await resolveDefaultDeps()), ...deps };
+
+  logger.trace('Watch mode: loaded CLI options:', cliOptions);
+
+  // Build config — same pattern as defaultAction
+  await runMigrationAction(cwd);
+
+  const fileConfig: RepomixConfigFile = await loadFileConfig(cwd, cliOptions.config ?? null, {
+    skipLocalConfig: cliOptions.skipLocalConfig,
+  });
+  logger.trace('Watch mode: loaded file config:', fileConfig);
+
+  const cliConfig: RepomixConfigCli = buildCliConfig(cliOptions);
+  logger.trace('Watch mode: CLI config:', cliConfig);
+
+  const config: RepomixConfigMerged = mergeConfigs(cwd, fileConfig, cliConfig);
+  logger.trace('Watch mode: merged config:', config);
+
+  const targetPaths = directories.map((directory) => path.resolve(cwd, directory));
+
+  // Run initial pack
+  const packResult = await runPack(targetPaths, config, cliOptions);
+  reportResults(cwd, packResult, config, cliOptions);
+  logger.log(pc.dim('Watching for changes...'));
+
+  // Resolve safeFilePaths against the first target path for watching
+  const rootDir = targetPaths[0];
+  const absoluteWatchPaths = packResult.safeFilePaths.map((filePath) => path.resolve(rootDir, filePath));
+
+  // Set up chokidar watcher
+  const watcher = resolvedDeps.watch(absoluteWatchPaths, {
+    ignoreInitial: true,
+    awaitWriteFinish: { stabilityThreshold: 100 },
+  });
+
+  // Debounced rebuild
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const scheduleRebuild = () => {
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer);
+    }
+    debounceTimer = setTimeout(async () => {
+      debounceTimer = null;
+      try {
+        const result = await runPack(targetPaths, config, cliOptions);
+        reportResults(cwd, result, config, cliOptions);
+        const now = new Date();
+        const timestamp = now.toLocaleTimeString('en-GB', { hour12: false });
+        logger.success(`Rebuilt at ${timestamp}`);
+        logger.log(pc.dim('Watching for changes...'));
+      } catch (error) {
+        logger.error('Watch rebuild failed:', error);
+      }
+    }, 300);
+  };
+
+  watcher.on('change', scheduleRebuild);
+  watcher.on('add', scheduleRebuild);
+  watcher.on('unlink', scheduleRebuild);
+
+  // Graceful shutdown
+  const cleanup = async () => {
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer);
+    }
+    await watcher.close();
+  };
+
+  if (resolvedDeps.signal) {
+    resolvedDeps.signal.addEventListener('abort', () => {
+      cleanup();
+    });
+  } else {
+    process.on('SIGINT', async () => {
+      await cleanup();
+      process.exit(0);
+    });
+    process.on('SIGTERM', async () => {
+      await cleanup();
+      process.exit(0);
+    });
+  }
+
+  // Keep alive — wait until signal is aborted (in tests) or process exits
+  if (resolvedDeps.signal) {
+    await new Promise<void>((resolve) => {
+      if (resolvedDeps.signal?.aborted) {
+        resolve();
+        return;
+      }
+      resolvedDeps.signal?.addEventListener('abort', () => resolve());
+    });
+  } else {
+    // In production, keep the process alive indefinitely
+    await new Promise<void>(() => {});
+  }
+};

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -250,6 +250,9 @@ export const runCli = async (directories: string[], cwd: string, options: CliOpt
     if (options.stdin) {
       throw new RepomixError('--watch cannot be used with --stdin. Watch mode discovers files automatically.');
     }
+    if (directories.length === 1 && isExplicitRemoteUrl(directories[0])) {
+      throw new RepomixError('--watch cannot be used with remote URLs. Watch mode only works with local directories.');
+    }
   }
 
   // Set log level based on verbose and quiet flags

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -257,6 +257,19 @@ export const runCli = async (directories: string[], cwd: string, options: CliOpt
   logger.trace('cwd:', cwd);
   logger.trace('options:', options);
 
+  // Validate --watch conflicts before any routing
+  if (options.watch) {
+    if (options.remote) {
+      throw new RepomixError('--watch cannot be used with --remote. Watch mode only works with local directories.');
+    }
+    if (options.stdout) {
+      throw new RepomixError('--watch cannot be used with --stdout. Watch mode writes to a file.');
+    }
+    if (options.stdin) {
+      throw new RepomixError('--watch cannot be used with --stdin. Watch mode discovers files automatically.');
+    }
+  }
+
   if (options.mcp) {
     const { runMcpAction } = await import('./actions/mcpAction.js');
     return await runMcpAction();

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -250,6 +250,11 @@ export const runCli = async (directories: string[], cwd: string, options: CliOpt
     if (options.stdin) {
       throw new RepomixError('--watch cannot be used with --stdin. Watch mode discovers files automatically.');
     }
+    if (options.splitOutput) {
+      throw new RepomixError(
+        '--watch cannot be used with --split-output. Watch mode does not yet support split output files.',
+      );
+    }
     if (directories.length === 1 && isExplicitRemoteUrl(directories[0])) {
       throw new RepomixError('--watch cannot be used with remote URLs. Watch mode only works with local directories.');
     }

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -40,6 +40,9 @@ const semanticSuggestionMap: Record<string, string[]> = {
   console: ['--stdout'],
   terminal: ['--stdout'],
   pipe: ['--stdin'],
+  monitor: ['--watch'],
+  live: ['--watch'],
+  auto: ['--watch'],
 };
 
 export const run = async () => {
@@ -183,6 +186,9 @@ export const run = async () => {
       )
       .option('--skill-output <path>', 'Specify skill output directory path directly (skips location prompt)')
       .option('-f, --force', 'Skip all confirmation prompts (currently: skill directory overwrite)')
+      // Watch Mode
+      .optionsGroup('Watch Mode')
+      .option('-w, --watch', 'Watch for file changes and automatically re-pack')
       .action(commanderActionEndpoint);
 
     // Custom error handling function
@@ -284,6 +290,11 @@ export const runCli = async (directories: string[], cwd: string, options: CliOpt
     logger.trace(`Auto-detected remote URL from positional argument: ${directories[0]}`);
     const { runRemoteAction } = await import('./actions/remoteAction.js');
     return await runRemoteAction(directories[0], options);
+  }
+
+  if (options.watch) {
+    const { runWatchAction } = await import('./actions/watchAction.js');
+    return await runWatchAction(directories, cwd, options);
   }
 
   const { runDefaultAction } = await import('./actions/defaultAction.js');

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -239,6 +239,19 @@ export const runCli = async (directories: string[], cwd: string, options: CliOpt
     options.stdout = true;
   }
 
+  // Validate --watch conflicts early, before log level changes can suppress error messages
+  if (options.watch) {
+    if (options.remote) {
+      throw new RepomixError('--watch cannot be used with --remote. Watch mode only works with local directories.');
+    }
+    if (options.stdout) {
+      throw new RepomixError('--watch cannot be used with --stdout. Watch mode writes to a file.');
+    }
+    if (options.stdin) {
+      throw new RepomixError('--watch cannot be used with --stdin. Watch mode discovers files automatically.');
+    }
+  }
+
   // Set log level based on verbose and quiet flags
   if (options.quiet) {
     logger.setLogLevel(repomixLogLevels.SILENT);
@@ -256,19 +269,6 @@ export const runCli = async (directories: string[], cwd: string, options: CliOpt
   logger.trace('directories:', directories);
   logger.trace('cwd:', cwd);
   logger.trace('options:', options);
-
-  // Validate --watch conflicts before any routing
-  if (options.watch) {
-    if (options.remote) {
-      throw new RepomixError('--watch cannot be used with --remote. Watch mode only works with local directories.');
-    }
-    if (options.stdout) {
-      throw new RepomixError('--watch cannot be used with --stdout. Watch mode writes to a file.');
-    }
-    if (options.stdin) {
-      throw new RepomixError('--watch cannot be used with --stdin. Watch mode discovers files automatically.');
-    }
-  }
 
   if (options.mcp) {
     const { runMcpAction } = await import('./actions/mcpAction.js');

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -67,6 +67,9 @@ export interface CliOptions extends OptionValues {
   skillOutput?: string; // Output path for skill (skips location prompt)
   force?: boolean; // Skip all confirmation prompts
 
+  // Watch Mode
+  watch?: boolean;
+
   // Other Options
   topFilesLen?: number;
   verbose?: boolean;

--- a/tests/cli/actions/watchAction.test.ts
+++ b/tests/cli/actions/watchAction.test.ts
@@ -113,7 +113,7 @@ describe('watchAction', () => {
       createMockConfig({
         cwd: process.cwd(),
         output: {
-          filePath: 'output.txt',
+          filePath: 'repomix-output.xml',
           style: 'plain',
           parsableStyle: false,
           fileSummary: true,
@@ -178,7 +178,7 @@ describe('watchAction', () => {
     expect(mockSpinner.succeed).toHaveBeenCalled();
   });
 
-  it('should set up chokidar watcher on safeFilePaths resolved against targetPaths[0]', async () => {
+  it('should watch target directories instead of individual files', async () => {
     const controller = new AbortController();
     const options: CliOptions = {};
     const mockWatch = createMockWatch(mockWatcher);
@@ -197,13 +197,37 @@ describe('watchAction', () => {
     controller.abort();
     await watchPromise;
 
-    const rootDir = path.resolve(cwd, '.');
-    const expectedPaths = ['src/index.ts', 'src/utils.ts'].map((p) => path.resolve(rootDir, p));
+    const expectedTargetPaths = [path.resolve(cwd, '.')];
 
-    expect(mockWatch).toHaveBeenCalledWith(expectedPaths, {
+    expect(mockWatch).toHaveBeenCalledWith(expectedTargetPaths, {
       ignoreInitial: true,
       awaitWriteFinish: { stabilityThreshold: 100 },
+      ignored: path.resolve(cwd, 'repomix-output.xml'),
     });
+  });
+
+  it('should ignore the output file path in the watcher', async () => {
+    const controller = new AbortController();
+    const options: CliOptions = {};
+    const mockWatch = createMockWatch(mockWatcher);
+    const cwd = process.cwd();
+
+    const watchPromise = (async () => {
+      const { runWatchAction } = await import('../../../src/cli/actions/watchAction.js');
+      return runWatchAction(['.'], cwd, options, {
+        watch: mockWatch,
+        signal: controller.signal,
+      });
+    })();
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    controller.abort();
+    await watchPromise;
+
+    const watchCall = (mockWatch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const watchOptions = watchCall[1];
+    expect(watchOptions.ignored).toBe(path.resolve(cwd, 'repomix-output.xml'));
   });
 
   it('should re-pack on file change after debounce', async () => {
@@ -270,6 +294,63 @@ describe('watchAction', () => {
     await watchPromise;
   });
 
+  it('should not start a concurrent rebuild while one is in progress', async () => {
+    const controller = new AbortController();
+    const options: CliOptions = {};
+    const mockWatch = createMockWatch(mockWatcher);
+
+    // Make pack take some time so we can trigger a change mid-rebuild
+    let resolveSecondPack: (() => void) | undefined;
+    let packCallCount = 0;
+
+    vi.mocked(packager.pack).mockImplementation(async () => {
+      packCallCount++;
+      if (packCallCount === 2) {
+        // Second pack (first rebuild) — hold it open so we can trigger a change mid-rebuild
+        await new Promise<void>((resolve) => {
+          resolveSecondPack = resolve;
+        });
+      }
+      return createMockPackResult();
+    });
+
+    const watchPromise = (async () => {
+      const { runWatchAction } = await import('../../../src/cli/actions/watchAction.js');
+      return runWatchAction(['.'], process.cwd(), options, {
+        watch: mockWatch,
+        signal: controller.signal,
+      });
+    })();
+
+    // Let initial pack complete
+    await vi.advanceTimersByTimeAsync(0);
+    expect(packager.pack).toHaveBeenCalledTimes(1);
+
+    // Trigger first rebuild
+    mockWatcher.emit('change', 'src/index.ts');
+    await vi.advanceTimersByTimeAsync(350);
+
+    // Second pack is now in progress (held open by resolveSecondPack)
+    expect(packager.pack).toHaveBeenCalledTimes(2);
+
+    // Trigger another change while rebuild is in progress
+    mockWatcher.emit('change', 'src/utils.ts');
+    await vi.advanceTimersByTimeAsync(350);
+
+    // Should still be 2 because the rebuild guard prevents a concurrent pack
+    expect(packager.pack).toHaveBeenCalledTimes(2);
+
+    // Resolve the in-progress pack — the pending rebuild should now fire
+    resolveSecondPack?.();
+    await vi.advanceTimersByTimeAsync(350);
+
+    // Now the queued rebuild should have run
+    expect(packager.pack).toHaveBeenCalledTimes(3);
+
+    controller.abort();
+    await watchPromise;
+  });
+
   it('should log "Rebuilt at" timestamp after rebuild', async () => {
     const controller = new AbortController();
     const options: CliOptions = {};
@@ -314,7 +395,7 @@ describe('watchAction', () => {
     // Let initial pack complete
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(loggerModule.logger.log).toHaveBeenCalledWith(expect.stringContaining('Watching for changes...'));
+    expect(loggerModule.logger.log).toHaveBeenCalledWith(expect.stringContaining('Watching'));
 
     controller.abort();
     await watchPromise;

--- a/tests/cli/actions/watchAction.test.ts
+++ b/tests/cli/actions/watchAction.test.ts
@@ -96,6 +96,14 @@ describe('watch option conflicts', () => {
     const options: CliOptions = { watch: true, stdin: true };
     await expect(runCli(['.'], process.cwd(), options)).rejects.toThrow('--watch cannot be used with --stdin');
   });
+
+  it('should throw when --watch is used with a positional remote URL', async () => {
+    const { runCli } = await import('../../../src/cli/cliRun.js');
+    const options: CliOptions = { watch: true };
+    await expect(runCli(['https://github.com/user/repo'], process.cwd(), options)).rejects.toThrow(
+      '--watch cannot be used with remote URLs',
+    );
+  });
 });
 
 describe('watchAction', () => {

--- a/tests/cli/actions/watchAction.test.ts
+++ b/tests/cli/actions/watchAction.test.ts
@@ -97,6 +97,12 @@ describe('watch option conflicts', () => {
     await expect(runCli(['.'], process.cwd(), options)).rejects.toThrow('--watch cannot be used with --stdin');
   });
 
+  it('should throw when --watch is used with --split-output', async () => {
+    const { runCli } = await import('../../../src/cli/cliRun.js');
+    const options: CliOptions = { watch: true, splitOutput: 1000 };
+    await expect(runCli(['.'], process.cwd(), options)).rejects.toThrow('--watch cannot be used with --split-output');
+  });
+
   it('should throw when --watch is used with a positional remote URL', async () => {
     const { runCli } = await import('../../../src/cli/cliRun.js');
     const options: CliOptions = { watch: true };

--- a/tests/cli/actions/watchAction.test.ts
+++ b/tests/cli/actions/watchAction.test.ts
@@ -1,0 +1,315 @@
+import { EventEmitter } from 'node:events';
+import path from 'node:path';
+import process from 'node:process';
+import { afterEach, beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest';
+import type { WatchDeps } from '../../../src/cli/actions/watchAction.js';
+import type { CliOptions } from '../../../src/cli/types.js';
+import * as configLoader from '../../../src/config/configLoad.js';
+import * as packager from '../../../src/core/packager.js';
+import * as loggerModule from '../../../src/shared/logger.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+vi.mock('../../../src/core/packager');
+vi.mock('../../../src/config/configLoad');
+vi.mock('../../../src/shared/logger');
+
+const mockSpinner = {
+  start: vi.fn() as MockedFunction<() => void>,
+  update: vi.fn() as MockedFunction<(message: string) => void>,
+  succeed: vi.fn() as MockedFunction<(message: string) => void>,
+  fail: vi.fn() as MockedFunction<(message: string) => void>,
+};
+
+vi.mock('../../../src/cli/cliSpinner', () => {
+  const MockSpinner = class {
+    start = mockSpinner.start;
+    update = mockSpinner.update;
+    succeed = mockSpinner.succeed;
+    fail = mockSpinner.fail;
+  };
+  return { Spinner: MockSpinner };
+});
+vi.mock('../../../src/cli/cliReport');
+vi.mock('../../../src/cli/actions/migrationAction', () => ({
+  runMigrationAction: vi.fn().mockResolvedValue({}),
+}));
+
+function createMockPackResult(overrides: Partial<packager.PackResult> = {}): packager.PackResult {
+  return {
+    totalFiles: 5,
+    totalCharacters: 500,
+    totalTokens: 100,
+    fileCharCounts: {},
+    fileTokenCounts: {},
+    suspiciousFilesResults: [],
+    suspiciousGitDiffResults: [],
+    suspiciousGitLogResults: [],
+    processedFiles: [],
+    safeFilePaths: ['src/index.ts', 'src/utils.ts'],
+    gitDiffTokenCount: 0,
+    gitLogTokenCount: 0,
+    skippedFiles: [],
+    ...overrides,
+  };
+}
+
+function createMockWatcher() {
+  const emitter = new EventEmitter();
+  const watcher = Object.assign(emitter, {
+    close: vi.fn().mockResolvedValue(undefined),
+    add: vi.fn(),
+    unwatch: vi.fn(),
+    getWatched: vi.fn().mockReturnValue({}),
+    closed: false,
+  });
+  return watcher;
+}
+
+function createMockWatch(watcher: ReturnType<typeof createMockWatcher>): WatchDeps['watch'] {
+  return vi.fn().mockReturnValue(watcher) as unknown as WatchDeps['watch'];
+}
+
+describe('watchAction', () => {
+  let mockWatcher: ReturnType<typeof createMockWatcher>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetAllMocks();
+    vi.clearAllMocks();
+
+    mockWatcher = createMockWatcher();
+
+    vi.mocked(configLoader.loadFileConfig).mockResolvedValue({});
+    vi.mocked(configLoader.mergeConfigs).mockReturnValue(
+      createMockConfig({
+        cwd: process.cwd(),
+        output: {
+          filePath: 'output.txt',
+          style: 'plain',
+          parsableStyle: false,
+          fileSummary: true,
+          directoryStructure: true,
+          topFilesLength: 5,
+          showLineNumbers: false,
+          removeComments: false,
+          removeEmptyLines: false,
+          compress: false,
+          copyToClipboard: false,
+          stdout: false,
+          git: {
+            sortByChanges: true,
+            sortByChangesMaxCommits: 100,
+            includeDiffs: false,
+          },
+          files: true,
+        },
+        ignore: {
+          useGitignore: true,
+          useDefaultPatterns: true,
+          customPatterns: [],
+        },
+        include: [],
+        security: {
+          enableSecurityCheck: true,
+        },
+        tokenCount: {
+          encoding: 'o200k_base',
+        },
+      }),
+    );
+
+    vi.mocked(packager.pack).mockResolvedValue(createMockPackResult());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetAllMocks();
+  });
+
+  it('should run initial pack on start', async () => {
+    const controller = new AbortController();
+    const options: CliOptions = {};
+
+    const watchPromise = (async () => {
+      const { runWatchAction } = await import('../../../src/cli/actions/watchAction.js');
+      return runWatchAction(['.'], process.cwd(), options, {
+        watch: createMockWatch(mockWatcher),
+        signal: controller.signal,
+      });
+    })();
+
+    // Let initial pack complete
+    await vi.advanceTimersByTimeAsync(0);
+
+    controller.abort();
+    await watchPromise;
+
+    expect(packager.pack).toHaveBeenCalledTimes(1);
+    expect(mockSpinner.start).toHaveBeenCalled();
+    expect(mockSpinner.succeed).toHaveBeenCalled();
+  });
+
+  it('should set up chokidar watcher on safeFilePaths resolved against targetPaths[0]', async () => {
+    const controller = new AbortController();
+    const options: CliOptions = {};
+    const mockWatch = createMockWatch(mockWatcher);
+    const cwd = process.cwd();
+
+    const watchPromise = (async () => {
+      const { runWatchAction } = await import('../../../src/cli/actions/watchAction.js');
+      return runWatchAction(['.'], cwd, options, {
+        watch: mockWatch,
+        signal: controller.signal,
+      });
+    })();
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    controller.abort();
+    await watchPromise;
+
+    const rootDir = path.resolve(cwd, '.');
+    const expectedPaths = ['src/index.ts', 'src/utils.ts'].map((p) => path.resolve(rootDir, p));
+
+    expect(mockWatch).toHaveBeenCalledWith(expectedPaths, {
+      ignoreInitial: true,
+      awaitWriteFinish: { stabilityThreshold: 100 },
+    });
+  });
+
+  it('should re-pack on file change after debounce', async () => {
+    const controller = new AbortController();
+    const options: CliOptions = {};
+    const mockWatch = createMockWatch(mockWatcher);
+
+    const watchPromise = (async () => {
+      const { runWatchAction } = await import('../../../src/cli/actions/watchAction.js');
+      return runWatchAction(['.'], process.cwd(), options, {
+        watch: mockWatch,
+        signal: controller.signal,
+      });
+    })();
+
+    // Let initial pack complete
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(packager.pack).toHaveBeenCalledTimes(1);
+
+    // Simulate a file change event
+    mockWatcher.emit('change', 'src/index.ts');
+
+    // Advance past the 300ms debounce
+    await vi.advanceTimersByTimeAsync(350);
+
+    expect(packager.pack).toHaveBeenCalledTimes(2);
+
+    controller.abort();
+    await watchPromise;
+  });
+
+  it('should debounce multiple rapid changes into one rebuild', async () => {
+    const controller = new AbortController();
+    const options: CliOptions = {};
+    const mockWatch = createMockWatch(mockWatcher);
+
+    const watchPromise = (async () => {
+      const { runWatchAction } = await import('../../../src/cli/actions/watchAction.js');
+      return runWatchAction(['.'], process.cwd(), options, {
+        watch: mockWatch,
+        signal: controller.signal,
+      });
+    })();
+
+    // Let initial pack complete
+    await vi.advanceTimersByTimeAsync(0);
+    expect(packager.pack).toHaveBeenCalledTimes(1);
+
+    // Fire multiple rapid changes within the debounce window
+    mockWatcher.emit('change', 'src/index.ts');
+    await vi.advanceTimersByTimeAsync(100);
+    mockWatcher.emit('change', 'src/utils.ts');
+    await vi.advanceTimersByTimeAsync(100);
+    mockWatcher.emit('add', 'src/new.ts');
+
+    // Advance past the 300ms debounce from the last event
+    await vi.advanceTimersByTimeAsync(350);
+
+    // Should only have rebuilt once (plus the initial pack)
+    expect(packager.pack).toHaveBeenCalledTimes(2);
+
+    controller.abort();
+    await watchPromise;
+  });
+
+  it('should log "Rebuilt at" timestamp after rebuild', async () => {
+    const controller = new AbortController();
+    const options: CliOptions = {};
+    const mockWatch = createMockWatch(mockWatcher);
+
+    const watchPromise = (async () => {
+      const { runWatchAction } = await import('../../../src/cli/actions/watchAction.js');
+      return runWatchAction(['.'], process.cwd(), options, {
+        watch: mockWatch,
+        signal: controller.signal,
+      });
+    })();
+
+    // Let initial pack complete
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Simulate a file change
+    mockWatcher.emit('change', 'src/index.ts');
+
+    // Advance past debounce
+    await vi.advanceTimersByTimeAsync(350);
+
+    expect(loggerModule.logger.success).toHaveBeenCalledWith(expect.stringContaining('Rebuilt at'));
+
+    controller.abort();
+    await watchPromise;
+  });
+
+  it('should log "Watching for changes..." after initial pack', async () => {
+    const controller = new AbortController();
+    const options: CliOptions = {};
+    const mockWatch = createMockWatch(mockWatcher);
+
+    const watchPromise = (async () => {
+      const { runWatchAction } = await import('../../../src/cli/actions/watchAction.js');
+      return runWatchAction(['.'], process.cwd(), options, {
+        watch: mockWatch,
+        signal: controller.signal,
+      });
+    })();
+
+    // Let initial pack complete
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(loggerModule.logger.log).toHaveBeenCalledWith(expect.stringContaining('Watching for changes...'));
+
+    controller.abort();
+    await watchPromise;
+  });
+
+  it('should close watcher on abort signal', async () => {
+    const controller = new AbortController();
+    const options: CliOptions = {};
+    const mockWatch = createMockWatch(mockWatcher);
+
+    const watchPromise = (async () => {
+      const { runWatchAction } = await import('../../../src/cli/actions/watchAction.js');
+      return runWatchAction(['.'], process.cwd(), options, {
+        watch: mockWatch,
+        signal: controller.signal,
+      });
+    })();
+
+    // Let initial pack complete
+    await vi.advanceTimersByTimeAsync(0);
+
+    controller.abort();
+    await watchPromise;
+
+    expect(mockWatcher.close).toHaveBeenCalled();
+  });
+});

--- a/tests/cli/actions/watchAction.test.ts
+++ b/tests/cli/actions/watchAction.test.ts
@@ -69,6 +69,35 @@ function createMockWatch(watcher: ReturnType<typeof createMockWatcher>): WatchDe
   return vi.fn().mockReturnValue(watcher) as unknown as WatchDeps['watch'];
 }
 
+describe('watch option conflicts', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should throw when --watch is used with --remote', async () => {
+    const { runCli } = await import('../../../src/cli/cliRun.js');
+    const options: CliOptions = { watch: true, remote: 'user/repo' };
+    await expect(runCli(['.'], process.cwd(), options)).rejects.toThrow('--watch cannot be used with --remote');
+  });
+
+  it('should throw when --watch is used with --stdout', async () => {
+    const { runCli } = await import('../../../src/cli/cliRun.js');
+    const options: CliOptions = { watch: true, stdout: true };
+    await expect(runCli(['.'], process.cwd(), options)).rejects.toThrow('--watch cannot be used with --stdout');
+  });
+
+  it('should throw when --watch is used with --stdin', async () => {
+    const { runCli } = await import('../../../src/cli/cliRun.js');
+    const options: CliOptions = { watch: true, stdin: true };
+    await expect(runCli(['.'], process.cwd(), options)).rejects.toThrow('--watch cannot be used with --stdin');
+  });
+});
+
 describe('watchAction', () => {
   let mockWatcher: ReturnType<typeof createMockWatcher>;
 

--- a/tests/cli/actions/watchAction.test.ts
+++ b/tests/cli/actions/watchAction.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, type MockedFunction, vi } 
 import type { WatchDeps } from '../../../src/cli/actions/watchAction.js';
 import type { CliOptions } from '../../../src/cli/types.js';
 import * as configLoader from '../../../src/config/configLoad.js';
+import { defaultIgnoreList } from '../../../src/config/defaultIgnore.js';
 import * as packager from '../../../src/core/packager.js';
 import * as loggerModule from '../../../src/shared/logger.js';
 import { createMockConfig } from '../../testing/testUtils.js';
@@ -173,13 +174,12 @@ describe('watchAction', () => {
     const controller = new AbortController();
     const options: CliOptions = {};
 
-    const watchPromise = (async () => {
-      const { runWatchAction } = await import('../../../src/cli/actions/watchAction.js');
-      return runWatchAction(['.'], process.cwd(), options, {
-        watch: createMockWatch(mockWatcher),
-        signal: controller.signal,
-      });
-    })();
+    // Import separately to ensure runWatchAction is called before abort
+    const { runWatchAction } = await import('../../../src/cli/actions/watchAction.js');
+    const watchPromise = runWatchAction(['.'], process.cwd(), options, {
+      watch: createMockWatch(mockWatcher),
+      signal: controller.signal,
+    });
 
     // Let initial pack complete
     await vi.advanceTimersByTimeAsync(0);
@@ -212,11 +212,12 @@ describe('watchAction', () => {
     await watchPromise;
 
     const expectedTargetPaths = [path.resolve(cwd, '.')];
+    const expectedIgnorePatterns = [...defaultIgnoreList, path.resolve(cwd, 'repomix-output.xml')];
 
     expect(mockWatch).toHaveBeenCalledWith(expectedTargetPaths, {
       ignoreInitial: true,
       awaitWriteFinish: { stabilityThreshold: 100 },
-      ignored: path.resolve(cwd, 'repomix-output.xml'),
+      ignored: expectedIgnorePatterns,
     });
   });
 
@@ -241,7 +242,9 @@ describe('watchAction', () => {
 
     const watchCall = (mockWatch as ReturnType<typeof vi.fn>).mock.calls[0];
     const watchOptions = watchCall[1];
-    expect(watchOptions.ignored).toBe(path.resolve(cwd, 'repomix-output.xml'));
+    // The ignored option should be an array that includes the output file path
+    expect(Array.isArray(watchOptions.ignored)).toBe(true);
+    expect(watchOptions.ignored).toContain(path.resolve(cwd, 'repomix-output.xml'));
   });
 
   it('should re-pack on file change after debounce', async () => {


### PR DESCRIPTION
Closes #1429

Adds a `--watch` / `-w` flag that watches input files for changes and automatically re-packs when files are modified, created, or deleted.

## How it works

1. Runs a normal pack on startup
2. Sets up a [chokidar](https://github.com/paulmillr/chokidar) file watcher on the files discovered during file search (`safeFilePaths`)
3. On file change events (`change`, `add`, `unlink`), debounces for 300ms then re-runs the pack
4. Logs a "Rebuilt at HH:MM:SS" timestamp after each rebuild
5. Gracefully shuts down on `Ctrl+C` (SIGINT/SIGTERM)

## Usage

```bash
# Watch all files in current directory
repomix --watch
repomix -w

# Combine with other options
repomix -w --include "src/**/*.ts"
repomix -w -o output.xml --style xml
```

## Conflict validation

`--watch` cannot be combined with:
- `--remote` (watch mode only works with local directories)
- `--stdout` (watch mode writes to a file)
- `--stdin` (watch mode discovers files automatically)

Clear error messages are shown when conflicting flags are used.

## Implementation details

- Uses chokidar for cross-platform file watching with `awaitWriteFinish` for stability
- Follows the existing action pattern (`remoteAction`, `defaultAction`) with dependency injection via `deps` parameter for testability
- Lazy-loads chokidar via dynamic `import()` so the dependency is only loaded when `--watch` is used
- 10 new tests (7 watch behavior + 3 conflict validation), all using fake timers and `AbortSignal` for deterministic testing

## Checklist

- [x] Run `npm run test` (1116 passed, 0 failures)
- [x] Run `npm run lint` (0 errors, only pre-existing warnings)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
