### PR TITLE
perf(security): Pre-start security worker pool to overlap initialization with file pipeline

### DIFF
--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -14,7 +14,11 @@ import { getGitLogs } from './git/gitLogHandle.js';
 import { calculateMetrics, createMetricsTaskRunner } from './metrics/calculateMetrics.js';
 import { prefetchSortData, sortOutputFiles } from './output/outputSort.js';
 import { produceOutput } from './packager/produceOutput.js';
-import { type SuspiciousFileResult, warmupSecurityWorkerPool } from './security/securityCheck.js';
+import {
+  cleanupWarmupSecurityWorkerPool,
+  type SuspiciousFileResult,
+  warmupSecurityWorkerPool,
+} from './security/securityCheck.js';
 import { validateFileSafety } from './security/validateFileSafety.js';
 import type { PackSkillParams } from './skill/packSkill.js';
 
@@ -87,9 +91,15 @@ export const pack = async (
 
   // Pre-start the security worker pool so secretlint module loading (~100-150ms)
   // overlaps with file search, collection, and processing instead of running
-  // sequentially after file collection completes.
+  // sequentially after file collection completes. Wrapped in try/catch so a
+  // worker spawn failure does not abort pack() — runSecurityCheck will fall
+  // back to on-demand initialization.
   if (config.security.enableSecurityCheck && !overrideDeps.validateFileSafety) {
-    warmupSecurityWorkerPool();
+    try {
+      warmupSecurityWorkerPool();
+    } catch (error) {
+      logger.trace('Failed to warmup security worker pool:', error);
+    }
   }
 
   progressCallback('Searching for files...');
@@ -268,5 +278,8 @@ export const pack = async (
   } finally {
     await metricsWarmupPromise.catch(() => {});
     await metricsTaskRunner.cleanup();
+    // Drain any warmed security pool that wasn't consumed (e.g. error before
+    // runSecurityCheck, or empty input that triggered its early return).
+    await cleanupWarmupSecurityWorkerPool().catch(() => {});
   }
 };

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -14,7 +14,7 @@ import { getGitLogs } from './git/gitLogHandle.js';
 import { calculateMetrics, createMetricsTaskRunner } from './metrics/calculateMetrics.js';
 import { prefetchSortData, sortOutputFiles } from './output/outputSort.js';
 import { produceOutput } from './packager/produceOutput.js';
-import type { SuspiciousFileResult } from './security/securityCheck.js';
+import { type SuspiciousFileResult, warmupSecurityWorkerPool } from './security/securityCheck.js';
 import { validateFileSafety } from './security/validateFileSafety.js';
 import type { PackSkillParams } from './skill/packSkill.js';
 
@@ -84,6 +84,13 @@ export const pack = async (
   const sortDataPromise = deps.prefetchSortData(config).catch((error) => {
     logger.trace('Failed to prefetch sort data:', error);
   });
+
+  // Pre-start the security worker pool so secretlint module loading (~100-150ms)
+  // overlaps with file search, collection, and processing instead of running
+  // sequentially after file collection completes.
+  if (config.security.enableSecurityCheck && !overrideDeps.validateFileSafety) {
+    warmupSecurityWorkerPool();
+  }
 
   progressCallback('Searching for files...');
   const searchResultsByDir = await withMemoryLogging('Search Files', async () =>

--- a/src/core/security/securityCheck.ts
+++ b/src/core/security/securityCheck.ts
@@ -40,6 +40,11 @@ export const warmupSecurityWorkerPool = (
     getProcessConcurrency: defaultGetProcessConcurrency,
   },
 ) => {
+  // Guard against double-warmup so an existing pool is not orphaned by
+  // overlapping pack() invocations or repeated calls.
+  if (_warmupTaskRunner) {
+    return;
+  }
   // Match the worker count used by runSecurityCheck so the warmed-up pool is
   // sized correctly for actual use.
   const maxSecurityWorkers = Math.min(2, deps.getProcessConcurrency());
@@ -49,6 +54,17 @@ export const warmupSecurityWorkerPool = (
     runtime: 'worker_threads',
     maxWorkerThreads: maxSecurityWorkers,
   });
+};
+
+// Drain any warmed-up pool that was never consumed by runSecurityCheck (e.g. when
+// pack() throws before reaching the security check, or when there are no items to
+// scan and runSecurityCheck returns early). Safe to call when no pool is warmed.
+export const cleanupWarmupSecurityWorkerPool = async () => {
+  const runner = _warmupTaskRunner;
+  _warmupTaskRunner = null;
+  if (runner) {
+    await runner.cleanup();
+  }
 };
 
 export const runSecurityCheck = async (
@@ -105,6 +121,8 @@ export const runSecurityCheck = async (
   const totalItems = allItems.length;
 
   if (totalItems === 0) {
+    // Drain any pre-warmed pool so its worker threads don't keep the process alive.
+    await cleanupWarmupSecurityWorkerPool();
     return [];
   }
 

--- a/src/core/security/securityCheck.ts
+++ b/src/core/security/securityCheck.ts
@@ -27,6 +27,30 @@ export interface SuspiciousFileResult {
 // is disabled, and needs a smaller batch size to avoid one batch monopolizing a worker.)
 const BATCH_SIZE = 50;
 
+type SecurityCheckTaskRunner = ReturnType<typeof initTaskRunner<SecurityCheckTask, (SuspiciousFileResult | null)[]>>;
+
+// Module-level slot for a pre-started worker pool. When non-null, the pool is
+// already initializing in a worker thread (loading secretlint, etc.) so that
+// subsequent runSecurityCheck calls can skip the pool startup latency.
+let _warmupTaskRunner: SecurityCheckTaskRunner | null = null;
+
+export const warmupSecurityWorkerPool = (
+  deps = {
+    initTaskRunner,
+    getProcessConcurrency: defaultGetProcessConcurrency,
+  },
+) => {
+  // Match the worker count used by runSecurityCheck so the warmed-up pool is
+  // sized correctly for actual use.
+  const maxSecurityWorkers = Math.min(2, deps.getProcessConcurrency());
+  _warmupTaskRunner = deps.initTaskRunner<SecurityCheckTask, (SuspiciousFileResult | null)[]>({
+    numOfTasks: Number.MAX_SAFE_INTEGER,
+    workerType: 'securityCheck',
+    runtime: 'worker_threads',
+    maxWorkerThreads: maxSecurityWorkers,
+  });
+};
+
 export const runSecurityCheck = async (
   rawFiles: RawFile[],
   progressCallback: RepomixProgressCallback = () => {},
@@ -89,13 +113,19 @@ export const runSecurityCheck = async (
   // so 2 workers provide sufficient parallelism even for large repos (1000 files = 20 batches).
   const maxSecurityWorkers = Math.min(2, deps.getProcessConcurrency());
 
-  // numOfTasks uses totalItems (not batches.length) to avoid under-sizing the pool.
-  const taskRunner = deps.initTaskRunner<SecurityCheckTask, (SuspiciousFileResult | null)[]>({
-    numOfTasks: totalItems,
-    workerType: 'securityCheck',
-    runtime: 'worker_threads',
-    maxWorkerThreads: maxSecurityWorkers,
-  });
+  // Reuse the pre-started worker pool when available (warmupSecurityWorkerPool).
+  // This skips the secretlint module load latency on the critical path.
+  let taskRunner = _warmupTaskRunner;
+  _warmupTaskRunner = null;
+  if (!taskRunner) {
+    // numOfTasks uses totalItems (not batches.length) to avoid under-sizing the pool.
+    taskRunner = deps.initTaskRunner<SecurityCheckTask, (SuspiciousFileResult | null)[]>({
+      numOfTasks: totalItems,
+      workerType: 'securityCheck',
+      runtime: 'worker_threads',
+      maxWorkerThreads: maxSecurityWorkers,
+    });
+  }
 
   // Split items into batches to reduce IPC round-trips
   const batches: SecurityCheckItem[][] = [];

--- a/tests/core/security/securityCheck.test.ts
+++ b/tests/core/security/securityCheck.test.ts
@@ -1,10 +1,14 @@
 // src/core/security/securityCheck.test.ts
 
 import pc from 'picocolors';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { RawFile } from '../../../src/core/file/fileTypes.js';
 import type { GitDiffResult } from '../../../src/core/git/gitDiffHandle.js';
-import { runSecurityCheck } from '../../../src/core/security/securityCheck.js';
+import {
+  cleanupWarmupSecurityWorkerPool,
+  runSecurityCheck,
+  warmupSecurityWorkerPool,
+} from '../../../src/core/security/securityCheck.js';
 import type { SecurityCheckTask } from '../../../src/core/security/workers/securityCheckWorker.js';
 import securityCheckWorker from '../../../src/core/security/workers/securityCheckWorker.js';
 import { logger, repomixLogLevels } from '../../../src/shared/logger.js';
@@ -54,6 +58,11 @@ const mockInitTaskRunner = <T, R>(_options: WorkerOptions) => {
 };
 
 describe('runSecurityCheck', () => {
+  // Ensure module-level warmup slot doesn't leak between tests.
+  afterEach(async () => {
+    await cleanupWarmupSecurityWorkerPool();
+  });
+
   it('should identify files with security issues', async () => {
     const result = await runSecurityCheck(mockFiles, () => {}, undefined, undefined, {
       initTaskRunner: mockInitTaskRunner,
@@ -209,6 +218,88 @@ describe('runSecurityCheck', () => {
 
     // With batch size 50 and 3 items (2 files + 1 git diff), all in a single batch
     expect(progressCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reuse the pre-warmed task runner exactly once', async () => {
+    const cleanup = vi.fn();
+    const run = vi.fn().mockImplementation(async (task: SecurityCheckTask) => {
+      return await securityCheckWorker(task);
+    });
+    const initSpy = vi.fn(() => ({ run, cleanup }));
+
+    warmupSecurityWorkerPool({
+      initTaskRunner: initSpy as unknown as typeof mockInitTaskRunner,
+      getProcessConcurrency: mockGetProcessConcurrency,
+    });
+    expect(initSpy).toHaveBeenCalledTimes(1);
+
+    const fallbackInit = vi.fn(mockInitTaskRunner);
+    await runSecurityCheck(mockFiles, () => {}, undefined, undefined, {
+      initTaskRunner: fallbackInit as unknown as typeof mockInitTaskRunner,
+      getProcessConcurrency: mockGetProcessConcurrency,
+    });
+
+    // Warmed runner consumed; fallback initTaskRunner not invoked
+    expect(fallbackInit).not.toHaveBeenCalled();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+
+    // Second call falls through to the provided init since warmup slot was consumed
+    await runSecurityCheck(mockFiles, () => {}, undefined, undefined, {
+      initTaskRunner: fallbackInit as unknown as typeof mockInitTaskRunner,
+      getProcessConcurrency: mockGetProcessConcurrency,
+    });
+    expect(fallbackInit).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not overwrite an existing warmed runner', async () => {
+    const initSpy = vi.fn(mockInitTaskRunner);
+
+    warmupSecurityWorkerPool({
+      initTaskRunner: initSpy as unknown as typeof mockInitTaskRunner,
+      getProcessConcurrency: mockGetProcessConcurrency,
+    });
+    warmupSecurityWorkerPool({
+      initTaskRunner: initSpy as unknown as typeof mockInitTaskRunner,
+      getProcessConcurrency: mockGetProcessConcurrency,
+    });
+
+    expect(initSpy).toHaveBeenCalledTimes(1);
+    await cleanupWarmupSecurityWorkerPool();
+  });
+
+  it('should clean up warmed runner on empty input early return', async () => {
+    const cleanup = vi.fn();
+    const initSpy = vi.fn(() => ({ run: vi.fn(), cleanup }));
+
+    warmupSecurityWorkerPool({
+      initTaskRunner: initSpy as unknown as typeof mockInitTaskRunner,
+      getProcessConcurrency: mockGetProcessConcurrency,
+    });
+
+    const result = await runSecurityCheck([], () => {}, undefined, undefined, {
+      initTaskRunner: mockInitTaskRunner,
+      getProcessConcurrency: mockGetProcessConcurrency,
+    });
+
+    expect(result).toEqual([]);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleanupWarmupSecurityWorkerPool drains a warmed runner and is a no-op otherwise', async () => {
+    const cleanup = vi.fn();
+    const initSpy = vi.fn(() => ({ run: vi.fn(), cleanup }));
+
+    warmupSecurityWorkerPool({
+      initTaskRunner: initSpy as unknown as typeof mockInitTaskRunner,
+      getProcessConcurrency: mockGetProcessConcurrency,
+    });
+
+    await cleanupWarmupSecurityWorkerPool();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+
+    // Calling again with nothing warmed must not throw.
+    await expect(cleanupWarmupSecurityWorkerPool()).resolves.toBeUndefined();
+    expect(cleanup).toHaveBeenCalledTimes(1);
   });
 
   it('should handle gitDiffResult with no diff content', async () => {


### PR DESCRIPTION
## Summary

Start the security check worker pool at the beginning of `pack()`, so secretlint module loading (~100-150ms) runs concurrently with file search, collection, and processing. Previously the worker pool was created only when the security check began, adding its initialization time to the critical path after file collection completed.

The warmup uses a module-level slot (`_warmupTaskRunner`) consumed by `runSecurityCheck` on first call. Tests that override `validateFileSafety` skip the warmup to avoid spawning real workers in the test environment.

## Implementation note

This is adapted from the original perf branch commit (which used `await deps.initTaskRunner(...)` because `initTaskRunner` was async there). On main, `initTaskRunner` is still synchronous, so the warmup stores the runner directly. The semantic benefit remains: starting the worker thread early means secretlint module loading inside the worker runs concurrently with the main thread's file pipeline.

The warmup pool size matches `runSecurityCheck`'s `Math.min(2, getProcessConcurrency())`.

## Benchmark

Original measurement (25 runs each, 2025-file repo):

| Metric | Before   | After    | Delta              |
|--------|----------|----------|--------------------|
| Median | 1196ms   | 1138ms   | **-58ms (-4.8%)** |
| Mean   | 1197ms   | 1134ms   | **-63ms (-5.3%)** |
| P90    | 1237ms   | 1178ms   | **-59ms (-4.8%)** |

Independent re-measurement (3 rounds, A/B interleaved on smaller repo):

| Round | main | branch | Δ |
|-------|------|--------|---|
| 1 | 375.4ms ± 5.0 | 371.5ms ± 2.5 | -3.9ms |
| 2 | 374.2ms ± 5.2 | 373.6ms ± 4.5 | -0.6ms |
| 3 | 368.9ms ± 2.9 | 372.5ms ± 3.1 | +3.6ms |
| **avg** | **372.8** | **372.5** | **-0.3ms** |

The independent measurement effect is much smaller on the repomix self-pack (~1000 files) than on the original 2025-file benchmark — likely because secretlint module load amortizes against a larger file count. Effect should be most pronounced on larger repos.

## Checklist

- [x] Run \`npm run test\` (1115 passed)
- [x] Run \`npm run lint\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
