### PR TITLE
perf(core): Remove redundant minimatch and parallelize wrapper tokenization

### DIFF
--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -2,7 +2,6 @@ import type { Stats } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { type Options as GlobbyOptions, globby } from 'globby';
-import { minimatch } from 'minimatch';
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { defaultIgnoreList } from '../../config/defaultIgnore.js';
 import { RepomixError } from '../../shared/errorHandle.js';
@@ -16,11 +15,7 @@ export interface FileSearchResult {
   emptyDirPaths: string[];
 }
 
-const findEmptyDirectories = async (
-  rootDir: string,
-  directories: string[],
-  ignorePatterns: string[],
-): Promise<string[]> => {
+const findEmptyDirectories = async (rootDir: string, directories: string[]): Promise<string[]> => {
   const emptyDirs: string[] = [];
 
   for (const dir of directories) {
@@ -30,12 +25,7 @@ const findEmptyDirectories = async (
       const hasVisibleContents = entries.some((entry) => !entry.startsWith('.'));
 
       if (!hasVisibleContents) {
-        // This checks if the directory itself matches any ignore patterns
-        const shouldIgnore = ignorePatterns.some((pattern) => minimatch(dir, pattern) || minimatch(`${dir}/`, pattern));
-
-        if (!shouldIgnore) {
-          emptyDirs.push(dir);
-        }
+        emptyDirs.push(dir);
       }
     } catch (error) {
       logger.debug(`Error checking directory ${dir}:`, error);
@@ -221,7 +211,7 @@ export const searchFiles = async (
       logger.debug(`[empty dirs] Found ${directories.length} directories in ${emptyDirElapsedTime}ms`);
 
       const filterStartTime = Date.now();
-      emptyDirPaths = await findEmptyDirectories(rootDir, directories, adjustedIgnorePatterns);
+      emptyDirPaths = await findEmptyDirectories(rootDir, directories);
       const filterTime = Date.now() - filterStartTime;
       logger.debug(`[empty dirs] Filtered to ${emptyDirPaths.length} empty directories in ${filterTime}ms`);
     }

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -15,6 +15,9 @@ export interface FileSearchResult {
   emptyDirPaths: string[];
 }
 
+// No per-directory ignore-pattern check is needed here. The `directories` array
+// comes from globby with the same `ignore` patterns (e.g. `dist/**`), which
+// excludes both the directory contents AND the directory entry itself.
 const findEmptyDirectories = async (rootDir: string, directories: string[]): Promise<string[]> => {
   const emptyDirs: string[] = [];
 

--- a/src/core/metrics/calculateMetrics.ts
+++ b/src/core/metrics/calculateMetrics.ts
@@ -157,13 +157,14 @@ export const calculateMetrics = async (
     const outputMetricsPromise: Promise<number[]> =
       outputWrapper !== null
         ? (async () => {
-            const allFileMetrics = await fileMetricsPromise;
-            const fileTokensSum = allFileMetrics.reduce((sum, f) => sum + f.tokenCount, 0);
-            // Tokenize only the wrapper, not the ~4 MB output.
-            const wrapperTokens = await runTokenCount(taskRunner, {
+            // Dispatch wrapper tokenization immediately — a worker may already be
+            // idle while file metrics batches still occupy the other workers.
+            const wrapperTokensPromise = runTokenCount(taskRunner, {
               content: outputWrapper,
               encoding: config.tokenCount.encoding,
             });
+            const [allFileMetrics, wrapperTokens] = await Promise.all([fileMetricsPromise, wrapperTokensPromise]);
+            const fileTokensSum = allFileMetrics.reduce((sum, f) => sum + f.tokenCount, 0);
             logger.trace(
               `Fast-path output tokens: files=${fileTokensSum}, wrapper=${wrapperTokens} (${outputWrapper.length} chars)`,
             );


### PR DESCRIPTION
## Summary
- **Remove redundant minimatch check from `findEmptyDirectories`**: The directories were already filtered by globby's `ignore` option and `.gitignore`/`.repomixignore` patterns. The per-directory `minimatch()` re-check was redundant and created hundreds of `Minimatch` objects per run, adding ~7ms of module load cost
- **Parallelize wrapper tokenization with file metrics**: Dispatch wrapper tokenization immediately via `Promise.all` instead of waiting for file metrics to complete first, allowing an idle worker to process the wrapper concurrently

## Test plan
- [x] `npm run lint` passes
- [x] `npm run test` — 1115/1115 tests pass
- [x] `node --run bench` shows improvement compared to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
