### PR TITLE
perf(core): Prefetch git sort data to overlap with file search and collection

### DIFF
--- a/src/core/output/outputSort.ts
+++ b/src/core/output/outputSort.ts
@@ -113,6 +113,22 @@ export const sortOutputFiles = async (
   return sortFilesByChangeCounts(files, fileChangeCounts);
 };
 
+/**
+ * Pre-fetch git file change counts so that a later `sortOutputFiles` call
+ * hits the in-memory cache instead of spawning git subprocesses on the
+ * critical path.
+ */
+export const prefetchSortData = async (
+  config: RepomixConfigMerged,
+  deps: SortDeps = {
+    getFileChangeCount,
+    isGitInstalled,
+  },
+): Promise<void> => {
+  if (!config.output.git?.sortByChanges) return;
+  await getFileChangeCounts(config.cwd, config.output.git?.sortByChangesMaxCommits, deps);
+};
+
 const sortFilesByChangeCounts = (files: ProcessedFile[], fileChangeCounts: Record<string, number>): ProcessedFile[] => {
   // Sort files by change count (files with more changes go to the bottom)
   return [...files].sort((a, b) => {

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -11,7 +11,7 @@ import type { ProcessedFile } from './file/fileTypes.js';
 import { getGitDiffs } from './git/gitDiffHandle.js';
 import { getGitLogs } from './git/gitLogHandle.js';
 import { calculateMetrics, createMetricsTaskRunner } from './metrics/calculateMetrics.js';
-import { sortOutputFiles } from './output/outputSort.js';
+import { prefetchSortData, sortOutputFiles } from './output/outputSort.js';
 import { produceOutput } from './packager/produceOutput.js';
 import type { SuspiciousFileResult } from './security/securityCheck.js';
 import { validateFileSafety } from './security/validateFileSafety.js';
@@ -44,6 +44,7 @@ const defaultDeps = {
   createMetricsTaskRunner,
   sortPaths,
   sortOutputFiles,
+  prefetchSortData,
   getGitDiffs,
   getGitLogs,
   // Lazy-load packSkill to defer importing the skill module chain
@@ -76,6 +77,10 @@ export const pack = async (
   };
 
   logMemoryUsage('Pack - Start');
+
+  // Pre-fetch git file-change counts for sortOutputFiles while search and
+  // collection are in flight, so the later sortOutputFiles call is a cache hit.
+  const sortDataPromise = deps.prefetchSortData(config).catch(() => {});
 
   progressCallback('Searching for files...');
   const searchResultsByDir = await withMemoryLogging('Search Files', async () =>
@@ -163,6 +168,7 @@ export const pack = async (
     // runs twice but is negligible (~1ms for 1000 files). This ordering is required by the
     // fast-path in `calculateMetrics`, which walks file contents through the output string
     // in order via `extractOutputWrapper`.
+    await sortDataPromise;
     const processedFiles = await deps.sortOutputFiles(filteredProcessedFiles, config);
 
     progressCallback('Generating output...');

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import type { RepomixConfigMerged } from '../config/configSchema.js';
+import { logger } from '../shared/logger.js';
 import { logMemoryUsage, withMemoryLogging } from '../shared/memoryUtils.js';
 import type { RepomixProgressCallback } from '../shared/types.js';
 import { collectFiles, type SkippedFileInfo } from './file/fileCollect.js';
@@ -80,7 +81,9 @@ export const pack = async (
 
   // Pre-fetch git file-change counts for sortOutputFiles while search and
   // collection are in flight, so the later sortOutputFiles call is a cache hit.
-  const sortDataPromise = deps.prefetchSortData(config).catch(() => {});
+  const sortDataPromise = deps.prefetchSortData(config).catch((error) => {
+    logger.trace('Failed to prefetch sort data:', error);
+  });
 
   progressCallback('Searching for files...');
   const searchResultsByDir = await withMemoryLogging('Search Files', async () =>


### PR DESCRIPTION
## Summary
- Add `prefetchSortData()` to launch `git --version` + `git log --name-only` subprocesses early in the pipeline, so that `sortOutputFiles` hits the in-memory cache instead of spawning ~15ms of subprocess overhead on the critical path
- The prefetch runs concurrently with `searchFiles` and `collectFiles`, hiding the git subprocess cost

## Test plan
- [x] `npm run lint` passes
- [x] `npm run test` — 1115/1115 tests pass
- [x] `node --run bench` shows improvement compared to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
