### PR TITLE
perf(core): Cap metrics worker pool to reduce BPE warmup CPU contention

### DIFF
--- a/src/core/metrics/calculateMetrics.ts
+++ b/src/core/metrics/calculateMetrics.ts
@@ -1,6 +1,6 @@
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
-import { getWorkerThreadCount, initTaskRunner } from '../../shared/processConcurrency.js';
+import { getProcessConcurrency, getWorkerThreadCount, initTaskRunner } from '../../shared/processConcurrency.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
 import type { ProcessedFile } from '../file/fileTypes.js';
 import type { GitDiffResult } from '../git/gitDiffHandle.js';
@@ -34,15 +34,24 @@ export interface MetricsTaskRunnerWithWarmup {
  * gpt-tokenizer initialization in parallel. This allows the expensive module
  * loading to overlap with other pipeline stages (security check, file processing,
  * output generation).
+ *
+ * Worker count is capped to avoid excessive BPE warmup CPU cost. Each worker
+ * needs ~290ms to initialize gpt-tokenizer's BPE encoder. With the default
+ * METRICS_BATCH_SIZE of 50, a 1000-file repo produces ~20 batch tasks — more
+ * workers than that just waste CPU on warmup while competing with the security
+ * worker pool and main thread for execution time.
  */
 export const createMetricsTaskRunner = (numOfTasks: number, encoding: TokenEncoding): MetricsTaskRunnerWithWarmup => {
+  const maxWorkerThreads = Math.max(4, Math.ceil(getProcessConcurrency() / 4));
+
   const taskRunner = initTaskRunner<MetricsWorkerTask, MetricsWorkerResult>({
     numOfTasks,
     workerType: 'calculateMetrics',
     runtime: 'worker_threads',
+    maxWorkerThreads,
   });
 
-  const { maxThreads } = getWorkerThreadCount(numOfTasks);
+  const { maxThreads } = getWorkerThreadCount(numOfTasks, maxWorkerThreads);
   const warmupPromise = Promise.all(
     Array.from({ length: maxThreads }, () => taskRunner.run({ content: '', encoding }).catch(() => 0)),
   );
@@ -112,12 +121,14 @@ export const calculateMetrics = async (
   progressCallback('Calculating metrics...');
 
   // Initialize a single task runner for all metrics calculations
+  const maxWorkerThreads = Math.max(4, Math.ceil(getProcessConcurrency() / 4));
   const taskRunner =
     deps.taskRunner ??
     initTaskRunner<MetricsWorkerTask, MetricsWorkerResult>({
       numOfTasks: processedFiles.length,
       workerType: 'calculateMetrics',
       runtime: 'worker_threads',
+      maxWorkerThreads,
     });
 
   try {


### PR DESCRIPTION
## Summary

Cap the metrics worker thread count at `max(4, ceil(cpuCount/4))` to reduce the CPU-time cost of BPE warmup. Previously the pool was sized at full \`processConcurrency\` (e.g., 16 on a modern laptop), causing 16 workers to each spend ~290ms initializing gpt-tokenizer's BPE encoder — effectively ~4.6s of total CPU time competing with the security worker pool and the main thread.

With \`METRICS_BATCH_SIZE = 50\` and ~1000 files, only ~20 batch tasks exist, so 16 workers would each receive only 1-2 tasks after their expensive warmup. Capping the pool eliminates most of that wasted warmup work.

## Benchmarks

### Original measurement (10 runs each, 1020-file repo)

| Metric | Before (16 workers) | After (4 workers) | Delta |
|---|---|---|---|
| median | 2.423s | 1.658s | **-765ms (-31.6%)** |
| user time | 11.4s | 4.67s | -59% |
| memory (RSS) | 1374 MB | 534 MB | -61% |

### Independent re-measurement on M-series Mac (16-core)

| Round | main wall | branch wall | Δ wall | main User | branch User |
|---|---|---|---|---|---|
| 1 | 382.0ms | 399.8ms | **+17.8ms** | 2624ms | 1541ms |
| 2 | 378.3ms | 398.3ms | **+20.0ms** | 2596ms | 1532ms |
| 3 | 386.6ms | 399.4ms | **+12.8ms** | 2640ms | 1527ms |

On a high-core-count machine the wall time slightly regresses (~+15ms), but total CPU time drops by ~41% (~1070ms reduction in user time).

## Interpretation

The fix trades a bit of wall-clock parallelism for a large CPU/memory reduction. Effect depends on hardware:

- **Low-core or CPU-constrained environments (CI runners, VMs, low-end laptops)**: should show wall-time improvement since the original implementation over-subscribes CPU.
- **High-core desktops/laptops (M-series Macs, workstations)**: wall time may regress slightly because the original 16 warmups run truly in parallel.

Worth discussing whether the CPU/memory reduction (including ~840 MB RSS savings) is valuable on its own even when wall time is neutral.

## Checklist

- [x] Run \`npm run test\` (1115 passed)
- [x] Run \`npm run lint\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
