### PR TITLE
feat(server): Log pack options and validation reject reasons

### DIFF
--- a/tests/website/server/packEventSchema.test.ts
+++ b/tests/website/server/packEventSchema.test.ts
@@ -1,87 +1,55 @@
 import { describe, expect, test } from 'vitest';
 import { z } from 'zod';
 import { classifyRejectReason, getRepoHost } from '../../../website/server/src/actions/packEventSchema.js';
-import { packRequestSchema } from '../../../website/server/src/actions/packRequestSchema.js';
-import { validateRequest } from '../../../website/server/src/utils/validation.js';
 
-// Exercise each rejection path through the real schema + validateRequest so
-// that if a zod message in packRequestSchema changes, the classifier falling
-// back to `'other'` fails the test in CI rather than quietly mislabeling a
-// dashboard bucket in production.
+// Classifier drift test. Messages below MUST match those defined in
+// `website/server/src/actions/packRequestSchema.ts`. If a schema message is
+// edited without updating this file, the classifier falls back to `'other'`
+// and dashboards quietly mislabel — but that drift is not caught here
+// (the test deliberately avoids importing the schema to keep this file's
+// module graph free of server-only packages like `repomix` and `hono` that
+// the root vitest harness doesn't install). For true schema drift catching,
+// the schema and classifier would need to share a constants module.
+
+// Construct a ZodError with a single issue whose message matches the one the
+// schema would produce. classifyRejectReason only reads `.message` and
+// `.path` from the first issue.
+const zodErrorWith = (message: string, path: (string | number)[] = []) =>
+  new z.ZodError([{ code: 'custom', message, path, input: undefined }]);
+
+// Mimic the AppError-with-cause wrapping that `validateRequest` does in
+// production — native Error with `cause` is enough to exercise the
+// cause-chain path in classifyRejectReason, no AppError import needed.
+const wrapped = (message: string, path: (string | number)[] = []) =>
+  new Error(`Invalid request: ${message}`, { cause: zodErrorWith(message, path) });
+
 describe('classifyRejectReason', () => {
-  const baseOptions = {
-    removeComments: false,
-    removeEmptyLines: false,
-    showLineNumbers: false,
-    fileSummary: false,
-    directoryStructure: false,
-    outputParsable: false,
-    compress: false,
-  };
-
-  const expectRejectReason = (input: unknown, expected: string) => {
-    let caught: unknown;
-    try {
-      validateRequest(packRequestSchema, input);
-    } catch (e) {
-      caught = e;
-    }
-    expect(caught).toBeDefined();
-    expect(classifyRejectReason(caught)).toBe(expected);
-  };
-
-  test('missing_input — neither url nor file', () => {
-    expectRejectReason({ format: 'xml', options: baseOptions }, 'missing_input');
+  test.each([
+    ['missing_input', 'Either URL or file must be provided'],
+    ['both_provided', 'Cannot provide both URL and file'],
+    ['invalid_url', 'Invalid repository URL'],
+    ['url_too_long', 'Repository URL is too long'],
+    ['url_empty', 'Repository URL is required'],
+    ['invalid_file', 'Invalid file format'],
+    ['not_zip', 'Only ZIP files are allowed'],
+    ['file_too_large', 'File size must be less than 10MB'],
+    ['invalid_ignore_chars', 'Invalid characters in ignore patterns'],
+    ['include_too_long', 'Include patterns too long'],
+    ['ignore_too_long', 'Ignore patterns too long'],
+  ])('%s — classifies "%s"', (expected, message) => {
+    expect(classifyRejectReason(zodErrorWith(message))).toBe(expected);
+    // Wrapped via AppError.cause (the real production path)
+    expect(classifyRejectReason(wrapped(message))).toBe(expected);
   });
 
-  test('invalid_url — URL fails isValidRemoteValue refine', () => {
-    expectRejectReason({ url: 'not-a-repo', format: 'xml', options: baseOptions }, 'invalid_url');
+  test('invalid_format — path "format" maps regardless of message text', () => {
+    const err = zodErrorWith('any zod message', ['format']);
+    expect(classifyRejectReason(err)).toBe('invalid_format');
   });
 
-  test('url_too_long — URL exceeds 200 chars', () => {
-    const longUrl = `https://github.com/${'a'.repeat(201)}`;
-    expectRejectReason({ url: longUrl, format: 'xml', options: baseOptions }, 'url_too_long');
-  });
-
-  test('url_empty — URL is empty string', () => {
-    expectRejectReason({ url: '', format: 'xml', options: baseOptions }, 'url_empty');
-  });
-
-  test('invalid_format — format not in enum', () => {
-    expectRejectReason({ url: 'yamadashy/repomix', format: 'json', options: baseOptions }, 'invalid_format');
-  });
-
-  test('invalid_ignore_chars — ignorePatterns fails regex', () => {
-    expectRejectReason(
-      {
-        url: 'yamadashy/repomix',
-        format: 'xml',
-        options: { ...baseOptions, ignorePatterns: 'evil;rm -rf' },
-      },
-      'invalid_ignore_chars',
-    );
-  });
-
-  test('include_too_long — includePatterns exceeds 100_000 chars', () => {
-    expectRejectReason(
-      {
-        url: 'yamadashy/repomix',
-        format: 'xml',
-        options: { ...baseOptions, includePatterns: 'a'.repeat(100_001) },
-      },
-      'include_too_long',
-    );
-  });
-
-  test('ignore_too_long — ignorePatterns exceeds 1_000 chars', () => {
-    expectRejectReason(
-      {
-        url: 'yamadashy/repomix',
-        format: 'xml',
-        options: { ...baseOptions, ignorePatterns: 'a'.repeat(1_001) },
-      },
-      'ignore_too_long',
-    );
+  test('other — unmapped message + unmapped path', () => {
+    const err = zodErrorWith('some never-seen message', ['options', 'compress']);
+    expect(classifyRejectReason(err)).toBe('other');
   });
 
   test('unknown — non-error input', () => {
@@ -91,22 +59,17 @@ describe('classifyRejectReason', () => {
   });
 
   test('unknown — ZodError with empty issues', () => {
-    const empty = new z.ZodError([]);
-    expect(classifyRejectReason(empty)).toBe('unknown');
+    expect(classifyRejectReason(new z.ZodError([]))).toBe('unknown');
   });
 
-  test('cause-chain extraction — issues live on error.cause', () => {
-    // validateRequest wraps ZodError in AppError with cause, so the classifier
-    // must read .cause to find the original issues.
-    let caught: unknown;
-    try {
-      validateRequest(packRequestSchema, { format: 'xml', options: baseOptions });
-    } catch (e) {
-      caught = e;
-    }
-    expect(caught).toBeInstanceOf(Error);
-    expect((caught as Error).cause).toBeInstanceOf(z.ZodError);
-    expect(classifyRejectReason(caught)).toBe('missing_input');
+  test('unknown — plain Error without issues', () => {
+    expect(classifyRejectReason(new Error('bare error'))).toBe('unknown');
+  });
+
+  test('cause-chain extraction — issues live on error.cause (AppError path)', () => {
+    const wrappedErr = wrapped('Either URL or file must be provided');
+    expect(wrappedErr.cause).toBeInstanceOf(z.ZodError);
+    expect(classifyRejectReason(wrappedErr)).toBe('missing_input');
   });
 });
 

--- a/tests/website/server/packEventSchema.test.ts
+++ b/tests/website/server/packEventSchema.test.ts
@@ -1,41 +1,45 @@
 import { describe, expect, test } from 'vitest';
 import { z } from 'zod';
 import { classifyRejectReason, getRepoHost } from '../../../website/server/src/actions/packEventSchema.js';
+import { MESSAGES } from '../../../website/server/src/actions/packRequestMessages.js';
 
-// Classifier drift test. Messages below MUST match those defined in
-// `website/server/src/actions/packRequestSchema.ts`. If a schema message is
-// edited without updating this file, the classifier falls back to `'other'`
-// and dashboards quietly mislabel — but that drift is not caught here
-// (the test deliberately avoids importing the schema to keep this file's
-// module graph free of server-only packages like `repomix` and `hono` that
-// the root vitest harness doesn't install). For true schema drift catching,
-// the schema and classifier would need to share a constants module.
+// Classifier drift test — imports MESSAGES from the same shared module that
+// packRequestSchema uses. This means a message-text rewrite automatically
+// propagates to the schema (producer), the classifier (consumer), AND the
+// test's expected values, so schema/classifier drift is impossible by
+// construction. The test's value is catching classifier-logic drift: if the
+// classifier's MESSAGE_TO_REASON map loses a key (or maps it to the wrong
+// label), the corresponding case here fails.
+//
+// Deliberately avoids importing packRequestSchema itself — that file
+// transitively depends on `repomix`, which the root vitest harness can't
+// resolve because repomix IS this repo.
 
-// Construct a ZodError with a single issue whose message matches the one the
-// schema would produce. classifyRejectReason only reads `.message` and
-// `.path` from the first issue.
+// Construct a ZodError with a single issue whose message matches the shared
+// constant. classifyRejectReason only reads `.message` and `.path` from the
+// first issue.
 const zodErrorWith = (message: string, path: (string | number)[] = []) =>
   new z.ZodError([{ code: 'custom', message, path, input: undefined }]);
 
 // Mimic the AppError-with-cause wrapping that `validateRequest` does in
 // production — native Error with `cause` is enough to exercise the
-// cause-chain path in classifyRejectReason, no AppError import needed.
+// cause-chain path in classifyRejectReason.
 const wrapped = (message: string, path: (string | number)[] = []) =>
   new Error(`Invalid request: ${message}`, { cause: zodErrorWith(message, path) });
 
 describe('classifyRejectReason', () => {
   test.each([
-    ['missing_input', 'Either URL or file must be provided'],
-    ['both_provided', 'Cannot provide both URL and file'],
-    ['invalid_url', 'Invalid repository URL'],
-    ['url_too_long', 'Repository URL is too long'],
-    ['url_empty', 'Repository URL is required'],
-    ['invalid_file', 'Invalid file format'],
-    ['not_zip', 'Only ZIP files are allowed'],
-    ['file_too_large', 'File size must be less than 10MB'],
-    ['invalid_ignore_chars', 'Invalid characters in ignore patterns'],
-    ['include_too_long', 'Include patterns too long'],
-    ['ignore_too_long', 'Ignore patterns too long'],
+    ['missing_input', MESSAGES.MISSING_INPUT],
+    ['both_provided', MESSAGES.BOTH_PROVIDED],
+    ['invalid_url', MESSAGES.INVALID_URL],
+    ['url_too_long', MESSAGES.URL_TOO_LONG],
+    ['url_empty', MESSAGES.URL_REQUIRED],
+    ['invalid_file', MESSAGES.INVALID_FILE],
+    ['not_zip', MESSAGES.NOT_ZIP],
+    ['file_too_large', MESSAGES.FILE_TOO_LARGE],
+    ['invalid_ignore_chars', MESSAGES.INVALID_IGNORE_CHARS],
+    ['include_too_long', MESSAGES.INCLUDE_TOO_LONG],
+    ['ignore_too_long', MESSAGES.IGNORE_TOO_LONG],
   ])('%s — classifies "%s"', (expected, message) => {
     expect(classifyRejectReason(zodErrorWith(message))).toBe(expected);
     // Wrapped via AppError.cause (the real production path)

--- a/tests/website/server/packEventSchema.test.ts
+++ b/tests/website/server/packEventSchema.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from 'vitest';
+import { z } from 'zod';
+import { classifyRejectReason, getRepoHost } from '../../../website/server/src/actions/packEventSchema.js';
+import { packRequestSchema } from '../../../website/server/src/actions/packRequestSchema.js';
+import { validateRequest } from '../../../website/server/src/utils/validation.js';
+
+// Exercise each rejection path through the real schema + validateRequest so
+// that if a zod message in packRequestSchema changes, the classifier falling
+// back to `'other'` fails the test in CI rather than quietly mislabeling a
+// dashboard bucket in production.
+describe('classifyRejectReason', () => {
+  const baseOptions = {
+    removeComments: false,
+    removeEmptyLines: false,
+    showLineNumbers: false,
+    fileSummary: false,
+    directoryStructure: false,
+    outputParsable: false,
+    compress: false,
+  };
+
+  const expectRejectReason = (input: unknown, expected: string) => {
+    let caught: unknown;
+    try {
+      validateRequest(packRequestSchema, input);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeDefined();
+    expect(classifyRejectReason(caught)).toBe(expected);
+  };
+
+  test('missing_input — neither url nor file', () => {
+    expectRejectReason({ format: 'xml', options: baseOptions }, 'missing_input');
+  });
+
+  test('invalid_url — URL fails isValidRemoteValue refine', () => {
+    expectRejectReason({ url: 'not-a-repo', format: 'xml', options: baseOptions }, 'invalid_url');
+  });
+
+  test('url_too_long — URL exceeds 200 chars', () => {
+    const longUrl = `https://github.com/${'a'.repeat(201)}`;
+    expectRejectReason({ url: longUrl, format: 'xml', options: baseOptions }, 'url_too_long');
+  });
+
+  test('url_empty — URL is empty string', () => {
+    expectRejectReason({ url: '', format: 'xml', options: baseOptions }, 'url_empty');
+  });
+
+  test('invalid_format — format not in enum', () => {
+    expectRejectReason({ url: 'yamadashy/repomix', format: 'json', options: baseOptions }, 'invalid_format');
+  });
+
+  test('invalid_ignore_chars — ignorePatterns fails regex', () => {
+    expectRejectReason(
+      {
+        url: 'yamadashy/repomix',
+        format: 'xml',
+        options: { ...baseOptions, ignorePatterns: 'evil;rm -rf' },
+      },
+      'invalid_ignore_chars',
+    );
+  });
+
+  test('include_too_long — includePatterns exceeds 100_000 chars', () => {
+    expectRejectReason(
+      {
+        url: 'yamadashy/repomix',
+        format: 'xml',
+        options: { ...baseOptions, includePatterns: 'a'.repeat(100_001) },
+      },
+      'include_too_long',
+    );
+  });
+
+  test('ignore_too_long — ignorePatterns exceeds 1_000 chars', () => {
+    expectRejectReason(
+      {
+        url: 'yamadashy/repomix',
+        format: 'xml',
+        options: { ...baseOptions, ignorePatterns: 'a'.repeat(1_001) },
+      },
+      'ignore_too_long',
+    );
+  });
+
+  test('unknown — non-error input', () => {
+    expect(classifyRejectReason(null)).toBe('unknown');
+    expect(classifyRejectReason(undefined)).toBe('unknown');
+    expect(classifyRejectReason('string error')).toBe('unknown');
+  });
+
+  test('unknown — ZodError with empty issues', () => {
+    const empty = new z.ZodError([]);
+    expect(classifyRejectReason(empty)).toBe('unknown');
+  });
+
+  test('cause-chain extraction — issues live on error.cause', () => {
+    // validateRequest wraps ZodError in AppError with cause, so the classifier
+    // must read .cause to find the original issues.
+    let caught: unknown;
+    try {
+      validateRequest(packRequestSchema, { format: 'xml', options: baseOptions });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).cause).toBeInstanceOf(z.ZodError);
+    expect(classifyRejectReason(caught)).toBe('missing_input');
+  });
+});
+
+describe('getRepoHost', () => {
+  test('file upload', () => {
+    expect(getRepoHost({ file: {} as unknown })).toBe('upload');
+  });
+
+  test('github URL', () => {
+    expect(getRepoHost({ url: 'https://github.com/yamadashy/repomix' })).toBe('github.com');
+  });
+
+  test('gitlab URL', () => {
+    expect(getRepoHost({ url: 'https://gitlab.com/user/repo' })).toBe('gitlab.com');
+  });
+
+  test('shorthand owner/repo → github.com fallback', () => {
+    expect(getRepoHost({ url: 'yamadashy/repomix' })).toBe('github.com');
+  });
+
+  test('neither url nor file', () => {
+    expect(getRepoHost({})).toBe('unknown');
+  });
+});

--- a/website/server/monitoring/dashboard.json
+++ b/website/server/monitoring/dashboard.json
@@ -460,10 +460,10 @@
       {
         "xPos": 0,
         "yPos": 24,
-        "width": 6,
+        "width": 3,
         "height": 4,
         "widget": {
-          "title": "Option usage — compress (Tree-sitter)",
+          "title": "Option usage — compress",
           "xyChart": {
             "dataSets": [
               {
@@ -488,9 +488,99 @@
         }
       },
       {
+        "xPos": 3,
+        "yPos": 24,
+        "width": 3,
+        "height": 4,
+        "widget": {
+          "title": "Option usage — removeComments",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/pack_options_usage\"",
+                    "aggregation": {
+                      "alignmentPeriod": "300s",
+                      "perSeriesAligner": "ALIGN_DELTA",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": ["metric.label.remove_comments"]
+                    }
+                  }
+                },
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "legendTemplate": "removeComments=${metric.label.remove_comments}"
+              }
+            ],
+            "yAxis": { "label": "count / 5min", "scale": "LINEAR" }
+          }
+        }
+      },
+      {
         "xPos": 6,
         "yPos": 24,
-        "width": 6,
+        "width": 3,
+        "height": 4,
+        "widget": {
+          "title": "Option usage — outputParsable",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/pack_options_usage\"",
+                    "aggregation": {
+                      "alignmentPeriod": "300s",
+                      "perSeriesAligner": "ALIGN_DELTA",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": ["metric.label.output_parsable"]
+                    }
+                  }
+                },
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "legendTemplate": "outputParsable=${metric.label.output_parsable}"
+              }
+            ],
+            "yAxis": { "label": "count / 5min", "scale": "LINEAR" }
+          }
+        }
+      },
+      {
+        "xPos": 9,
+        "yPos": 24,
+        "width": 3,
+        "height": 4,
+        "widget": {
+          "title": "Option usage — include patterns",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/pack_options_usage\"",
+                    "aggregation": {
+                      "alignmentPeriod": "300s",
+                      "perSeriesAligner": "ALIGN_DELTA",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": ["metric.label.has_include_patterns"]
+                    }
+                  }
+                },
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "legendTemplate": "hasIncludePatterns=${metric.label.has_include_patterns}"
+              }
+            ],
+            "yAxis": { "label": "count / 5min", "scale": "LINEAR" }
+          }
+        }
+      },
+      {
+        "xPos": 0,
+        "yPos": 28,
+        "width": 12,
         "height": 4,
         "widget": {
           "title": "Validation rejections (by reason)",

--- a/website/server/monitoring/dashboard.json
+++ b/website/server/monitoring/dashboard.json
@@ -164,6 +164,123 @@
         }
       },
       {
+        "xPos": 0,
+        "yPos": 12,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Pack outcome (stacked by outcome)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/pack_requests\"",
+                    "aggregation": {
+                      "alignmentPeriod": "300s",
+                      "perSeriesAligner": "ALIGN_DELTA",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": ["metric.label.outcome"]
+                    }
+                  }
+                },
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1"
+              }
+            ],
+            "yAxis": { "label": "count / 5min", "scale": "LINEAR" }
+          }
+        }
+      },
+      {
+        "xPos": 6,
+        "yPos": 12,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Cache hit ratio (success only)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/pack_requests\" metric.label.outcome=\"success\"",
+                    "aggregation": {
+                      "alignmentPeriod": "300s",
+                      "perSeriesAligner": "ALIGN_DELTA",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": ["metric.label.cached"]
+                    }
+                  }
+                },
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "legendTemplate": "cached=${metric.label.cached}"
+              }
+            ],
+            "yAxis": { "label": "count / 5min", "scale": "LINEAR" }
+          }
+        }
+      },
+      {
+        "xPos": 0,
+        "yPos": 16,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Input type (URL vs file upload)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/pack_requests\" metric.label.outcome=\"success\"",
+                    "aggregation": {
+                      "alignmentPeriod": "300s",
+                      "perSeriesAligner": "ALIGN_DELTA",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": ["metric.label.input_type"]
+                    }
+                  }
+                },
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1"
+              }
+            ],
+            "yAxis": { "label": "count / 5min", "scale": "LINEAR" }
+          }
+        }
+      },
+      {
+        "xPos": 6,
+        "yPos": 16,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Country TOP (stacked)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/pack_requests_by_country\"",
+                    "aggregation": {
+                      "alignmentPeriod": "300s",
+                      "perSeriesAligner": "ALIGN_DELTA",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": ["metric.label.country"]
+                    }
+                  }
+                },
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1"
+              }
+            ],
+            "yAxis": { "label": "count / 5min", "scale": "LINEAR" }
+          }
+        }
+      },
+      {
         "xPos": 6,
         "yPos": 8,
         "width": 6,
@@ -219,6 +336,183 @@
               }
             ],
             "yAxis": { "label": "ms", "scale": "LINEAR" }
+          }
+        }
+      },
+      {
+        "xPos": 0,
+        "yPos": 20,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Pack output tokens (P50 / P95 / P99)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/pack_output_tokens\"",
+                    "aggregation": {
+                      "alignmentPeriod": "300s",
+                      "perSeriesAligner": "ALIGN_PERCENTILE_50",
+                      "crossSeriesReducer": "REDUCE_MEAN"
+                    }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "P50",
+                "targetAxis": "Y1"
+              },
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/pack_output_tokens\"",
+                    "aggregation": {
+                      "alignmentPeriod": "300s",
+                      "perSeriesAligner": "ALIGN_PERCENTILE_95",
+                      "crossSeriesReducer": "REDUCE_MEAN"
+                    }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "P95",
+                "targetAxis": "Y1"
+              },
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/pack_output_tokens\"",
+                    "aggregation": {
+                      "alignmentPeriod": "300s",
+                      "perSeriesAligner": "ALIGN_PERCENTILE_99",
+                      "crossSeriesReducer": "REDUCE_MEAN"
+                    }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "P99",
+                "targetAxis": "Y1"
+              }
+            ],
+            "yAxis": { "label": "tokens", "scale": "LOG10" }
+          }
+        }
+      },
+      {
+        "xPos": 6,
+        "yPos": 20,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Pack output files (P50 / P95 / P99)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/pack_output_files\"",
+                    "aggregation": {
+                      "alignmentPeriod": "300s",
+                      "perSeriesAligner": "ALIGN_PERCENTILE_50",
+                      "crossSeriesReducer": "REDUCE_MEAN"
+                    }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "P50",
+                "targetAxis": "Y1"
+              },
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/pack_output_files\"",
+                    "aggregation": {
+                      "alignmentPeriod": "300s",
+                      "perSeriesAligner": "ALIGN_PERCENTILE_95",
+                      "crossSeriesReducer": "REDUCE_MEAN"
+                    }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "P95",
+                "targetAxis": "Y1"
+              },
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/pack_output_files\"",
+                    "aggregation": {
+                      "alignmentPeriod": "300s",
+                      "perSeriesAligner": "ALIGN_PERCENTILE_99",
+                      "crossSeriesReducer": "REDUCE_MEAN"
+                    }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "P99",
+                "targetAxis": "Y1"
+              }
+            ],
+            "yAxis": { "label": "files", "scale": "LOG10" }
+          }
+        }
+      },
+      {
+        "xPos": 0,
+        "yPos": 24,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Option usage — compress (Tree-sitter)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/pack_options_usage\"",
+                    "aggregation": {
+                      "alignmentPeriod": "300s",
+                      "perSeriesAligner": "ALIGN_DELTA",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": ["metric.label.compress"]
+                    }
+                  }
+                },
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "legendTemplate": "compress=${metric.label.compress}"
+              }
+            ],
+            "yAxis": { "label": "count / 5min", "scale": "LINEAR" }
+          }
+        }
+      },
+      {
+        "xPos": 6,
+        "yPos": 24,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Validation rejections (by reason)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/pack_validation_errors\"",
+                    "aggregation": {
+                      "alignmentPeriod": "300s",
+                      "perSeriesAligner": "ALIGN_DELTA",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": ["metric.label.reject_reason"]
+                    }
+                  }
+                },
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1"
+              }
+            ],
+            "yAxis": { "label": "count / 5min", "scale": "LINEAR" }
           }
         }
       }

--- a/website/server/src/actions/packAction.ts
+++ b/website/server/src/actions/packAction.ts
@@ -90,6 +90,11 @@ export const packAction = async (c: Context) => {
   // Computed once so both success and pack_error logs can include it — OOMs
   // typically land in pack_error, so logging options only on success would
   // create survivorship bias for OOM investigation.
+  //
+  // `Boolean()` intentionally collapses `undefined` (user didn't send the
+  // field) into `false`. The metric is designed to answer "what % of packs
+  // had compress enabled" — both "user disabled" and "user didn't send"
+  // mean the feature wasn't active, which is the signal we want.
   const packOptions = {
     compress: Boolean(validatedData.options.compress),
     removeComments: Boolean(validatedData.options.removeComments),

--- a/website/server/src/actions/packAction.ts
+++ b/website/server/src/actions/packAction.ts
@@ -11,7 +11,7 @@ import { logError, logInfo } from '../utils/logger.js';
 import { calculateMemoryDiff, getMemoryUsage } from '../utils/memory.js';
 import { formatLatencyForDisplay } from '../utils/time.js';
 import { validateRequest } from '../utils/validation.js';
-import { getRepoHost, PACK_EVENT, type PackOutcome } from './packEventSchema.js';
+import { classifyRejectReason, getRepoHost, PACK_EVENT, type PackOutcome } from './packEventSchema.js';
 import { type PackRequest, packRequestSchema } from './packRequestSchema.js';
 
 export const packAction = async (c: Context) => {
@@ -33,6 +33,14 @@ export const packAction = async (c: Context) => {
     try {
       options = optionsRaw ? JSON.parse(optionsRaw) : {};
     } catch {
+      const jsonError = new Error('Invalid JSON in options');
+      logError('Pack validation failed', jsonError, {
+        event: PACK_EVENT,
+        outcome: 'validation_error' satisfies PackOutcome,
+        rejectReason: classifyRejectReason(jsonError),
+        requestId: c.get('requestId'),
+        source: clientInfo.source,
+      });
       return c.json(createErrorResponse('Invalid JSON in options', c.get('requestId')), 400);
     }
     const file = formData.get('file') as File | null;
@@ -58,6 +66,7 @@ export const packAction = async (c: Context) => {
     logError('Pack validation failed', error instanceof Error ? error : new Error('Unknown error'), {
       event: PACK_EVENT,
       outcome: 'validation_error' satisfies PackOutcome,
+      rejectReason: classifyRejectReason(error),
       requestId: c.get('requestId'),
       source: clientInfo.source,
     });
@@ -165,6 +174,20 @@ export const packAction = async (c: Context) => {
         durationMs: Date.now() - startTime,
         repository: result.metadata.repository,
         duration: formatLatencyForDisplay(startTime),
+        // Booleans flattened for log-based metric extraction. Patterns are
+        // logged as presence-only booleans to avoid high cardinality and user
+        // input leakage.
+        packOptions: {
+          compress: Boolean(validatedData.options.compress),
+          removeComments: Boolean(validatedData.options.removeComments),
+          removeEmptyLines: Boolean(validatedData.options.removeEmptyLines),
+          showLineNumbers: Boolean(validatedData.options.showLineNumbers),
+          fileSummary: Boolean(validatedData.options.fileSummary),
+          directoryStructure: Boolean(validatedData.options.directoryStructure),
+          outputParsable: Boolean(validatedData.options.outputParsable),
+          hasIncludePatterns: Boolean(validatedData.options.includePatterns),
+          hasIgnorePatterns: Boolean(validatedData.options.ignorePatterns),
+        },
         clientInfo: {
           ip: clientInfo.ip,
           userAgent: clientInfo.userAgent,

--- a/website/server/src/actions/packAction.ts
+++ b/website/server/src/actions/packAction.ts
@@ -85,6 +85,22 @@ export const packAction = async (c: Context) => {
   const requestId = c.get('requestId');
   const inputType: 'file' | 'url' = validatedData.file ? 'file' : 'url';
   const repoHost = getRepoHost({ file: validatedData.file, url: validatedData.url });
+  // Booleans flattened for log-based metric extraction. Patterns are logged
+  // as presence-only booleans to avoid high cardinality and user input leakage.
+  // Computed once so both success and pack_error logs can include it — OOMs
+  // typically land in pack_error, so logging options only on success would
+  // create survivorship bias for OOM investigation.
+  const packOptions = {
+    compress: Boolean(validatedData.options.compress),
+    removeComments: Boolean(validatedData.options.removeComments),
+    removeEmptyLines: Boolean(validatedData.options.removeEmptyLines),
+    showLineNumbers: Boolean(validatedData.options.showLineNumbers),
+    fileSummary: Boolean(validatedData.options.fileSummary),
+    directoryStructure: Boolean(validatedData.options.directoryStructure),
+    outputParsable: Boolean(validatedData.options.outputParsable),
+    hasIncludePatterns: Boolean(validatedData.options.includePatterns),
+    hasIgnorePatterns: Boolean(validatedData.options.ignorePatterns),
+  };
 
   // Stream NDJSON with per-line gzip flush. Bypasses hono/compress (which uses
   // Web CompressionStream and cannot flush mid-stream) by pre-setting
@@ -180,20 +196,7 @@ export const packAction = async (c: Context) => {
         durationMs: Date.now() - startTime,
         repository: result.metadata.repository,
         duration: formatLatencyForDisplay(startTime),
-        // Booleans flattened for log-based metric extraction. Patterns are
-        // logged as presence-only booleans to avoid high cardinality and user
-        // input leakage.
-        packOptions: {
-          compress: Boolean(validatedData.options.compress),
-          removeComments: Boolean(validatedData.options.removeComments),
-          removeEmptyLines: Boolean(validatedData.options.removeEmptyLines),
-          showLineNumbers: Boolean(validatedData.options.showLineNumbers),
-          fileSummary: Boolean(validatedData.options.fileSummary),
-          directoryStructure: Boolean(validatedData.options.directoryStructure),
-          outputParsable: Boolean(validatedData.options.outputParsable),
-          hasIncludePatterns: Boolean(validatedData.options.includePatterns),
-          hasIgnorePatterns: Boolean(validatedData.options.ignorePatterns),
-        },
+        packOptions,
         clientInfo: {
           ip: clientInfo.ip,
           userAgent: clientInfo.userAgent,
@@ -222,6 +225,7 @@ export const packAction = async (c: Context) => {
         repoHost,
         source: clientInfo.source,
         durationMs: Date.now() - startTime,
+        packOptions,
       });
 
       const { handlePackError } = await import('../utils/errorHandler.js');

--- a/website/server/src/actions/packAction.ts
+++ b/website/server/src/actions/packAction.ts
@@ -32,15 +32,21 @@ export const packAction = async (c: Context) => {
     let options: unknown = {};
     try {
       options = optionsRaw ? JSON.parse(optionsRaw) : {};
-    } catch {
-      const jsonError = new Error('Invalid JSON in options');
-      logError('Pack validation failed', jsonError, {
-        event: PACK_EVENT,
-        outcome: 'validation_error' satisfies PackOutcome,
-        rejectReason: classifyRejectReason(jsonError),
-        requestId: c.get('requestId'),
-        source: clientInfo.source,
-      });
+    } catch (jsonError) {
+      // Preserve the original SyntaxError so the log has position / token
+      // context — just the invalid_json count without the cause makes the
+      // invalid_json bucket unactionable when it spikes.
+      logError(
+        'Pack validation failed',
+        jsonError instanceof Error ? jsonError : new Error('Invalid JSON in options'),
+        {
+          event: PACK_EVENT,
+          outcome: 'validation_error' satisfies PackOutcome,
+          rejectReason: 'invalid_json',
+          requestId: c.get('requestId'),
+          source: clientInfo.source,
+        },
+      );
       return c.json(createErrorResponse('Invalid JSON in options', c.get('requestId')), 400);
     }
     const file = formData.get('file') as File | null;

--- a/website/server/src/actions/packEventSchema.ts
+++ b/website/server/src/actions/packEventSchema.ts
@@ -28,17 +28,22 @@ export function getRepoHost(input: { file?: unknown; url?: string }): string {
 }
 
 // Map a validation error to a stable `rejectReason` label for log-based metrics.
-// Matches against the zod issue message (strings are stable because they are
-// defined in this project's schema). Falls back to 'other' for unmapped paths
-// so a sudden jump in `other` surfaces unknown failure modes in the dashboard.
+// Matches against the first zod issue's message (strings are stable because
+// they are defined in this project's schema — see packRequestSchema.ts). Falls
+// back to 'other' for unmapped paths so a sudden jump in `other` surfaces
+// unknown failure modes in the dashboard. NOTE: only the first issue is
+// classified — a request failing multiple validations (e.g. both URL and
+// options) gets bucketed by whichever zod surfaces first.
+//
+// `validateRequest` wraps ZodError in AppError, so the original issues live on
+// `error.cause`. We check both so callers don't need to know which layer is
+// responsible for wrapping.
 export function classifyRejectReason(error: unknown): string {
   if (error instanceof Error && error.message === 'Invalid JSON in options') {
     return 'invalid_json';
   }
-  if (!error || typeof error !== 'object') return 'unknown';
-
-  const issues = (error as { issues?: Array<{ message?: string; path?: Array<string | number> }> }).issues;
-  if (!Array.isArray(issues) || issues.length === 0) return 'unknown';
+  const issues = extractZodIssues(error);
+  if (!issues || issues.length === 0) return 'unknown';
 
   const first = issues[0];
   const msg = first?.message ?? '';
@@ -69,4 +74,20 @@ export function classifyRejectReason(error: unknown): string {
   const path = Array.isArray(first?.path) ? first.path.join('.') : '';
   if (path === 'format') return 'invalid_format';
   return 'other';
+}
+
+type ZodIssueShape = { message?: string; path?: Array<string | number> };
+
+// Pull `.issues` from either the error itself (raw ZodError) or the wrapped
+// `.cause` (AppError wrapping). Shallow — doesn't walk the cause chain further.
+function extractZodIssues(error: unknown): ZodIssueShape[] | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const direct = (error as { issues?: unknown }).issues;
+  if (Array.isArray(direct)) return direct as ZodIssueShape[];
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause && typeof cause === 'object') {
+    const causeIssues = (cause as { issues?: unknown }).issues;
+    if (Array.isArray(causeIssues)) return causeIssues as ZodIssueShape[];
+  }
+  return undefined;
 }

--- a/website/server/src/actions/packEventSchema.ts
+++ b/website/server/src/actions/packEventSchema.ts
@@ -38,10 +38,11 @@ export function getRepoHost(input: { file?: unknown; url?: string }): string {
 // `validateRequest` wraps ZodError in AppError, so the original issues live on
 // `error.cause`. We check both so callers don't need to know which layer is
 // responsible for wrapping.
+//
+// Pre-zod paths (e.g. the JSON.parse failure in packAction) set
+// `rejectReason: 'invalid_json'` directly at the call site since the label is
+// statically known — no synthetic error needs to be routed through here.
 export function classifyRejectReason(error: unknown): string {
-  if (error instanceof Error && error.message === 'Invalid JSON in options') {
-    return 'invalid_json';
-  }
   const issues = extractZodIssues(error);
   if (!issues || issues.length === 0) return 'unknown';
 

--- a/website/server/src/actions/packEventSchema.ts
+++ b/website/server/src/actions/packEventSchema.ts
@@ -1,3 +1,5 @@
+import { MESSAGES } from './packRequestMessages.js';
+
 // Shared log schema for `pack_completed` events. Used by packAction (success /
 // validation_error / pack_error) and rateLimitMiddleware (rate_limited) so that
 // log-based metric filters and outcome labels stay in sync between the two
@@ -28,11 +30,11 @@ export function getRepoHost(input: { file?: unknown; url?: string }): string {
 }
 
 // Map a validation error to a stable `rejectReason` label for log-based metrics.
-// Matches against the first zod issue's message (strings are stable because
-// they are defined in this project's schema — see packRequestSchema.ts). Falls
-// back to 'other' for unmapped paths so a sudden jump in `other` surfaces
-// unknown failure modes in the dashboard. NOTE: only the first issue is
-// classified — a request failing multiple validations (e.g. both URL and
+// Matches against the first zod issue's message — strings come from the
+// shared MESSAGES module so schema and classifier cannot drift out of sync.
+// Falls back to 'other' for unmapped paths so a sudden jump in `other`
+// surfaces unknown failure modes in the dashboard. NOTE: only the first issue
+// is classified — a request failing multiple validations (e.g. both URL and
 // options) gets bucketed by whichever zod surfaces first.
 //
 // `validateRequest` wraps ZodError in AppError, so the original issues live on
@@ -42,36 +44,29 @@ export function getRepoHost(input: { file?: unknown; url?: string }): string {
 // Pre-zod paths (e.g. the JSON.parse failure in packAction) set
 // `rejectReason: 'invalid_json'` directly at the call site since the label is
 // statically known — no synthetic error needs to be routed through here.
+const MESSAGE_TO_REASON: Record<string, string> = {
+  [MESSAGES.MISSING_INPUT]: 'missing_input',
+  [MESSAGES.BOTH_PROVIDED]: 'both_provided',
+  [MESSAGES.INVALID_URL]: 'invalid_url',
+  [MESSAGES.URL_TOO_LONG]: 'url_too_long',
+  [MESSAGES.URL_REQUIRED]: 'url_empty',
+  [MESSAGES.INVALID_FILE]: 'invalid_file',
+  [MESSAGES.NOT_ZIP]: 'not_zip',
+  [MESSAGES.FILE_TOO_LARGE]: 'file_too_large',
+  [MESSAGES.INVALID_IGNORE_CHARS]: 'invalid_ignore_chars',
+  [MESSAGES.INCLUDE_TOO_LONG]: 'include_too_long',
+  [MESSAGES.IGNORE_TOO_LONG]: 'ignore_too_long',
+};
+
 export function classifyRejectReason(error: unknown): string {
   const issues = extractZodIssues(error);
   if (!issues || issues.length === 0) return 'unknown';
 
   const first = issues[0];
   const msg = first?.message ?? '';
-  switch (msg) {
-    case 'Either URL or file must be provided':
-      return 'missing_input';
-    case 'Cannot provide both URL and file':
-      return 'both_provided';
-    case 'Invalid repository URL':
-      return 'invalid_url';
-    case 'Repository URL is too long':
-      return 'url_too_long';
-    case 'Repository URL is required':
-      return 'url_empty';
-    case 'Invalid file format':
-      return 'invalid_file';
-    case 'Only ZIP files are allowed':
-      return 'not_zip';
-    case 'File size must be less than 10MB':
-      return 'file_too_large';
-    case 'Invalid characters in ignore patterns':
-      return 'invalid_ignore_chars';
-    case 'Include patterns too long':
-      return 'include_too_long';
-    case 'Ignore patterns too long':
-      return 'ignore_too_long';
-  }
+  const byMessage = MESSAGE_TO_REASON[msg];
+  if (byMessage) return byMessage;
+
   const path = Array.isArray(first?.path) ? first.path.join('.') : '';
   if (path === 'format') return 'invalid_format';
   return 'other';

--- a/website/server/src/actions/packEventSchema.ts
+++ b/website/server/src/actions/packEventSchema.ts
@@ -26,3 +26,47 @@ export function getRepoHost(input: { file?: unknown; url?: string }): string {
     return 'github.com';
   }
 }
+
+// Map a validation error to a stable `rejectReason` label for log-based metrics.
+// Matches against the zod issue message (strings are stable because they are
+// defined in this project's schema). Falls back to 'other' for unmapped paths
+// so a sudden jump in `other` surfaces unknown failure modes in the dashboard.
+export function classifyRejectReason(error: unknown): string {
+  if (error instanceof Error && error.message === 'Invalid JSON in options') {
+    return 'invalid_json';
+  }
+  if (!error || typeof error !== 'object') return 'unknown';
+
+  const issues = (error as { issues?: Array<{ message?: string; path?: Array<string | number> }> }).issues;
+  if (!Array.isArray(issues) || issues.length === 0) return 'unknown';
+
+  const first = issues[0];
+  const msg = first?.message ?? '';
+  switch (msg) {
+    case 'Either URL or file must be provided':
+      return 'missing_input';
+    case 'Cannot provide both URL and file':
+      return 'both_provided';
+    case 'Invalid repository URL':
+      return 'invalid_url';
+    case 'Repository URL is too long':
+      return 'url_too_long';
+    case 'Repository URL is required':
+      return 'url_empty';
+    case 'Invalid file format':
+      return 'invalid_file';
+    case 'Only ZIP files are allowed':
+      return 'not_zip';
+    case 'File size must be less than 10MB':
+      return 'file_too_large';
+    case 'Invalid characters in ignore patterns':
+      return 'invalid_ignore_chars';
+    case 'Include patterns too long':
+      return 'include_too_long';
+    case 'Ignore patterns too long':
+      return 'ignore_too_long';
+  }
+  const path = Array.isArray(first?.path) ? first.path.join('.') : '';
+  if (path === 'format') return 'invalid_format';
+  return 'other';
+}

--- a/website/server/src/actions/packRequestMessages.ts
+++ b/website/server/src/actions/packRequestMessages.ts
@@ -1,0 +1,22 @@
+// Shared validation-error message strings used by both packRequestSchema (the
+// producer — zod issues) and packEventSchema.classifyRejectReason (the consumer
+// — maps message back to a metric label). Keeping these in one module makes
+// drift impossible by construction: a message rewrite propagates to both
+// sides automatically, and the reject-reason bucket on the dashboard stays
+// aligned with what zod actually emits.
+//
+// Tests import the same constants, so there is no third copy to keep in sync.
+
+export const MESSAGES = {
+  URL_REQUIRED: 'Repository URL is required',
+  URL_TOO_LONG: 'Repository URL is too long',
+  INVALID_URL: 'Invalid repository URL',
+  INVALID_FILE: 'Invalid file format',
+  NOT_ZIP: 'Only ZIP files are allowed',
+  FILE_TOO_LARGE: 'File size must be less than 10MB',
+  INVALID_IGNORE_CHARS: 'Invalid characters in ignore patterns',
+  INCLUDE_TOO_LONG: 'Include patterns too long',
+  IGNORE_TOO_LONG: 'Ignore patterns too long',
+  MISSING_INPUT: 'Either URL or file must be provided',
+  BOTH_PROVIDED: 'Cannot provide both URL and file',
+} as const;

--- a/website/server/src/actions/packRequestSchema.ts
+++ b/website/server/src/actions/packRequestSchema.ts
@@ -1,27 +1,28 @@
 import { isValidRemoteValue } from 'repomix';
 import { z } from 'zod';
 import { FILE_SIZE_LIMITS } from '../domains/pack/utils/fileUtils.js';
+import { MESSAGES } from './packRequestMessages.js';
 
 export const packRequestSchema = z
   .object({
     url: z
       .string()
-      .min(1, 'Repository URL is required')
-      .max(200, 'Repository URL is too long')
+      .min(1, MESSAGES.URL_REQUIRED)
+      .max(200, MESSAGES.URL_TOO_LONG)
       .transform((val) => val.trim())
-      .refine((val) => isValidRemoteValue(val), { message: 'Invalid repository URL' })
+      .refine((val) => isValidRemoteValue(val), { message: MESSAGES.INVALID_URL })
       .optional(),
     file: z
       .custom<File>()
       .refine((file) => file instanceof File, {
-        message: 'Invalid file format',
+        message: MESSAGES.INVALID_FILE,
       })
       .refine((file) => file.type === 'application/zip' || file.name.endsWith('.zip'), {
-        message: 'Only ZIP files are allowed',
+        message: MESSAGES.NOT_ZIP,
       })
       .refine((file) => file.size <= FILE_SIZE_LIMITS.MAX_ZIP_SIZE, {
         // 10MB limit
-        message: 'File size must be less than 10MB',
+        message: MESSAGES.FILE_TOO_LARGE,
       })
       .optional(),
     format: z.enum(['xml', 'markdown', 'plain']),
@@ -34,15 +35,15 @@ export const packRequestSchema = z
         directoryStructure: z.boolean().optional(),
         includePatterns: z
           .string()
-          .max(100_000, 'Include patterns too long')
+          .max(100_000, MESSAGES.INCLUDE_TOO_LONG)
           .optional()
           .transform((val) => val?.trim()),
         ignorePatterns: z
           .string()
           // Regular expression to validate ignore patterns
           // Allowed characters: alphanumeric, *, ?, /, -, _, ., !, (, ), space, comma
-          .regex(/^[a-zA-Z0-9*?/\-_.,!()\s]*$/, 'Invalid characters in ignore patterns')
-          .max(1000, 'Ignore patterns too long')
+          .regex(/^[a-zA-Z0-9*?/\-_.,!()\s]*$/, MESSAGES.INVALID_IGNORE_CHARS)
+          .max(1000, MESSAGES.IGNORE_TOO_LONG)
           .optional()
           .transform((val) => val?.trim()),
         outputParsable: z.boolean().optional(),
@@ -52,10 +53,10 @@ export const packRequestSchema = z
   })
   .strict()
   .refine((data) => data.url || data.file, {
-    message: 'Either URL or file must be provided',
+    message: MESSAGES.MISSING_INPUT,
   })
   .refine((data) => !(data.url && data.file), {
-    message: 'Cannot provide both URL and file',
+    message: MESSAGES.BOTH_PROVIDED,
   });
 
 export type PackRequest = z.infer<typeof packRequestSchema>;

--- a/website/server/src/utils/errorHandler.ts
+++ b/website/server/src/utils/errorHandler.ts
@@ -4,7 +4,7 @@ export class AppError extends Error {
   constructor(
     message: string,
     public readonly statusCode: ContentfulStatusCode = 500,
-    options?: { cause?: unknown },
+    options?: ErrorOptions,
   ) {
     super(message, options);
     this.name = 'AppError';

--- a/website/server/src/utils/errorHandler.ts
+++ b/website/server/src/utils/errorHandler.ts
@@ -4,8 +4,9 @@ export class AppError extends Error {
   constructor(
     message: string,
     public readonly statusCode: ContentfulStatusCode = 500,
+    options?: { cause?: unknown },
   ) {
-    super(message);
+    super(message, options);
     this.name = 'AppError';
   }
 }

--- a/website/server/src/utils/validation.ts
+++ b/website/server/src/utils/validation.ts
@@ -7,7 +7,9 @@ export function validateRequest<T>(schema: z.ZodSchema<T>, data: unknown): T {
   } catch (error) {
     if (error instanceof z.ZodError) {
       const messages = error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join(', ');
-      throw new AppError(`Invalid request: ${messages}`, 400);
+      // Preserve the original ZodError via `cause` so downstream log classifiers
+      // (packEventSchema.classifyRejectReason) can still read `.issues`.
+      throw new AppError(`Invalid request: ${messages}`, 400, { cause: error });
     }
     throw error;
   }


### PR DESCRIPTION
## Summary

Follow-up to PR #1483 adding three observability signals that the first-pass PR intentionally deferred to keep scope small. Each maps to a question raised during the recent traffic-spike investigation but left unanswered.

| Question | How it's answered now |
|---|---|
| What size of repo drives OOM risk? | Distribution metrics on `metrics.totalTokens` / `metrics.totalFiles` → P50/P95/P99 heatmap panels |
| Which differentiating features do users actually use? | New `packOptions` block on pack_completed logs + `pack_options_usage` metric with label extractors for `compress` / `removeComments` / `outputParsable` / `hasIncludePatterns` |
| What inputs does validation reject? | New `rejectReason` field on validation_error logs (classified via `classifyRejectReason`) + `pack_validation_errors` metric |

## What changed

### Application code

**`src/actions/packEventSchema.ts`** — New `classifyRejectReason(error)` function maps a validation error to a stable label (`invalid_url`, `file_too_large`, `missing_input`, `both_provided`, `invalid_json`, …). Matches against the zod issue message strings defined in `packRequestSchema.ts`; non-zod errors (notably the pre-zod `Invalid JSON in options` path) get an explicit branch.

**`src/actions/packAction.ts`** — Two log additions:
- The JSON-parse catch (previously returned 400 with no log) now emits a `validation_error` log with `rejectReason: 'invalid_json'` — otherwise this path would have been invisible in the new metric.
- The zod catch now attaches `rejectReason: classifyRejectReason(error)`.
- Success log now includes a `packOptions` block with boolean option values (pattern strings reduced to presence booleans to avoid cardinality / PII in labels).

### Monitoring (GCP, already applied)

New log-based metrics:
- `pack_output_tokens` — DISTRIBUTION, extracts `metrics.totalTokens`. Labels: `input_type`.
- `pack_output_files` — DISTRIBUTION, extracts `metrics.totalFiles`. Labels: `input_type`.
- `pack_options_usage` — COUNTER with labels `compress`, `remove_comments`, `output_parsable`, `has_include_patterns`. 16 series max.
- `pack_validation_errors` — COUNTER with label `reject_reason`.

New dashboard panels (added to existing dashboard, already deployed):
- Pack output tokens P50/P95/P99 (log-scaled Y axis)
- Pack output files P50/P95/P99 (log-scaled Y axis)
- Option usage — compress (stacked by compress=true/false)
- Validation rejections (stacked by reason)

## Why this scope

The brainstorm produced ~30 candidate signals across SRE / security / product-analytics angles. Filtered to these three because each:
- Directly answers an open question from the recent spike investigation
- Uses existing log data or needs only a ≤3-line code change
- Avoids unbounded cardinality in metric labels

Deferred (higher cost, lower marginal value right now): concurrent-request gauges, instance-age / cold-start correlation, per-instance memory leak detection, TLS/JA4 fingerprinting, BigQuery analytics joins.

## Checklist

- [x] `npm run test` — 1115 tests passed
- [x] `npm run lint` — clean
- [x] `npm run lint` (server tsgo) — clean
- [x] Log-based metrics applied to GCP
- [x] Dashboard updated in GCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
