### PR TITLE
perf(core): Replace synchronous lstatSync loop with concurrent async lstat

### DIFF
--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -1,6 +1,5 @@
 import { execFileSync } from 'node:child_process';
 import type { Stats } from 'node:fs';
-import { lstatSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { type Options as GlobbyOptions, globby } from 'globby';
@@ -130,16 +129,27 @@ const searchFilesGitFastPath = async (
   let files = [...new Set(stdout.split('\0').filter(Boolean))];
   logger.trace(`git ls-files returned ${files.length} files`);
 
-  // Filter out symlinks and non-regular files.
-  // globby with followSymbolicLinks:false + onlyFiles:true uses lstat,
-  // which reports symlinks as non-files.
-  files = files.filter((f) => {
-    try {
-      return lstatSync(path.join(rootDir, f)).isFile();
-    } catch {
-      return false;
-    }
-  });
+  // Filter out symlinks and non-regular files to match globby's behavior
+  // (followSymbolicLinks:false + onlyFiles:true reports symlinks as non-files).
+  // Uses concurrent async lstat in batches to avoid blocking the event loop
+  // with 1000+ sequential synchronous syscalls.
+  const LSTAT_BATCH = 512;
+  const isFileResults: boolean[] = [];
+  for (let i = 0; i < files.length; i += LSTAT_BATCH) {
+    const batch = files.slice(i, i + LSTAT_BATCH);
+    const results = await Promise.all(
+      batch.map(async (f) => {
+        try {
+          const stat = await fs.lstat(path.join(rootDir, f));
+          return stat.isFile();
+        } catch {
+          return false;
+        }
+      }),
+    );
+    isFileResults.push(...results);
+  }
+  files = files.filter((_, i) => isFileResults[i]);
 
   // Build an ignore filter combining default + custom patterns and
   // patterns from .repomixignore / .ignore files.

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -1,7 +1,11 @@
+import { execFileSync } from 'node:child_process';
 import type { Stats } from 'node:fs';
+import { lstatSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { type Options as GlobbyOptions, globby } from 'globby';
+import ignore from 'ignore';
+import { Minimatch } from 'minimatch';
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { defaultIgnoreList } from '../../config/defaultIgnore.js';
 import { RepomixError } from '../../shared/errorHandle.js';
@@ -85,6 +89,109 @@ export const normalizeGlobPattern = (pattern: string): string => {
   return pattern;
 };
 
+/**
+ * Fast file enumeration using `git ls-files` for git repositories.
+ *
+ * `git ls-files --cached --others --exclude-standard` reads from the
+ * pre-built git index (~5ms) instead of walking the filesystem (~250ms
+ * with globby). The result is then post-filtered through the `ignore`
+ * package (for default/custom/repomixignore patterns) and `picomatch`
+ * (for include patterns) to produce the same file set as globby.
+ *
+ * Returns `null` when the fast path is not applicable (not a git repo,
+ * `useGitignore` disabled, or git command failure), signalling the
+ * caller to fall back to globby.
+ */
+const searchFilesGitFastPath = async (
+  rootDir: string,
+  includePatterns: string[],
+  adjustedIgnorePatterns: string[],
+  ignoreFilePatterns: string[],
+): Promise<string[] | null> => {
+  // Run git ls-files to get all non-gitignored files.
+  // --cached: tracked files in the index
+  // --others: untracked files not in .gitignore
+  // --exclude-standard: apply .gitignore + .git/info/exclude + global gitignore
+  // -z: NUL-separated output (handles filenames with special chars)
+  let stdout: string;
+  try {
+    stdout = execFileSync('git', ['ls-files', '--cached', '--others', '--exclude-standard', '-z'], {
+      cwd: rootDir,
+      maxBuffer: 100 * 1024 * 1024,
+      encoding: 'utf-8',
+    });
+  } catch {
+    logger.trace('git ls-files failed, falling back to globby');
+    return null;
+  }
+
+  // Deduplicate: git ls-files can list a file multiple times during
+  // merge conflicts (one entry per conflict stage).
+  let files = [...new Set(stdout.split('\0').filter(Boolean))];
+  logger.trace(`git ls-files returned ${files.length} files`);
+
+  // Filter out symlinks and non-regular files.
+  // globby with followSymbolicLinks:false + onlyFiles:true uses lstat,
+  // which reports symlinks as non-files.
+  files = files.filter((f) => {
+    try {
+      return lstatSync(path.join(rootDir, f)).isFile();
+    } catch {
+      return false;
+    }
+  });
+
+  // Build an ignore filter combining default + custom patterns and
+  // patterns from .repomixignore / .ignore files.
+  const ig = ignore();
+  ig.add(adjustedIgnorePatterns);
+
+  // Read ignore file patterns (e.g., **/.repomixignore, **/.ignore).
+  // Find matching files from the git output, read their patterns,
+  // and apply them scoped to the file's directory.
+  for (const filePattern of ignoreFilePatterns) {
+    const fileName = filePattern.replace(/^\*\*\//, '');
+    const matchingFiles = files.filter((f) => f === fileName || f.endsWith(`/${fileName}`));
+
+    for (const ignoreFile of matchingFiles) {
+      try {
+        const content = await fs.readFile(path.join(rootDir, ignoreFile), 'utf-8');
+        const patterns = parseIgnoreContent(content);
+        const dir = path.dirname(ignoreFile);
+
+        if (dir === '.') {
+          // Root-level ignore file: patterns apply from root
+          ig.add(patterns);
+        } else {
+          // Nested ignore file: scope patterns to its directory.
+          // Prefix each pattern with the directory so the global
+          // ignore instance checks correctly against root-relative paths.
+          ig.add(
+            patterns.map((p) => {
+              if (p.startsWith('!')) return `!${dir}/${p.slice(1)}`;
+              if (p.startsWith('/')) return `${dir}${p}`;
+              return `${dir}/${p}`;
+            }),
+          );
+        }
+      } catch {
+        logger.trace(`Could not read ignore file: ${ignoreFile}`);
+      }
+    }
+  }
+
+  files = ig.filter(files);
+
+  // Apply include patterns (minimatch, same glob semantics as globby)
+  const isDefaultInclude = includePatterns.length === 1 && includePatterns[0] === '**/*';
+  if (!isDefaultInclude && includePatterns.length > 0) {
+    const matchers = includePatterns.map((p) => new Minimatch(p, { dot: true }));
+    files = files.filter((f) => matchers.some((m) => m.match(f)));
+  }
+
+  return files;
+};
+
 // Get all file paths considering the config
 export const searchFiles = async (
   rootDir: string,
@@ -139,7 +246,10 @@ export const searchFiles = async (
   }
 
   try {
-    const { adjustedIgnorePatterns, ignoreFilePatterns } = await prepareIgnoreContext(rootDir, config);
+    const { adjustedIgnorePatterns, rawIgnorePatterns, ignoreFilePatterns } = await prepareIgnoreContext(
+      rootDir,
+      config,
+    );
 
     logger.trace('Ignore patterns:', adjustedIgnorePatterns);
     logger.trace('Ignore file patterns:', ignoreFilePatterns);
@@ -179,26 +289,50 @@ export const searchFiles = async (
     logger.trace('Ignore patterns:', adjustedIgnorePatterns);
     logger.trace('Ignore file patterns (for globby):', ignoreFilePatterns);
 
-    logger.debug('[globby] Starting file search...');
-    const globbyStartTime = Date.now();
+    // Try the git ls-files fast path first. It reads from the pre-built git
+    // index (~5ms) instead of walking the filesystem (~250ms with globby).
+    // Falls back to globby when:
+    // - not in a git repo
+    // - useGitignore is disabled (git ls-files relies on .gitignore)
+    // - explicit files are provided (stdin mode uses exact paths)
+    // - git command fails for any reason
+    const canUseGitFastPath = config.ignore.useGitignore && !explicitFiles;
+    let filePaths: string[] | null = null;
 
-    const filePaths = await globby(includePatterns, {
-      ...createBaseGlobbyOptions(rootDir, config, adjustedIgnorePatterns, ignoreFilePatterns),
-      onlyFiles: true,
-    }).catch((error: unknown) => {
-      // Handle EPERM errors specifically
-      const code = (error as NodeJS.ErrnoException | { code?: string })?.code;
-      if (code === 'EPERM' || code === 'EACCES') {
-        throw new PermissionError(
-          `Permission denied while scanning directory. Please check folder access permissions for your terminal app. path: ${rootDir}`,
-          rootDir,
-        );
+    if (canUseGitFastPath) {
+      const gitStartTime = Date.now();
+      // Use raw (unescaped) include patterns for the git fast path.
+      // escapeGlobPattern transforms `src/(foo)` → `src/\(foo\)` for globby,
+      // but Minimatch needs literal patterns that match actual file paths.
+      const rawIncludePatterns = config.include.length > 0 ? config.include : ['**/*'];
+      filePaths = await searchFilesGitFastPath(rootDir, rawIncludePatterns, rawIgnorePatterns, ignoreFilePatterns);
+      if (filePaths !== null) {
+        const gitElapsedTime = Date.now() - gitStartTime;
+        logger.debug(`[git ls-files] Completed in ${gitElapsedTime}ms, found ${filePaths.length} files`);
       }
-      throw error;
-    });
+    }
 
-    const globbyElapsedTime = Date.now() - globbyStartTime;
-    logger.debug(`[globby] Completed in ${globbyElapsedTime}ms, found ${filePaths.length} files`);
+    if (filePaths === null) {
+      logger.debug('[globby] Starting file search...');
+      const globbyStartTime = Date.now();
+
+      filePaths = await globby(includePatterns, {
+        ...createBaseGlobbyOptions(rootDir, config, adjustedIgnorePatterns, ignoreFilePatterns),
+        onlyFiles: true,
+      }).catch((error: unknown) => {
+        const code = (error as NodeJS.ErrnoException | { code?: string })?.code;
+        if (code === 'EPERM' || code === 'EACCES') {
+          throw new PermissionError(
+            `Permission denied while scanning directory. Please check folder access permissions for your terminal app. path: ${rootDir}`,
+            rootDir,
+          );
+        }
+        throw error;
+      });
+
+      const globbyElapsedTime = Date.now() - globbyStartTime;
+      logger.debug(`[globby] Completed in ${globbyElapsedTime}ms, found ${filePaths.length} files`);
+    }
 
     let emptyDirPaths: string[] = [];
     if (config.output.includeEmptyDirectories) {
@@ -265,7 +399,11 @@ export const parseIgnoreContent = (content: string): string[] => {
 const prepareIgnoreContext = async (
   rootDir: string,
   config: RepomixConfigMerged,
-): Promise<{ adjustedIgnorePatterns: string[]; ignoreFilePatterns: string[] }> => {
+): Promise<{
+  adjustedIgnorePatterns: string[];
+  rawIgnorePatterns: string[];
+  ignoreFilePatterns: string[];
+}> => {
   const [ignorePatterns, ignoreFilePatterns] = await Promise.all([
     getIgnorePatterns(rootDir, config),
     getIgnoreFilePatterns(config),
@@ -289,7 +427,21 @@ const prepareIgnoreContext = async (
     }
   }
 
-  return { adjustedIgnorePatterns, ignoreFilePatterns };
+  // Raw (un-normalized) patterns are used by the git fast path where
+  // the `ignore` package applies gitignore semantics directly. The
+  // normalizeGlobPattern transform (e.g., `**/foo` → `**/foo/**`) is
+  // designed for globby and would break `ignore`-based matching for
+  // file-level patterns like `**/package-lock.json`.
+  const rawIgnorePatterns = [...ignorePatterns];
+  if (isWorktree) {
+    const gitIndex = rawIgnorePatterns.indexOf('.git/**');
+    if (gitIndex !== -1) {
+      rawIgnorePatterns.splice(gitIndex, 1);
+      rawIgnorePatterns.push('.git');
+    }
+  }
+
+  return { adjustedIgnorePatterns, rawIgnorePatterns, ignoreFilePatterns };
 };
 
 /**


### PR DESCRIPTION
## Summary

In the git fast-path file search (\`searchFilesGitFastPath\`), replace the synchronous \`lstatSync\` filter loop with batched concurrent \`fs.lstat\` calls.

**Note:** This PR includes the prerequisite commit \"Use git ls-files for fast file search in git repositories\" (#29ac8820) which introduces the git fast-path that this optimization targets. If that commit is merged separately first, this PR can be rebased to a single commit.

## Problem

\`searchFilesGitFastPath\` filters symlinks/non-regular files by calling \`lstatSync\` once per file returned by \`git ls-files\`. For a ~1000-file repo this means ~1000 sequential blocking syscalls on the main thread, each costing ~0.05-0.1ms. The total wall time is 50-100ms of event-loop blocking that prevents concurrent async work (metrics warmup, git diff/log subprocesses) from making progress.

## Solution

Replace the synchronous filter with batched \`Promise.all\` over async \`fs.lstat\` calls (512 files per batch). The kernel can batch the stat syscalls and the event loop remains free for other work during I/O wait. Batching keeps concurrent operations bounded for very large repos.

## Benchmark

Original measurement (20 interleaved A/B runs on \`node bin/repomix.cjs\` over the repomix repo, ~1020 files):

| Metric       | Baseline | This patch | Delta           |
|--------------|----------|------------|-----------------|
| median       | 2545 ms  | 2445 ms    | **-100 ms (-3.9%)** |
| trimmed mean | 2564 ms  | 2454 ms    | **-110 ms (-4.3%)** |

Note: Independent re-measurement on a different machine showed neutral results (round 1 +8ms, round 2 -5ms with σ=10-13ms noise). Effect likely depends on filesystem and CPU load.

## Checklist

- [x] Run \`npm run test\` (1115 passed)
- [x] Run \`npm run lint\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
