### PR TITLE
perf(config): Migrate configSchema from zod to valibot (experimental)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "@types/node": "^24.12.2",
         "@types/strip-comments": "^2.0.4",
         "@typescript/native-preview": "^7.0.0-dev.20260410.1",
+        "@valibot/to-json-schema": "^1.6.0",
         "@vitest/coverage-v8": "^4.1.4",
         "@xmldom/xmldom": "^0.9.9",
         "git-up": "^8.1.1",
@@ -2012,6 +2013,16 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@valibot/to-json-schema": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@valibot/to-json-schema/-/to-json-schema-1.6.0.tgz",
+      "integrity": "sha512-d6rYyK5KVa2XdqamWgZ4/Nr+cXhxjy7lmpe6Iajw15J/jmU+gyxl2IEd1Otg1d7Rl3gOQL5reulnSypzBtYy1A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "valibot": "^1.3.0"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "tar": "^7.5.13",
         "tinyclip": "^0.1.12",
         "tinypool": "^2.1.0",
+        "valibot": "^1.3.1",
         "web-tree-sitter": "^0.26.8",
         "zod": "^4.3.6"
       },
@@ -229,9 +230,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -249,9 +247,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -269,9 +264,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -289,9 +281,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1114,9 +1103,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1134,9 +1120,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1154,9 +1137,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1174,9 +1154,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1194,9 +1171,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1214,9 +1188,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1234,9 +1205,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1254,9 +1222,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5322,7 +5287,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -5372,6 +5337,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.3.1.tgz",
+      "integrity": "sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "tar": "^7.5.13",
     "tinyclip": "^0.1.12",
     "tinypool": "^2.1.0",
+    "valibot": "^1.3.1",
     "web-tree-sitter": "^0.26.8",
     "zod": "^4.3.6"
   },

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "@types/node": "^24.12.2",
     "@types/strip-comments": "^2.0.4",
     "@typescript/native-preview": "^7.0.0-dev.20260410.1",
+    "@valibot/to-json-schema": "^1.6.0",
     "@vitest/coverage-v8": "^4.1.4",
     "@xmldom/xmldom": "^0.9.9",
     "git-up": "^8.1.1",

--- a/scripts/memory/package-lock.json
+++ b/scripts/memory/package-lock.json
@@ -21,6 +21,7 @@
       }
     },
     "../..": {
+      "name": "repomix",
       "version": "1.13.1",
       "license": "MIT",
       "dependencies": {
@@ -48,6 +49,7 @@
         "tar": "^7.5.13",
         "tinyclip": "^0.1.12",
         "tinypool": "^2.1.0",
+        "valibot": "^1.3.1",
         "web-tree-sitter": "^0.26.8",
         "zod": "^4.3.6"
       },
@@ -60,6 +62,7 @@
         "@types/node": "^24.12.2",
         "@types/strip-comments": "^2.0.4",
         "@typescript/native-preview": "^7.0.0-dev.20260410.1",
+        "@valibot/to-json-schema": "^1.6.0",
         "@vitest/coverage-v8": "^4.1.4",
         "@xmldom/xmldom": "^0.9.9",
         "git-up": "^8.1.1",

--- a/scripts/memory/tsconfig.json
+++ b/scripts/memory/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
     "outDir": "./dist",
     "rootDir": "./src",

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import * as v from 'valibot';
 import { loadFileConfig, mergeConfigs } from '../../config/configLoad.js';
 import {
   type RepomixConfigCli,
@@ -10,7 +11,7 @@ import {
 import { readFilePathsFromStdin } from '../../core/file/fileStdin.js';
 import { type PackResult, pack } from '../../core/packager.js';
 import { generateDefaultSkillName } from '../../core/skill/skillUtils.js';
-import { RepomixError, rethrowValidationErrorIfZodError } from '../../shared/errorHandle.js';
+import { RepomixError, rethrowValidationErrorIfSchemaError } from '../../shared/errorHandle.js';
 import { logger } from '../../shared/logger.js';
 import { splitPatterns } from '../../shared/patternUtils.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
@@ -343,9 +344,9 @@ export const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
   }
 
   try {
-    return repomixConfigCliSchema.parse(cliConfig);
+    return v.parse(repomixConfigCliSchema, cliConfig);
   } catch (error) {
-    rethrowValidationErrorIfZodError(error, 'Invalid cli arguments');
+    rethrowValidationErrorIfSchemaError(error, 'Invalid cli arguments');
     throw error;
   }
 };

--- a/src/config/configLoad.ts
+++ b/src/config/configLoad.ts
@@ -3,7 +3,8 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import JSON5 from 'json5';
 import pc from 'picocolors';
-import { RepomixError, rethrowValidationErrorIfZodError } from '../shared/errorHandle.js';
+import * as v from 'valibot';
+import { RepomixError, rethrowValidationErrorIfSchemaError } from '../shared/errorHandle.js';
 import { logger } from '../shared/logger.js';
 import {
   defaultConfig,
@@ -149,7 +150,13 @@ const loadAndValidateConfig = async (
       case 'cjs': {
         // Use jiti for TypeScript and JavaScript files
         // This provides consistent behavior and avoids Node.js module cache issues
-        config = await deps.jitiImport(pathToFileURL(filePath).href);
+        const imported = await deps.jitiImport(pathToFileURL(filePath).href);
+        // jiti.import returns an ESM Module namespace for `export default {...}` even
+        // with `interopDefault: true`. Unwrap it so the schema sees the user's config.
+        config =
+          imported && typeof imported === 'object' && 'default' in imported
+            ? (imported as { default: unknown }).default
+            : imported;
         break;
       }
 
@@ -166,9 +173,9 @@ const loadAndValidateConfig = async (
         throw new RepomixError(`Unsupported config file format: ${filePath}`);
     }
 
-    return repomixConfigFileSchema.parse(config);
+    return v.parse(repomixConfigFileSchema, config);
   } catch (error) {
-    rethrowValidationErrorIfZodError(error, 'Invalid config schema');
+    rethrowValidationErrorIfSchemaError(error, 'Invalid config schema');
     if (error instanceof SyntaxError) {
       throw new RepomixError(`Invalid syntax in config file ${filePath}: ${error.message}`);
     }
@@ -247,9 +254,9 @@ export const mergeConfigs = (
   };
 
   try {
-    return repomixConfigMergedSchema.parse(mergedConfig);
+    return v.parse(repomixConfigMergedSchema, mergedConfig);
   } catch (error) {
-    rethrowValidationErrorIfZodError(error, 'Invalid merged config');
+    rethrowValidationErrorIfSchemaError(error, 'Invalid merged config');
     throw error;
   }
 };

--- a/src/config/configLoad.ts
+++ b/src/config/configLoad.ts
@@ -157,6 +157,9 @@ const loadAndValidateConfig = async (
         // (both ESM Module namespaces and jiti's TS interop). Unwrap only when
         // `default` is itself an object — this preserves a CJS config that
         // legitimately exports `{ default: 'plain', ...rest }` as-is.
+        // Known limitation: a CJS module exporting `{ default: { ... }, otherKey: ... }`
+        // would still be treated as an ESM wrapper and `otherKey` would be discarded.
+        // No known user hits this pattern; RepomixConfig has no `default` field.
         const defaultExport =
           imported && typeof imported === 'object' && 'default' in imported
             ? (imported as { default: unknown }).default

--- a/src/config/configLoad.ts
+++ b/src/config/configLoad.ts
@@ -151,12 +151,15 @@ const loadAndValidateConfig = async (
         // Use jiti for TypeScript and JavaScript files
         // This provides consistent behavior and avoids Node.js module cache issues
         const imported = await deps.jitiImport(pathToFileURL(filePath).href);
-        // jiti.import returns an ESM Module namespace for `export default {...}` even
-        // with `interopDefault: true`. Unwrap it so the schema sees the user's config.
-        config =
+        // jiti.import returns a `{ default: ... }` wrapper for `export default {...}`
+        // (both ESM Module namespaces and jiti's TS interop). Unwrap only when
+        // `default` is itself an object — this preserves a CJS config that
+        // legitimately exports `{ default: 'plain', ...rest }` as-is.
+        const defaultExport =
           imported && typeof imported === 'object' && 'default' in imported
             ? (imported as { default: unknown }).default
-            : imported;
+            : undefined;
+        config = defaultExport && typeof defaultExport === 'object' ? defaultExport : imported;
         break;
       }
 

--- a/src/config/configLoad.ts
+++ b/src/config/configLoad.ts
@@ -59,12 +59,14 @@ const findConfigFile = async (configPaths: string[], logPrefix: string): Promise
 
 // Default jiti import implementation for loading JS/TS config files
 // Lazy-loads jiti to avoid importing its heavy TypeScript toolchain
-// when using JSON/JSON5 config files or default config (the common case)
+// when using JSON/JSON5 config files or default config (the common case).
+// We deliberately do not pass `interopDefault`; the call site below handles
+// the ESM namespace `{ default: config }` unwrap explicitly so the behavior
+// is the same for .ts / .mts / .js / .mjs / .cjs inputs.
 const defaultJitiImport = async (fileUrl: string): Promise<unknown> => {
   const { createJiti } = await import('jiti');
   const jiti = createJiti(import.meta.url, {
     moduleCache: false, // Disable cache to ensure fresh config loads
-    interopDefault: true, // Automatically use default export
   });
   return await jiti.import(fileUrl);
 };

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -97,7 +97,7 @@ export const repomixConfigDefaultSchema = v.object({
     copyToClipboard: v.optional(v.boolean(), false),
     includeEmptyDirectories: v.optional(v.boolean()),
     includeFullDirectoryStructure: v.optional(v.boolean(), false),
-    splitOutput: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
+    splitOutput: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(Number.MAX_SAFE_INTEGER))),
     tokenCountTree: v.optional(v.union([v.boolean(), v.number(), v.string()]), false),
     git: v.object({
       sortByChanges: v.optional(v.boolean(), true),

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -40,7 +40,7 @@ export const repomixConfigBaseSchema = v.object({
       copyToClipboard: v.optional(v.boolean()),
       includeEmptyDirectories: v.optional(v.boolean()),
       includeFullDirectoryStructure: v.optional(v.boolean()),
-      splitOutput: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
+      splitOutput: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(Number.MAX_SAFE_INTEGER))),
       tokenCountTree: v.optional(v.union([v.boolean(), v.number(), v.string()])),
       git: v.optional(
         v.object({

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -138,7 +138,11 @@ export const repomixConfigCliSchema = v.intersect([
   }),
 ]);
 
-// Merged schema for all configurations
+// Merged schema for all configurations.
+// `v.intersect` is intentional: it layers the default schema (required fields
+// with applied defaults) over the file and CLI schemas (all fields optional).
+// Flattening to a single object via spread would silently demote the
+// required-with-default fields to optional and change merge semantics.
 export const repomixConfigMergedSchema = v.intersect([
   repomixConfigDefaultSchema,
   repomixConfigFileSchema,

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -1,9 +1,9 @@
-import { z } from 'zod';
+import * as v from 'valibot';
 import { TOKEN_ENCODINGS } from '../core/metrics/TokenCounter.js';
 
 // Output style enum
-export const repomixOutputStyleSchema = z.enum(['xml', 'markdown', 'json', 'plain']);
-export type RepomixOutputStyle = z.infer<typeof repomixOutputStyleSchema>;
+export const repomixOutputStyleSchema = v.picklist(['xml', 'markdown', 'json', 'plain']);
+export type RepomixOutputStyle = v.InferOutput<typeof repomixOutputStyleSchema>;
 
 // Default values map
 export const defaultFilePathMap: Record<RepomixOutputStyle, string> = {
@@ -14,115 +14,111 @@ export const defaultFilePathMap: Record<RepomixOutputStyle, string> = {
 } as const;
 
 // Base config schema
-export const repomixConfigBaseSchema = z.object({
-  $schema: z.string().optional(),
-  input: z
-    .object({
-      maxFileSize: z.number().optional(),
-    })
-    .optional(),
-  output: z
-    .object({
-      filePath: z.string().optional(),
-      style: repomixOutputStyleSchema.optional(),
-      parsableStyle: z.boolean().optional(),
-      headerText: z.string().optional(),
-      instructionFilePath: z.string().optional(),
-      fileSummary: z.boolean().optional(),
-      directoryStructure: z.boolean().optional(),
-      files: z.boolean().optional(),
-      removeComments: z.boolean().optional(),
-      removeEmptyLines: z.boolean().optional(),
-      compress: z.boolean().optional(),
-      topFilesLength: z.number().optional(),
-      showLineNumbers: z.boolean().optional(),
-      truncateBase64: z.boolean().optional(),
-      copyToClipboard: z.boolean().optional(),
-      includeEmptyDirectories: z.boolean().optional(),
-      includeFullDirectoryStructure: z.boolean().optional(),
-      splitOutput: z.number().int().min(1).optional(),
-      tokenCountTree: z.union([z.boolean(), z.number(), z.string()]).optional(),
-      git: z
-        .object({
-          sortByChanges: z.boolean().optional(),
-          sortByChangesMaxCommits: z.number().optional(),
-          includeDiffs: z.boolean().optional(),
-          includeLogs: z.boolean().optional(),
-          includeLogsCount: z.number().optional(),
-        })
-        .optional(),
-    })
-    .optional(),
-  include: z.array(z.string()).optional(),
-  ignore: z
-    .object({
-      useGitignore: z.boolean().optional(),
-      useDotIgnore: z.boolean().optional(),
-      useDefaultPatterns: z.boolean().optional(),
-      customPatterns: z.array(z.string()).optional(),
-    })
-    .optional(),
-  security: z
-    .object({
-      enableSecurityCheck: z.boolean().optional(),
-    })
-    .optional(),
-  tokenCount: z
-    .object({
-      encoding: z.string().optional(),
-    })
-    .optional(),
+export const repomixConfigBaseSchema = v.object({
+  $schema: v.optional(v.string()),
+  input: v.optional(
+    v.object({
+      maxFileSize: v.optional(v.number()),
+    }),
+  ),
+  output: v.optional(
+    v.object({
+      filePath: v.optional(v.string()),
+      style: v.optional(repomixOutputStyleSchema),
+      parsableStyle: v.optional(v.boolean()),
+      headerText: v.optional(v.string()),
+      instructionFilePath: v.optional(v.string()),
+      fileSummary: v.optional(v.boolean()),
+      directoryStructure: v.optional(v.boolean()),
+      files: v.optional(v.boolean()),
+      removeComments: v.optional(v.boolean()),
+      removeEmptyLines: v.optional(v.boolean()),
+      compress: v.optional(v.boolean()),
+      topFilesLength: v.optional(v.number()),
+      showLineNumbers: v.optional(v.boolean()),
+      truncateBase64: v.optional(v.boolean()),
+      copyToClipboard: v.optional(v.boolean()),
+      includeEmptyDirectories: v.optional(v.boolean()),
+      includeFullDirectoryStructure: v.optional(v.boolean()),
+      splitOutput: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
+      tokenCountTree: v.optional(v.union([v.boolean(), v.number(), v.string()])),
+      git: v.optional(
+        v.object({
+          sortByChanges: v.optional(v.boolean()),
+          sortByChangesMaxCommits: v.optional(v.number()),
+          includeDiffs: v.optional(v.boolean()),
+          includeLogs: v.optional(v.boolean()),
+          includeLogsCount: v.optional(v.number()),
+        }),
+      ),
+    }),
+  ),
+  include: v.optional(v.array(v.string())),
+  ignore: v.optional(
+    v.object({
+      useGitignore: v.optional(v.boolean()),
+      useDotIgnore: v.optional(v.boolean()),
+      useDefaultPatterns: v.optional(v.boolean()),
+      customPatterns: v.optional(v.array(v.string())),
+    }),
+  ),
+  security: v.optional(
+    v.object({
+      enableSecurityCheck: v.optional(v.boolean()),
+    }),
+  ),
+  tokenCount: v.optional(
+    v.object({
+      encoding: v.optional(v.string()),
+    }),
+  ),
 });
 
 // Default config schema with default values
-export const repomixConfigDefaultSchema = z.object({
-  input: z.object({
-    maxFileSize: z
-      .number()
-      .int()
-      .min(1)
-      .default(50 * 1024 * 1024), // Default: 50MB
+export const repomixConfigDefaultSchema = v.object({
+  input: v.object({
+    maxFileSize: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1)), 50 * 1024 * 1024), // Default: 50MB
   }),
-  output: z.object({
-    filePath: z.string().default(defaultFilePathMap.xml),
-    style: repomixOutputStyleSchema.default('xml'),
-    parsableStyle: z.boolean().default(false),
-    headerText: z.string().optional(),
-    instructionFilePath: z.string().optional(),
-    fileSummary: z.boolean().default(true),
-    directoryStructure: z.boolean().default(true),
-    files: z.boolean().default(true),
-    removeComments: z.boolean().default(false),
-    removeEmptyLines: z.boolean().default(false),
-    compress: z.boolean().default(false),
-    topFilesLength: z.number().int().min(0).default(5),
-    showLineNumbers: z.boolean().default(false),
-    truncateBase64: z.boolean().default(false),
-    copyToClipboard: z.boolean().default(false),
-    includeEmptyDirectories: z.boolean().optional(),
-    includeFullDirectoryStructure: z.boolean().default(false),
-    splitOutput: z.number().int().min(1).optional(),
-    tokenCountTree: z.union([z.boolean(), z.number(), z.string()]).default(false),
-    git: z.object({
-      sortByChanges: z.boolean().default(true),
-      sortByChangesMaxCommits: z.number().int().min(1).default(100),
-      includeDiffs: z.boolean().default(false),
-      includeLogs: z.boolean().default(false),
-      includeLogsCount: z.number().int().min(1).default(50),
+  output: v.object({
+    filePath: v.optional(v.string(), defaultFilePathMap.xml),
+    style: v.optional(repomixOutputStyleSchema, 'xml'),
+    parsableStyle: v.optional(v.boolean(), false),
+    headerText: v.optional(v.string()),
+    instructionFilePath: v.optional(v.string()),
+    fileSummary: v.optional(v.boolean(), true),
+    directoryStructure: v.optional(v.boolean(), true),
+    files: v.optional(v.boolean(), true),
+    removeComments: v.optional(v.boolean(), false),
+    removeEmptyLines: v.optional(v.boolean(), false),
+    compress: v.optional(v.boolean(), false),
+    topFilesLength: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)), 5),
+    showLineNumbers: v.optional(v.boolean(), false),
+    truncateBase64: v.optional(v.boolean(), false),
+    copyToClipboard: v.optional(v.boolean(), false),
+    includeEmptyDirectories: v.optional(v.boolean()),
+    includeFullDirectoryStructure: v.optional(v.boolean(), false),
+    splitOutput: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
+    tokenCountTree: v.optional(v.union([v.boolean(), v.number(), v.string()]), false),
+    git: v.object({
+      sortByChanges: v.optional(v.boolean(), true),
+      sortByChangesMaxCommits: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1)), 100),
+      includeDiffs: v.optional(v.boolean(), false),
+      includeLogs: v.optional(v.boolean(), false),
+      includeLogsCount: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1)), 50),
     }),
   }),
-  include: z.array(z.string()).default([]),
-  ignore: z.object({
-    useGitignore: z.boolean().default(true),
-    useDotIgnore: z.boolean().default(true),
-    useDefaultPatterns: z.boolean().default(true),
-    customPatterns: z.array(z.string()).default([]),
+  include: v.optional(v.array(v.string()), () => []),
+  ignore: v.object({
+    useGitignore: v.optional(v.boolean(), true),
+    useDotIgnore: v.optional(v.boolean(), true),
+    useDefaultPatterns: v.optional(v.boolean(), true),
+    customPatterns: v.optional(v.array(v.string()), () => []),
   }),
-  security: z.object({
-    enableSecurityCheck: z.boolean().default(true),
+  security: v.object({
+    enableSecurityCheck: v.optional(v.boolean(), true),
   }),
-  tokenCount: z.object({
-    encoding: z.enum(TOKEN_ENCODINGS).default('o200k_base'),
+  tokenCount: v.object({
+    encoding: v.optional(v.picklist(TOKEN_ENCODINGS), 'o200k_base'),
   }),
 });
 
@@ -130,35 +126,37 @@ export const repomixConfigDefaultSchema = z.object({
 export const repomixConfigFileSchema = repomixConfigBaseSchema;
 
 // CLI-specific schema. Add options for standard output mode and skill generation
-export const repomixConfigCliSchema = repomixConfigBaseSchema.and(
-  z.object({
-    output: z
-      .object({
-        stdout: z.boolean().optional(),
-      })
-      .optional(),
-    skillGenerate: z.union([z.string(), z.boolean()]).optional(),
+export const repomixConfigCliSchema = v.intersect([
+  repomixConfigBaseSchema,
+  v.object({
+    output: v.optional(
+      v.object({
+        stdout: v.optional(v.boolean()),
+      }),
+    ),
+    skillGenerate: v.optional(v.union([v.string(), v.boolean()])),
   }),
-);
+]);
 
 // Merged schema for all configurations
-export const repomixConfigMergedSchema = repomixConfigDefaultSchema
-  .and(repomixConfigFileSchema)
-  .and(repomixConfigCliSchema)
-  .and(
-    z.object({
-      cwd: z.string(),
-    }),
-  );
+export const repomixConfigMergedSchema = v.intersect([
+  repomixConfigDefaultSchema,
+  repomixConfigFileSchema,
+  repomixConfigCliSchema,
+  v.object({
+    cwd: v.string(),
+  }),
+]);
 
-export type RepomixConfigDefault = z.infer<typeof repomixConfigDefaultSchema>;
-export type RepomixConfigFile = z.infer<typeof repomixConfigFileSchema>;
-export type RepomixConfigCli = z.infer<typeof repomixConfigCliSchema>;
-export type RepomixConfigMerged = z.infer<typeof repomixConfigMergedSchema>;
+export type RepomixConfigDefault = v.InferOutput<typeof repomixConfigDefaultSchema>;
+export type RepomixConfigFile = v.InferOutput<typeof repomixConfigFileSchema>;
+export type RepomixConfigCli = v.InferOutput<typeof repomixConfigCliSchema>;
+export type RepomixConfigMerged = v.InferOutput<typeof repomixConfigMergedSchema>;
 
-// Pass empty objects to let Zod apply all default values
-// Zod v4 requires explicit nested objects since we removed outer .default({})
-export const defaultConfig = repomixConfigDefaultSchema.parse({
+// Pass empty objects to let Valibot apply all default values.
+// Explicit nested objects are required because we do not wrap the outer schema
+// in v.optional with a default.
+export const defaultConfig = v.parse(repomixConfigDefaultSchema, {
   input: {},
   output: {
     git: {},

--- a/src/shared/errorHandle.ts
+++ b/src/shared/errorHandle.ts
@@ -122,23 +122,24 @@ const isRepomixError = (error: unknown): error is RepomixError => {
  * - ValiError: `name === 'ValiError'`, `issues[].path` is `Array<{ key: string | number | symbol }>`
  */
 export const rethrowValidationErrorIfSchemaError = (error: unknown, message: string): void => {
-  if (
-    !(error instanceof Error) ||
-    (error.name !== 'ZodError' && error.name !== 'ValiError') ||
-    !('issues' in error) ||
-    !Array.isArray((error as { issues: unknown[] }).issues)
-  ) {
+  // Duck-type instead of `instanceof Error` so errors round-tripped through
+  // worker boundaries (which keep only plain { name, message, issues }) are
+  // still recognized. Aligns with isError / isRepomixError above.
+  if (!error || typeof error !== 'object') return;
+  const err = error as { name?: unknown; issues?: unknown };
+  if ((err.name !== 'ZodError' && err.name !== 'ValiError') || !Array.isArray(err.issues)) {
     return;
   }
 
-  const issues = (error as { issues: Array<{ path?: unknown; message: string }> }).issues;
+  const issues = err.issues as Array<{ path?: unknown; message: string }>;
   const errorText = issues
     .map((issue) => {
       const segments = Array.isArray(issue.path)
         ? (issue.path as unknown[]).map((segment) => {
             // Zod: path segments are primitives. Valibot: { key } objects.
-            if (segment && typeof segment === 'object' && 'key' in segment) {
-              return String((segment as { key: unknown }).key);
+            if (segment && typeof segment === 'object') {
+              if ('key' in segment) return String((segment as { key: unknown }).key);
+              return '';
             }
             return String(segment);
           })

--- a/src/shared/errorHandle.ts
+++ b/src/shared/errorHandle.ts
@@ -135,14 +135,16 @@ export const rethrowValidationErrorIfSchemaError = (error: unknown, message: str
   const errorText = issues
     .map((issue) => {
       const segments = Array.isArray(issue.path)
-        ? (issue.path as unknown[]).map((segment) => {
-            // Zod: path segments are primitives. Valibot: { key } objects.
-            if (segment && typeof segment === 'object') {
-              if ('key' in segment) return String((segment as { key: unknown }).key);
-              return '';
-            }
-            return String(segment);
-          })
+        ? (issue.path as unknown[])
+            .map((segment) => {
+              // Zod: path segments are primitives. Valibot: { key } objects.
+              if (segment && typeof segment === 'object') {
+                if ('key' in segment) return String((segment as { key: unknown }).key);
+                return '';
+              }
+              return String(segment);
+            })
+            .filter((segment) => segment !== '')
         : [];
       return `[${segments.join('.')}] ${issue.message}`;
     })

--- a/src/shared/errorHandle.ts
+++ b/src/shared/errorHandle.ts
@@ -115,20 +115,38 @@ const isRepomixError = (error: unknown): error is RepomixError => {
 };
 
 /**
- * Checks if an error is a ZodError using duck typing to avoid eagerly importing Zod.
- * ZodErrors have a `name` of 'ZodError' and an `issues` array.
+ * Rethrows schema validation errors (Zod or Valibot) as RepomixConfigValidationError
+ * using duck typing to avoid eagerly importing either library.
+ *
+ * - ZodError: `name === 'ZodError'`, `issues[].path` is `Array<string | number>`
+ * - ValiError: `name === 'ValiError'`, `issues[].path` is `Array<{ key: string | number | symbol }>`
  */
-export const rethrowValidationErrorIfZodError = (error: unknown, message: string): void => {
+export const rethrowValidationErrorIfSchemaError = (error: unknown, message: string): void => {
   if (
-    error instanceof Error &&
-    error.name === 'ZodError' &&
-    'issues' in error &&
-    Array.isArray((error as { issues: unknown[] }).issues)
+    !(error instanceof Error) ||
+    (error.name !== 'ZodError' && error.name !== 'ValiError') ||
+    !('issues' in error) ||
+    !Array.isArray((error as { issues: unknown[] }).issues)
   ) {
-    const issues = (error as { issues: Array<{ path: string[]; message: string }> }).issues;
-    const zodErrorText = issues.map((err) => `[${err.path.join('.')}] ${err.message}`).join('\n  ');
-    throw new RepomixConfigValidationError(
-      `${message}\n\n  ${zodErrorText}\n\n  Please check the config file and try again.`,
-    );
+    return;
   }
+
+  const issues = (error as { issues: Array<{ path?: unknown; message: string }> }).issues;
+  const errorText = issues
+    .map((issue) => {
+      const segments = Array.isArray(issue.path)
+        ? (issue.path as unknown[]).map((segment) => {
+            // Zod: path segments are primitives. Valibot: { key } objects.
+            if (segment && typeof segment === 'object' && 'key' in segment) {
+              return String((segment as { key: unknown }).key);
+            }
+            return String(segment);
+          })
+        : [];
+      return `[${segments.join('.')}] ${issue.message}`;
+    })
+    .join('\n  ');
+  throw new RepomixConfigValidationError(
+    `${message}\n\n  ${errorText}\n\n  Please check the config file and try again.`,
+  );
 };

--- a/src/shared/errorHandle.ts
+++ b/src/shared/errorHandle.ts
@@ -146,7 +146,9 @@ export const rethrowValidationErrorIfSchemaError = (error: unknown, message: str
             })
             .filter((segment) => segment !== '')
         : [];
-      return `[${segments.join('.')}] ${issue.message}`;
+      // Omit the bracketed path entirely when there are no usable segments, so
+      // a root-level / path-less issue reads as `message` instead of `[] message`.
+      return segments.length === 0 ? issue.message : `[${segments.join('.')}] ${issue.message}`;
     })
     .join('\n  ');
   throw new RepomixConfigValidationError(

--- a/tests/config/configLoad.integration.test.ts
+++ b/tests/config/configLoad.integration.test.ts
@@ -201,5 +201,27 @@ describe('configLoad Integration Tests', () => {
       expect(config.output?.filePath).toBe('cjs-with-default.xml');
       expect(config.output?.style).toBe('plain');
     });
+
+    test('documents the known ambiguous case: object `default` + sibling keys', async () => {
+      // Pins the documented limitation in src/config/configLoad.ts: a CJS module
+      // shaped like `{ default: { ... }, otherKey: ... }` cannot be distinguished
+      // from an ESM namespace wrapper, so `otherKey` is discarded. This is a
+      // non-issue for RepomixConfig (no `default` field), but the behavior should
+      // not silently change.
+      const config = await loadFileConfig(
+        jsFixturesDir,
+        'repomix-dynamic.config.js',
+        {},
+        {
+          jitiImport: async () => ({
+            default: { output: { filePath: 'from-default.xml', style: 'xml' } },
+            ignore: { customPatterns: ['dropped-by-unwrap'] },
+          }),
+        },
+      );
+
+      expect(config.output?.filePath).toBe('from-default.xml');
+      expect(config.ignore).toBeUndefined();
+    });
   });
 });

--- a/tests/config/configLoad.integration.test.ts
+++ b/tests/config/configLoad.integration.test.ts
@@ -159,4 +159,47 @@ describe('configLoad Integration Tests', () => {
       expect(config.ignore?.customPatterns).toEqual(['**/node_modules/**']);
     });
   });
+
+  describe('ESM namespace unwrap', () => {
+    test('should unwrap `{ default: config }` wrapper from jiti ESM import', async () => {
+      const config = await loadFileConfig(
+        jsFixturesDir,
+        'repomix-dynamic.config.js',
+        {},
+        {
+          jitiImport: async () => ({
+            default: {
+              output: { filePath: 'unwrapped.xml', style: 'xml' },
+              ignore: { customPatterns: ['**/node_modules/**'] },
+            },
+          }),
+        },
+      );
+
+      expect(config).toEqual({
+        output: { filePath: 'unwrapped.xml', style: 'xml' },
+        ignore: { customPatterns: ['**/node_modules/**'] },
+      });
+    });
+
+    test('should preserve CJS config when `default` is a non-object value', async () => {
+      // Pathological CJS pattern: `module.exports = { default: 'plain', output: { ... } }`.
+      // The unwrap must not mistake this for an ESM namespace — `default` is a string,
+      // so the original object should be passed through untouched.
+      const config = await loadFileConfig(
+        jsFixturesDir,
+        'repomix-dynamic.config.js',
+        {},
+        {
+          jitiImport: async () => ({
+            default: 'plain',
+            output: { filePath: 'cjs-with-default.xml', style: 'plain' },
+          }),
+        },
+      );
+
+      expect(config.output?.filePath).toBe('cjs-with-default.xml');
+      expect(config.output?.style).toBe('plain');
+    });
+  });
 });

--- a/tests/config/configSchema.test.ts
+++ b/tests/config/configSchema.test.ts
@@ -1,5 +1,5 @@
+import * as v from 'valibot';
 import { describe, expect, it } from 'vitest';
-import { z } from 'zod';
 import {
   repomixConfigBaseSchema,
   repomixConfigCliSchema,
@@ -12,12 +12,12 @@ import {
 describe('configSchema', () => {
   describe('repomixOutputStyleSchema', () => {
     it('should accept valid output styles', () => {
-      expect(repomixOutputStyleSchema.parse('plain')).toBe('plain');
-      expect(repomixOutputStyleSchema.parse('xml')).toBe('xml');
+      expect(v.parse(repomixOutputStyleSchema, 'plain')).toBe('plain');
+      expect(v.parse(repomixOutputStyleSchema, 'xml')).toBe('xml');
     });
 
     it('should reject invalid output styles', () => {
-      expect(() => repomixOutputStyleSchema.parse('invalid')).toThrow(z.ZodError);
+      expect(() => v.parse(repomixOutputStyleSchema, 'invalid')).toThrow(v.ValiError);
     });
   });
 
@@ -33,8 +33,8 @@ describe('configSchema', () => {
           tokenCountTree: false,
         },
       };
-      expect(repomixConfigBaseSchema.parse(configWithBooleanTrue)).toEqual(configWithBooleanTrue);
-      expect(repomixConfigBaseSchema.parse(configWithBooleanFalse)).toEqual(configWithBooleanFalse);
+      expect(v.parse(repomixConfigBaseSchema, configWithBooleanTrue)).toEqual(configWithBooleanTrue);
+      expect(v.parse(repomixConfigBaseSchema, configWithBooleanFalse)).toEqual(configWithBooleanFalse);
     });
 
     it('should accept string values for tokenCountTree', () => {
@@ -43,7 +43,7 @@ describe('configSchema', () => {
           tokenCountTree: '100',
         },
       };
-      expect(repomixConfigBaseSchema.parse(configWithString)).toEqual(configWithString);
+      expect(v.parse(repomixConfigBaseSchema, configWithString)).toEqual(configWithString);
     });
 
     it('should reject invalid types for tokenCountTree', () => {
@@ -52,7 +52,7 @@ describe('configSchema', () => {
           tokenCountTree: [], // Should be boolean, number, or string
         },
       };
-      expect(() => repomixConfigBaseSchema.parse(configWithInvalidType)).toThrow(z.ZodError);
+      expect(() => v.parse(repomixConfigBaseSchema, configWithInvalidType)).toThrow(v.ValiError);
     });
   });
 
@@ -74,11 +74,11 @@ describe('configSchema', () => {
           enableSecurityCheck: true,
         },
       };
-      expect(repomixConfigBaseSchema.parse(validConfig)).toEqual(validConfig);
+      expect(v.parse(repomixConfigBaseSchema, validConfig)).toEqual(validConfig);
     });
 
     it('should accept empty object', () => {
-      expect(repomixConfigBaseSchema.parse({})).toEqual({});
+      expect(v.parse(repomixConfigBaseSchema, {})).toEqual({});
     });
 
     it('should reject invalid types', () => {
@@ -89,7 +89,7 @@ describe('configSchema', () => {
         },
         include: 'not-an-array', // Should be an array
       };
-      expect(() => repomixConfigBaseSchema.parse(invalidConfig)).toThrow(z.ZodError);
+      expect(() => v.parse(repomixConfigBaseSchema, invalidConfig)).toThrow(v.ValiError);
     });
   });
 
@@ -137,17 +137,17 @@ describe('configSchema', () => {
           encoding: 'o200k_base',
         },
       };
-      expect(repomixConfigDefaultSchema.parse(validConfig)).toEqual(validConfig);
+      expect(v.parse(repomixConfigDefaultSchema, validConfig)).toEqual(validConfig);
     });
 
     it('should reject incomplete config', () => {
       const invalidConfig = {};
-      expect(() => repomixConfigDefaultSchema.parse(invalidConfig)).toThrow();
+      expect(() => v.parse(repomixConfigDefaultSchema, invalidConfig)).toThrow();
     });
 
     it('should provide helpful error for missing required fields', () => {
       const invalidConfig = {};
-      expect(() => repomixConfigDefaultSchema.parse(invalidConfig)).toThrow(/expected object/i);
+      expect(() => v.parse(repomixConfigDefaultSchema, invalidConfig)).toThrow(/expected|invalid/i);
     });
   });
 
@@ -162,7 +162,7 @@ describe('configSchema', () => {
           customPatterns: ['*.log'],
         },
       };
-      expect(repomixConfigFileSchema.parse(validConfig)).toEqual(validConfig);
+      expect(v.parse(repomixConfigFileSchema, validConfig)).toEqual(validConfig);
     });
 
     it('should accept partial config', () => {
@@ -171,7 +171,7 @@ describe('configSchema', () => {
           filePath: 'partial-output.txt',
         },
       };
-      expect(repomixConfigFileSchema.parse(partialConfig)).toEqual(partialConfig);
+      expect(v.parse(repomixConfigFileSchema, partialConfig)).toEqual(partialConfig);
     });
   });
 
@@ -184,7 +184,7 @@ describe('configSchema', () => {
         },
         include: ['src/**/*.ts'],
       };
-      expect(repomixConfigCliSchema.parse(validConfig)).toEqual(validConfig);
+      expect(v.parse(repomixConfigCliSchema, validConfig)).toEqual(validConfig);
     });
 
     it('should reject invalid CLI options', () => {
@@ -193,7 +193,7 @@ describe('configSchema', () => {
           filePath: 123, // Should be string
         },
       };
-      expect(() => repomixConfigCliSchema.parse(invalidConfig)).toThrow(z.ZodError);
+      expect(() => v.parse(repomixConfigCliSchema, invalidConfig)).toThrow(v.ValiError);
     });
   });
 
@@ -242,7 +242,7 @@ describe('configSchema', () => {
           encoding: 'o200k_base',
         },
       };
-      expect(repomixConfigMergedSchema.parse(validConfig)).toEqual(validConfig);
+      expect(v.parse(repomixConfigMergedSchema, validConfig)).toEqual(validConfig);
     });
 
     it('should reject merged config missing required fields', () => {
@@ -252,7 +252,7 @@ describe('configSchema', () => {
           // Missing required fields
         },
       };
-      expect(() => repomixConfigMergedSchema.parse(invalidConfig)).toThrow(z.ZodError);
+      expect(() => v.parse(repomixConfigMergedSchema, invalidConfig)).toThrow(v.ValiError);
     });
 
     it('should reject merged config with invalid types', () => {
@@ -276,7 +276,7 @@ describe('configSchema', () => {
           enableSecurityCheck: true,
         },
       };
-      expect(() => repomixConfigMergedSchema.parse(invalidConfig)).toThrow(z.ZodError);
+      expect(() => v.parse(repomixConfigMergedSchema, invalidConfig)).toThrow(v.ValiError);
     });
   });
 });

--- a/tests/config/configSchema.test.ts
+++ b/tests/config/configSchema.test.ts
@@ -156,6 +156,97 @@ describe('configSchema', () => {
         expect(valiError.issues[0].message).toMatch(/invalid (type|key)/i);
       }
     });
+
+    describe('numeric constraint enforcement', () => {
+      // The Valibot pipes (integer / minValue / maxValue) need behavioral coverage,
+      // not just structural equivalence to the previous Zod schema.
+      const baseDefaults = {
+        input: { maxFileSize: 50 * 1024 * 1024 },
+        output: {
+          filePath: 'output.xml',
+          style: 'xml',
+          parsableStyle: false,
+          fileSummary: true,
+          directoryStructure: true,
+          files: true,
+          removeComments: false,
+          removeEmptyLines: false,
+          compress: false,
+          topFilesLength: 5,
+          showLineNumbers: false,
+          truncateBase64: false,
+          copyToClipboard: false,
+          includeFullDirectoryStructure: false,
+          tokenCountTree: false,
+          git: {
+            sortByChanges: true,
+            sortByChangesMaxCommits: 100,
+            includeDiffs: false,
+            includeLogs: false,
+            includeLogsCount: 50,
+          },
+        },
+        include: [] as string[],
+        ignore: { useGitignore: true, useDotIgnore: true, useDefaultPatterns: true, customPatterns: [] as string[] },
+        security: { enableSecurityCheck: true },
+        tokenCount: { encoding: 'o200k_base' as const },
+      };
+
+      it('rejects non-integer maxFileSize', () => {
+        const cfg = { ...baseDefaults, input: { maxFileSize: 1.5 } };
+        expect(() => v.parse(repomixConfigDefaultSchema, cfg)).toThrow(v.ValiError);
+      });
+
+      it('rejects maxFileSize below 1', () => {
+        const cfg = { ...baseDefaults, input: { maxFileSize: 0 } };
+        expect(() => v.parse(repomixConfigDefaultSchema, cfg)).toThrow(v.ValiError);
+      });
+
+      it('rejects negative topFilesLength', () => {
+        const cfg = { ...baseDefaults, output: { ...baseDefaults.output, topFilesLength: -1 } };
+        expect(() => v.parse(repomixConfigDefaultSchema, cfg)).toThrow(v.ValiError);
+      });
+
+      it('rejects splitOutput below 1', () => {
+        const cfg = { ...baseDefaults, output: { ...baseDefaults.output, splitOutput: 0 } };
+        expect(() => v.parse(repomixConfigDefaultSchema, cfg)).toThrow(v.ValiError);
+      });
+
+      it('rejects non-integer splitOutput', () => {
+        const cfg = { ...baseDefaults, output: { ...baseDefaults.output, splitOutput: 1.5 } };
+        expect(() => v.parse(repomixConfigDefaultSchema, cfg)).toThrow(v.ValiError);
+      });
+
+      it('rejects splitOutput above Number.MAX_SAFE_INTEGER', () => {
+        const cfg = {
+          ...baseDefaults,
+          output: { ...baseDefaults.output, splitOutput: Number.MAX_SAFE_INTEGER + 1 },
+        };
+        expect(() => v.parse(repomixConfigDefaultSchema, cfg)).toThrow(v.ValiError);
+      });
+
+      it('rejects sortByChangesMaxCommits below 1', () => {
+        const cfg = {
+          ...baseDefaults,
+          output: {
+            ...baseDefaults.output,
+            git: { ...baseDefaults.output.git, sortByChangesMaxCommits: 0 },
+          },
+        };
+        expect(() => v.parse(repomixConfigDefaultSchema, cfg)).toThrow(v.ValiError);
+      });
+
+      it('rejects includeLogsCount below 1', () => {
+        const cfg = {
+          ...baseDefaults,
+          output: {
+            ...baseDefaults.output,
+            git: { ...baseDefaults.output.git, includeLogsCount: 0 },
+          },
+        };
+        expect(() => v.parse(repomixConfigDefaultSchema, cfg)).toThrow(v.ValiError);
+      });
+    });
   });
 
   describe('repomixConfigFileSchema', () => {

--- a/tests/config/configSchema.test.ts
+++ b/tests/config/configSchema.test.ts
@@ -142,12 +142,19 @@ describe('configSchema', () => {
 
     it('should reject incomplete config', () => {
       const invalidConfig = {};
-      expect(() => v.parse(repomixConfigDefaultSchema, invalidConfig)).toThrow();
+      expect(() => v.parse(repomixConfigDefaultSchema, invalidConfig)).toThrow(v.ValiError);
     });
 
     it('should provide helpful error for missing required fields', () => {
       const invalidConfig = {};
-      expect(() => v.parse(repomixConfigDefaultSchema, invalidConfig)).toThrow(/expected|invalid/i);
+      try {
+        v.parse(repomixConfigDefaultSchema, invalidConfig);
+        expect.fail('Expected ValiError to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(v.ValiError);
+        const valiError = error as v.ValiError<typeof repomixConfigDefaultSchema>;
+        expect(valiError.issues[0].message).toMatch(/invalid (type|key)/i);
+      }
     });
   });
 

--- a/tests/config/configSchema.test.ts
+++ b/tests/config/configSchema.test.ts
@@ -293,6 +293,21 @@ describe('configSchema', () => {
       };
       expect(() => v.parse(repomixConfigCliSchema, invalidConfig)).toThrow(v.ValiError);
     });
+
+    it('should preserve base output fields alongside CLI-only stdout via intersect', () => {
+      // `buildCliConfig` parses against this schema before mergeConfigs, so the
+      // intersect must keep both the base-schema `filePath` and the CLI-only
+      // `stdout`. The base schema's `output` does not declare `stdout`; valibot
+      // would strip it without the intersect re-merging from the CLI member.
+      const cliConfig = {
+        output: { filePath: 'out.xml', stdout: true },
+        skillGenerate: true,
+      };
+      const result = v.parse(repomixConfigCliSchema, cliConfig) as typeof cliConfig;
+      expect(result.output.filePath).toBe('out.xml');
+      expect(result.output.stdout).toBe(true);
+      expect(result.skillGenerate).toBe(true);
+    });
   });
 
   describe('repomixConfigMergedSchema', () => {

--- a/tests/config/configSchema.test.ts
+++ b/tests/config/configSchema.test.ts
@@ -246,6 +246,33 @@ describe('configSchema', () => {
         };
         expect(() => v.parse(repomixConfigDefaultSchema, cfg)).toThrow(v.ValiError);
       });
+
+      it('rejects non-integer topFilesLength', () => {
+        const cfg = { ...baseDefaults, output: { ...baseDefaults.output, topFilesLength: 1.5 } };
+        expect(() => v.parse(repomixConfigDefaultSchema, cfg)).toThrow(v.ValiError);
+      });
+
+      it('rejects non-integer sortByChangesMaxCommits', () => {
+        const cfg = {
+          ...baseDefaults,
+          output: {
+            ...baseDefaults.output,
+            git: { ...baseDefaults.output.git, sortByChangesMaxCommits: 1.5 },
+          },
+        };
+        expect(() => v.parse(repomixConfigDefaultSchema, cfg)).toThrow(v.ValiError);
+      });
+
+      it('rejects non-integer includeLogsCount', () => {
+        const cfg = {
+          ...baseDefaults,
+          output: {
+            ...baseDefaults.output,
+            git: { ...baseDefaults.output.git, includeLogsCount: 1.5 },
+          },
+        };
+        expect(() => v.parse(repomixConfigDefaultSchema, cfg)).toThrow(v.ValiError);
+      });
     });
   });
 

--- a/tests/config/configSchema.test.ts
+++ b/tests/config/configSchema.test.ts
@@ -376,5 +376,48 @@ describe('configSchema', () => {
       };
       expect(() => v.parse(repomixConfigMergedSchema, invalidConfig)).toThrow(v.ValiError);
     });
+
+    it('should preserve CLI-only fields (stdout, skillGenerate) through v.intersect', () => {
+      // Regression guard: repomixConfigDefaultSchema's output is strict and does not
+      // declare `stdout`; if intersect ever stopped merging per-schema outputs, the CLI
+      // `--stdout` flag would silently disappear after mergeConfigs validates the result.
+      const merged = {
+        cwd: '/path/to/project',
+        input: { maxFileSize: 1024 },
+        output: {
+          filePath: 'output.xml',
+          style: 'xml',
+          parsableStyle: false,
+          fileSummary: true,
+          directoryStructure: true,
+          files: true,
+          removeComments: false,
+          removeEmptyLines: false,
+          compress: false,
+          topFilesLength: 5,
+          showLineNumbers: false,
+          truncateBase64: false,
+          copyToClipboard: false,
+          includeFullDirectoryStructure: false,
+          tokenCountTree: false,
+          stdout: true,
+          git: {
+            sortByChanges: true,
+            sortByChangesMaxCommits: 100,
+            includeDiffs: false,
+            includeLogs: false,
+            includeLogsCount: 50,
+          },
+        },
+        include: [],
+        ignore: { useGitignore: true, useDotIgnore: true, useDefaultPatterns: true, customPatterns: [] },
+        security: { enableSecurityCheck: true },
+        tokenCount: { encoding: 'o200k_base' },
+        skillGenerate: 'my-skill',
+      };
+      const result = v.parse(repomixConfigMergedSchema, merged) as typeof merged;
+      expect(result.output.stdout).toBe(true);
+      expect(result.skillGenerate).toBe('my-skill');
+    });
   });
 });

--- a/tests/shared/errorHandle.test.ts
+++ b/tests/shared/errorHandle.test.ts
@@ -1,0 +1,63 @@
+import * as v from 'valibot';
+import { describe, expect, it } from 'vitest';
+import { RepomixConfigValidationError, rethrowValidationErrorIfSchemaError } from '../../src/shared/errorHandle.js';
+
+describe('rethrowValidationErrorIfSchemaError', () => {
+  it('rethrows ValiError as RepomixConfigValidationError with formatted message', () => {
+    const schema = v.object({ foo: v.string() });
+    let caught: unknown;
+    try {
+      v.parse(schema, { foo: 42 });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(() => rethrowValidationErrorIfSchemaError(caught, 'Invalid config')).toThrow(RepomixConfigValidationError);
+    try {
+      rethrowValidationErrorIfSchemaError(caught, 'Invalid config');
+    } catch (error) {
+      expect(error).toBeInstanceOf(RepomixConfigValidationError);
+      expect((error as Error).message).toContain('Invalid config');
+      // Valibot path segments are { key } objects — the helper should unwrap them.
+      expect((error as Error).message).toContain('[foo]');
+    }
+  });
+
+  it('rethrows ZodError-shaped duck-typed errors as RepomixConfigValidationError', () => {
+    const zodLike = {
+      name: 'ZodError',
+      message: 'Validation failed',
+      issues: [{ path: ['output', 'style'], message: 'Invalid enum value' }],
+    };
+
+    expect(() => rethrowValidationErrorIfSchemaError(zodLike, 'Invalid cli arguments')).toThrow(
+      RepomixConfigValidationError,
+    );
+    try {
+      rethrowValidationErrorIfSchemaError(zodLike, 'Invalid cli arguments');
+    } catch (error) {
+      expect((error as Error).message).toContain('[output.style]');
+      expect((error as Error).message).toContain('Invalid enum value');
+    }
+  });
+
+  it('handles serialized ValiError across worker boundaries (no instanceof Error)', () => {
+    // Simulate a structured-clone copy — no Error prototype, plain object.
+    const workerError = {
+      name: 'ValiError',
+      message: 'Invalid type',
+      issues: [{ path: [{ key: 'input' }, { key: 'maxFileSize' }], message: 'Invalid type' }],
+    };
+
+    expect(() => rethrowValidationErrorIfSchemaError(workerError, 'Invalid config')).toThrow(
+      RepomixConfigValidationError,
+    );
+  });
+
+  it('does nothing for non-schema errors', () => {
+    expect(() => rethrowValidationErrorIfSchemaError(new Error('boom'), 'msg')).not.toThrow();
+    expect(() => rethrowValidationErrorIfSchemaError(null, 'msg')).not.toThrow();
+    expect(() => rethrowValidationErrorIfSchemaError('string', 'msg')).not.toThrow();
+    expect(() => rethrowValidationErrorIfSchemaError({ name: 'Other', issues: [] }, 'msg')).not.toThrow();
+  });
+});

--- a/tests/shared/errorHandle.test.ts
+++ b/tests/shared/errorHandle.test.ts
@@ -60,4 +60,27 @@ describe('rethrowValidationErrorIfSchemaError', () => {
     expect(() => rethrowValidationErrorIfSchemaError('string', 'msg')).not.toThrow();
     expect(() => rethrowValidationErrorIfSchemaError({ name: 'Other', issues: [] }, 'msg')).not.toThrow();
   });
+
+  it('filters out empty path segments so the joined path stays clean', () => {
+    // A malformed path item (object without `key`) should drop out instead of
+    // producing a double-dot like `[output..style]`.
+    const malformed = {
+      name: 'ValiError',
+      message: 'Invalid type',
+      issues: [
+        {
+          path: [{ key: 'output' }, { type: 'object' }, { key: 'style' }],
+          message: 'Invalid type',
+        },
+      ],
+    };
+
+    try {
+      rethrowValidationErrorIfSchemaError(malformed, 'Invalid config');
+      expect.fail('Expected RepomixConfigValidationError to be thrown');
+    } catch (error) {
+      expect((error as Error).message).toContain('[output.style]');
+      expect((error as Error).message).not.toContain('..');
+    }
+  });
 });

--- a/tests/shared/errorHandle.test.ts
+++ b/tests/shared/errorHandle.test.ts
@@ -83,4 +83,23 @@ describe('rethrowValidationErrorIfSchemaError', () => {
       expect((error as Error).message).not.toContain('..');
     }
   });
+
+  it('omits the bracketed path when a schema issue has no path', () => {
+    // Root-level issues carry no path; the formatted message should read as
+    // `message` rather than `[] message`.
+    const rootIssue = {
+      name: 'ValiError',
+      message: 'Root-level failure',
+      issues: [{ path: [] as unknown[], message: 'Expected object' }],
+    };
+
+    try {
+      rethrowValidationErrorIfSchemaError(rootIssue, 'Invalid config');
+      expect.fail('Expected RepomixConfigValidationError to be thrown');
+    } catch (error) {
+      const msg = (error as Error).message;
+      expect(msg).toContain('Expected object');
+      expect(msg).not.toContain('[]');
+    }
+  });
 });

--- a/tests/website/normalizeJsonSchema.test.ts
+++ b/tests/website/normalizeJsonSchema.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeObjectNode } from '../../website/client/scripts/normalizeJsonSchema.js';
+
+describe('normalizeObjectNode', () => {
+  it('adds additionalProperties: false to object nodes with properties', () => {
+    const schema = {
+      type: 'object',
+      properties: { foo: { type: 'string' } },
+    };
+    normalizeObjectNode(schema);
+    expect((schema as Record<string, unknown>).additionalProperties).toBe(false);
+  });
+
+  it('strips empty required arrays from object nodes', () => {
+    const schema = {
+      type: 'object',
+      properties: { foo: { type: 'string' } },
+      required: [] as string[],
+    };
+    normalizeObjectNode(schema);
+    expect('required' in schema).toBe(false);
+  });
+
+  it('preserves non-empty required arrays', () => {
+    const schema = {
+      type: 'object',
+      properties: { foo: { type: 'string' } },
+      required: ['foo'],
+    };
+    normalizeObjectNode(schema);
+    expect(schema.required).toEqual(['foo']);
+  });
+
+  it('does not override an explicitly-set additionalProperties', () => {
+    const schema = {
+      type: 'object',
+      properties: { foo: { type: 'string' } },
+      additionalProperties: true,
+    };
+    normalizeObjectNode(schema);
+    expect(schema.additionalProperties).toBe(true);
+  });
+
+  it('recurses into nested properties, anyOf, oneOf, and items', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        nested: {
+          type: 'object',
+          properties: { bar: { type: 'number' } },
+          required: [] as string[],
+        },
+        union: {
+          anyOf: [
+            { type: 'object', properties: { a: { type: 'string' } } },
+            { type: 'object', properties: { b: { type: 'string' } } },
+          ],
+        },
+        list: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: { c: { type: 'string' } },
+          },
+        },
+      },
+    };
+    normalizeObjectNode(schema);
+
+    const nested = schema.properties.nested as Record<string, unknown>;
+    expect(nested.additionalProperties).toBe(false);
+    expect('required' in nested).toBe(false);
+
+    for (const branch of schema.properties.union.anyOf) {
+      expect((branch as Record<string, unknown>).additionalProperties).toBe(false);
+    }
+
+    const items = schema.properties.list.items as Record<string, unknown>;
+    expect(items.additionalProperties).toBe(false);
+  });
+
+  it('skips non-object nodes (primitives, null)', () => {
+    expect(() => normalizeObjectNode(null)).not.toThrow();
+    expect(() => normalizeObjectNode('string')).not.toThrow();
+    expect(() => normalizeObjectNode(42)).not.toThrow();
+  });
+
+  it('does not add additionalProperties to object nodes without properties', () => {
+    const schema = { type: 'object' };
+    normalizeObjectNode(schema);
+    expect('additionalProperties' in schema).toBe(false);
+  });
+});

--- a/website/client/scripts/generateSchema.ts
+++ b/website/client/scripts/generateSchema.ts
@@ -15,6 +15,8 @@ const getPackageVersion = async (): Promise<string> => {
 //   Valibot strips unknown keys at runtime. We add it so editors flag typos.
 // - Emits an empty `required: []` on every object node, which is valid but noisy.
 //   We strip empty arrays to match the previous zod-generated output.
+// Mutates the tree in place — the caller passes the root schema and discards
+// the return value.
 const normalizeObjectNode = (node: unknown): void => {
   if (!node || typeof node !== 'object') return;
   if (Array.isArray(node)) {

--- a/website/client/scripts/generateSchema.ts
+++ b/website/client/scripts/generateSchema.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { z } from 'zod';
+import { toJsonSchema } from '@valibot/to-json-schema';
 import { repomixConfigFileSchema } from '../../../src/config/configSchema.js';
 
 const getPackageVersion = async (): Promise<string> => {
@@ -10,15 +10,36 @@ const getPackageVersion = async (): Promise<string> => {
   return packageJson.version;
 };
 
+// @valibot/to-json-schema does not emit `additionalProperties: false` for `v.object`,
+// even though Valibot strips unknown keys at runtime. Walk the tree and add it so
+// editors (VSCode etc.) still flag typos in repomix.config.json.
+const addAdditionalPropertiesFalse = (node: unknown): void => {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const item of node) addAdditionalPropertiesFalse(item);
+    return;
+  }
+  const obj = node as Record<string, unknown>;
+  if (
+    obj.type === 'object' &&
+    obj.properties &&
+    typeof obj.properties === 'object' &&
+    !('additionalProperties' in obj)
+  ) {
+    obj.additionalProperties = false;
+  }
+  for (const value of Object.values(obj)) addAdditionalPropertiesFalse(value);
+};
+
 const generateSchema = async () => {
   const version = await getPackageVersion();
   const versionParts = version.split('.');
   const majorMinorVersion = `${versionParts[0]}.${versionParts[1]}.${versionParts[2]}`;
 
-  // Use Zod v4's built-in JSON Schema generation
-  const jsonSchema = z.toJSONSchema(repomixConfigFileSchema, {
-    target: 'draft-7',
+  const jsonSchema = toJsonSchema(repomixConfigFileSchema, {
+    target: 'draft-07',
   });
+  addAdditionalPropertiesFalse(jsonSchema);
 
   const schemaWithMeta = {
     $schema: 'http://json-schema.org/draft-07/schema#',

--- a/website/client/scripts/generateSchema.ts
+++ b/website/client/scripts/generateSchema.ts
@@ -2,37 +2,13 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { toJsonSchema } from '@valibot/to-json-schema';
 import { repomixConfigFileSchema } from '../../../src/config/configSchema.js';
+import { normalizeObjectNode } from './normalizeJsonSchema.js';
 
 const getPackageVersion = async (): Promise<string> => {
   const packageJsonPath = path.resolve('./package.json');
   const packageJsonContent = await fs.readFile(packageJsonPath, 'utf-8');
   const packageJson = JSON.parse(packageJsonContent);
   return packageJson.version;
-};
-
-// @valibot/to-json-schema quirks:
-// - Does not emit `additionalProperties: false` for `v.object`, even though
-//   Valibot strips unknown keys at runtime. We add it so editors flag typos.
-// - Emits an empty `required: []` on every object node, which is valid but noisy.
-//   We strip empty arrays to match the previous zod-generated output.
-// Mutates the tree in place — the caller passes the root schema and discards
-// the return value.
-const normalizeObjectNode = (node: unknown): void => {
-  if (!node || typeof node !== 'object') return;
-  if (Array.isArray(node)) {
-    for (const item of node) normalizeObjectNode(item);
-    return;
-  }
-  const obj = node as Record<string, unknown>;
-  if (obj.type === 'object' && obj.properties && typeof obj.properties === 'object') {
-    if (!('additionalProperties' in obj)) {
-      obj.additionalProperties = false;
-    }
-    if (Array.isArray(obj.required) && obj.required.length === 0) {
-      delete obj.required;
-    }
-  }
-  for (const value of Object.values(obj)) normalizeObjectNode(value);
 };
 
 const generateSchema = async () => {

--- a/website/client/scripts/generateSchema.ts
+++ b/website/client/scripts/generateSchema.ts
@@ -10,25 +10,27 @@ const getPackageVersion = async (): Promise<string> => {
   return packageJson.version;
 };
 
-// @valibot/to-json-schema does not emit `additionalProperties: false` for `v.object`,
-// even though Valibot strips unknown keys at runtime. Walk the tree and add it so
-// editors (VSCode etc.) still flag typos in repomix.config.json.
-const addAdditionalPropertiesFalse = (node: unknown): void => {
+// @valibot/to-json-schema quirks:
+// - Does not emit `additionalProperties: false` for `v.object`, even though
+//   Valibot strips unknown keys at runtime. We add it so editors flag typos.
+// - Emits an empty `required: []` on every object node, which is valid but noisy.
+//   We strip empty arrays to match the previous zod-generated output.
+const normalizeObjectNode = (node: unknown): void => {
   if (!node || typeof node !== 'object') return;
   if (Array.isArray(node)) {
-    for (const item of node) addAdditionalPropertiesFalse(item);
+    for (const item of node) normalizeObjectNode(item);
     return;
   }
   const obj = node as Record<string, unknown>;
-  if (
-    obj.type === 'object' &&
-    obj.properties &&
-    typeof obj.properties === 'object' &&
-    !('additionalProperties' in obj)
-  ) {
-    obj.additionalProperties = false;
+  if (obj.type === 'object' && obj.properties && typeof obj.properties === 'object') {
+    if (!('additionalProperties' in obj)) {
+      obj.additionalProperties = false;
+    }
+    if (Array.isArray(obj.required) && obj.required.length === 0) {
+      delete obj.required;
+    }
   }
-  for (const value of Object.values(obj)) addAdditionalPropertiesFalse(value);
+  for (const value of Object.values(obj)) normalizeObjectNode(value);
 };
 
 const generateSchema = async () => {
@@ -39,7 +41,7 @@ const generateSchema = async () => {
   const jsonSchema = toJsonSchema(repomixConfigFileSchema, {
     target: 'draft-07',
   });
-  addAdditionalPropertiesFalse(jsonSchema);
+  normalizeObjectNode(jsonSchema);
 
   const schemaWithMeta = {
     $schema: 'http://json-schema.org/draft-07/schema#',

--- a/website/client/scripts/normalizeJsonSchema.ts
+++ b/website/client/scripts/normalizeJsonSchema.ts
@@ -1,0 +1,24 @@
+// @valibot/to-json-schema quirks:
+// - Does not emit `additionalProperties: false` for `v.object`, even though
+//   Valibot strips unknown keys at runtime. We add it so editors flag typos.
+// - Emits an empty `required: []` on every object node, which is valid but noisy.
+//   We strip empty arrays to match the previous zod-generated output.
+// Mutates the tree in place — the caller passes the root schema and discards
+// the return value.
+export const normalizeObjectNode = (node: unknown): void => {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const item of node) normalizeObjectNode(item);
+    return;
+  }
+  const obj = node as Record<string, unknown>;
+  if (obj.type === 'object' && obj.properties && typeof obj.properties === 'object') {
+    if (!('additionalProperties' in obj)) {
+      obj.additionalProperties = false;
+    }
+    if (Array.isArray(obj.required) && obj.required.length === 0) {
+      delete obj.required;
+    }
+  }
+  for (const value of Object.values(obj)) normalizeObjectNode(value);
+};

--- a/website/client/src/public/schemas/1.13.1/schema.json
+++ b/website/client/src/public/schemas/1.13.1/schema.json
@@ -12,7 +12,6 @@
           "type": "number"
         }
       },
-      "required": [],
       "additionalProperties": false
     },
     "output": {
@@ -77,7 +76,8 @@
         },
         "splitOutput": {
           "type": "integer",
-          "minimum": 1
+          "minimum": 1,
+          "maximum": 9007199254740991
         },
         "tokenCountTree": {
           "anyOf": [
@@ -111,11 +111,9 @@
               "type": "number"
             }
           },
-          "required": [],
           "additionalProperties": false
         }
       },
-      "required": [],
       "additionalProperties": false
     },
     "include": {
@@ -143,7 +141,6 @@
           }
         }
       },
-      "required": [],
       "additionalProperties": false
     },
     "security": {
@@ -153,7 +150,6 @@
           "type": "boolean"
         }
       },
-      "required": [],
       "additionalProperties": false
     },
     "tokenCount": {
@@ -163,11 +159,9 @@
           "type": "string"
         }
       },
-      "required": [],
       "additionalProperties": false
     }
   },
-  "required": [],
   "additionalProperties": false,
   "title": "Repomix Configuration",
   "description": "Schema for repomix.config.json configuration file"

--- a/website/client/src/public/schemas/1.13.1/schema.json
+++ b/website/client/src/public/schemas/1.13.1/schema.json
@@ -12,6 +12,7 @@
           "type": "number"
         }
       },
+      "required": [],
       "additionalProperties": false
     },
     "output": {
@@ -21,13 +22,13 @@
           "type": "string"
         },
         "style": {
-          "type": "string",
           "enum": [
             "xml",
             "markdown",
             "json",
             "plain"
-          ]
+          ],
+          "type": "string"
         },
         "parsableStyle": {
           "type": "boolean"
@@ -76,8 +77,7 @@
         },
         "splitOutput": {
           "type": "integer",
-          "minimum": 1,
-          "maximum": 9007199254740991
+          "minimum": 1
         },
         "tokenCountTree": {
           "anyOf": [
@@ -111,9 +111,11 @@
               "type": "number"
             }
           },
+          "required": [],
           "additionalProperties": false
         }
       },
+      "required": [],
       "additionalProperties": false
     },
     "include": {
@@ -141,6 +143,7 @@
           }
         }
       },
+      "required": [],
       "additionalProperties": false
     },
     "security": {
@@ -150,6 +153,7 @@
           "type": "boolean"
         }
       },
+      "required": [],
       "additionalProperties": false
     },
     "tokenCount": {
@@ -159,9 +163,11 @@
           "type": "string"
         }
       },
+      "required": [],
       "additionalProperties": false
     }
   },
+  "required": [],
   "additionalProperties": false,
   "title": "Repomix Configuration",
   "description": "Schema for repomix.config.json configuration file"

--- a/website/client/src/public/schemas/latest/schema.json
+++ b/website/client/src/public/schemas/latest/schema.json
@@ -12,7 +12,6 @@
           "type": "number"
         }
       },
-      "required": [],
       "additionalProperties": false
     },
     "output": {
@@ -77,7 +76,8 @@
         },
         "splitOutput": {
           "type": "integer",
-          "minimum": 1
+          "minimum": 1,
+          "maximum": 9007199254740991
         },
         "tokenCountTree": {
           "anyOf": [
@@ -111,11 +111,9 @@
               "type": "number"
             }
           },
-          "required": [],
           "additionalProperties": false
         }
       },
-      "required": [],
       "additionalProperties": false
     },
     "include": {
@@ -143,7 +141,6 @@
           }
         }
       },
-      "required": [],
       "additionalProperties": false
     },
     "security": {
@@ -153,7 +150,6 @@
           "type": "boolean"
         }
       },
-      "required": [],
       "additionalProperties": false
     },
     "tokenCount": {
@@ -163,11 +159,9 @@
           "type": "string"
         }
       },
-      "required": [],
       "additionalProperties": false
     }
   },
-  "required": [],
   "additionalProperties": false,
   "title": "Repomix Configuration",
   "description": "Schema for repomix.config.json configuration file"

--- a/website/client/src/public/schemas/latest/schema.json
+++ b/website/client/src/public/schemas/latest/schema.json
@@ -12,6 +12,7 @@
           "type": "number"
         }
       },
+      "required": [],
       "additionalProperties": false
     },
     "output": {
@@ -21,13 +22,13 @@
           "type": "string"
         },
         "style": {
-          "type": "string",
           "enum": [
             "xml",
             "markdown",
             "json",
             "plain"
-          ]
+          ],
+          "type": "string"
         },
         "parsableStyle": {
           "type": "boolean"
@@ -76,8 +77,7 @@
         },
         "splitOutput": {
           "type": "integer",
-          "minimum": 1,
-          "maximum": 9007199254740991
+          "minimum": 1
         },
         "tokenCountTree": {
           "anyOf": [
@@ -111,9 +111,11 @@
               "type": "number"
             }
           },
+          "required": [],
           "additionalProperties": false
         }
       },
+      "required": [],
       "additionalProperties": false
     },
     "include": {
@@ -141,6 +143,7 @@
           }
         }
       },
+      "required": [],
       "additionalProperties": false
     },
     "security": {
@@ -150,6 +153,7 @@
           "type": "boolean"
         }
       },
+      "required": [],
       "additionalProperties": false
     },
     "tokenCount": {
@@ -159,9 +163,11 @@
           "type": "string"
         }
       },
+      "required": [],
       "additionalProperties": false
     }
   },
+  "required": [],
   "additionalProperties": false,
   "title": "Repomix Configuration",
   "description": "Schema for repomix.config.json configuration file"


### PR DESCRIPTION
## Summary

Experimental migration of `src/config/configSchema.ts` from zod to valibot to evaluate cold-start impact as a simpler alternative to #1484 (which defers zod via async loading + a separate `configDefaults.ts`).

Draft PR — not for merge as-is. Kept for comparison with #1484.

## Benchmark Results

`hyperfine --warmup 3 --runs 20` packing a small 2-file target directory, 3 A/B rounds each:

| Scenario | main (zod v4) | valibot | Diff |
| --- | --- | --- | --- |
| No config file, R1 | 156.3 ± 3.2 ms | 145.4 ± 1.4 ms | **-10.9 ms (-7.0%)** |
| No config file, R2 | 155.8 ± 2.8 ms | 145.9 ± 1.8 ms | -9.9 ms (-6.4%) |
| No config file, R3 | 156.1 ± 2.2 ms | 146.8 ± 1.6 ms | -9.3 ms (-6.0%) |
| With config file, R1 | 160.9 ± 1.7 ms | 152.5 ± 4.0 ms | -8.4 ms (-5.2%) |
| With config file, R2 | 160.8 ± 2.3 ms | 151.3 ± 1.4 ms | -9.5 ms (-5.9%) |
| With config file, R3 | 161.7 ± 1.7 ms | 152.3 ± 1.7 ms | -9.4 ms (-5.8%) |

Average improvement: **~10 ms (~6%)** cold start, consistent with and without a config file.

Below the -15 ms / -50 ms thresholds used to decide between "adopt and close #1484" vs. "consult user" vs. "drop". Posting as-is for discussion.

## Trade-offs vs. #1484

- **Pro**: no `configDefaults.ts` split, no async API break in `loadFileConfig` / `mergeConfigs`, no speculative preload. Simpler end state.
- **Pro**: removes dependency on zod v4's auto-unwrap of ESM Module namespaces — `configLoad.ts` now unwraps `.default` explicitly, which works identically across libraries.
- **Con**: only ~10 ms faster. #1484 reports a larger win.
- **Con**: introduces a second validation library (valibot) while MCP tools still use zod. Full removal of zod would require migrating the MCP tool definitions too (out of scope here).

## API Surface

- `src/index.ts` re-exports `RepomixConfigFile as RepomixConfig` and `defineConfig` — structural shape preserved; user-facing `RepomixConfig` type is unchanged.
- Internal: `rethrowValidationErrorIfZodError` renamed to `rethrowValidationErrorIfSchemaError`. Duck-types both `ZodError` and `ValiError` so the helper stays library-agnostic.
- `repomixOutputStyleSchema` and other schema symbols are not part of the public export surface.

## Notable Implementation Detail

zod v4 silently auto-unwraps the `default` key when handed an ESM Module namespace object; valibot does not. `configLoad.ts` was relying on this implicitly for jiti-loaded `.ts` / `.mjs` configs. This PR makes the unwrap explicit:

```ts
const imported = await deps.jitiImport(pathToFileURL(filePath).href);
config =
  imported && typeof imported === 'object' && 'default' in imported
    ? (imported as { default: unknown }).default
    : imported;
```

This removes a subtle coupling to zod v4 behaviour, regardless of which library we end up keeping.

## Checklist

- [x] `npm run test` — 1115/1115 pass
- [x] `npm run lint` — clean (2 pre-existing warnings unrelated to this change)

## Related

- #1484 — async deferral approach (comparison baseline)