### PR TITLE
perf(core): Automated performance tuning by Claude

### DIFF
--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -15,11 +15,33 @@ import { RepomixError, rethrowValidationErrorIfSchemaError } from '../../shared/
 import { logger } from '../../shared/logger.js';
 import { splitPatterns } from '../../shared/patternUtils.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
-import { reportResults } from '../cliReport.js';
+import type { reportResults as reportResultsType } from '../cliReport.js';
 import { Spinner } from '../cliSpinner.js';
-import { promptSkillLocation, resolveAndPrepareSkillDir } from '../prompts/skillPrompts.js';
+import type {
+  promptSkillLocation as promptSkillLocationType,
+  resolveAndPrepareSkillDir as resolveAndPrepareSkillDirType,
+} from '../prompts/skillPrompts.js';
 import type { CliOptions } from '../types.js';
 import { runMigrationAction } from './migrationAction.js';
+
+// Lazy-load cliReport to keep its tokenCountTreeReporter chain off the static
+// import graph. Fired early and awaited just before reportResults so the
+// parse overlaps with pack().
+let _cliReportPromise: Promise<{ reportResults: typeof reportResultsType }> | null = null;
+const loadCliReport = () => {
+  _cliReportPromise ??= import('../cliReport.js');
+  return _cliReportPromise;
+};
+
+// skillPrompts is only reached on --skill-generate.
+let _skillPromptsPromise: Promise<{
+  promptSkillLocation: typeof promptSkillLocationType;
+  resolveAndPrepareSkillDir: typeof resolveAndPrepareSkillDirType;
+}> | null = null;
+const loadSkillPrompts = () => {
+  _skillPromptsPromise ??= import('../prompts/skillPrompts.js');
+  return _skillPromptsPromise;
+};
 
 export interface DefaultActionRunnerResult {
   packResult: PackResult;
@@ -33,6 +55,10 @@ export const runDefaultAction = async (
   progressCallback?: RepomixProgressCallback,
 ): Promise<DefaultActionRunnerResult> => {
   logger.trace('Loaded CLI options:', cliOptions);
+
+  // Kick off cliReport load in parallel with pack(); awaited just before the call.
+  const reportPromise = loadCliReport();
+  reportPromise.catch(() => {});
 
   // Run migration before loading config
   await runMigrationAction(cwd);
@@ -78,9 +104,11 @@ export const runDefaultAction = async (
     // Determine skill directory
     if (cliOptions.skillOutput && !cliOptions.skillDir) {
       // Non-interactive mode: use provided path directly
+      const { resolveAndPrepareSkillDir } = await loadSkillPrompts();
       cliOptions.skillDir = await resolveAndPrepareSkillDir(cliOptions.skillOutput, cwd, cliOptions.force ?? false);
     } else if (!cliOptions.skillDir) {
       // Interactive mode: prompt for skill location
+      const { promptSkillLocation } = await loadSkillPrompts();
       const promptResult = await promptSkillLocation(cliOptions.skillName, cwd);
       cliOptions.skillDir = promptResult.skillDir;
     }
@@ -138,6 +166,7 @@ export const runDefaultAction = async (
   }
 
   // Report results
+  const { reportResults } = await reportPromise;
   reportResults(cwd, packResult, config, cliOptions);
 
   return {

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -1,5 +1,6 @@
 import * as v from 'valibot';
-import { TOKEN_ENCODINGS } from '../core/metrics/TokenCounter.js';
+// Use the lightweight tokenEncodings module so gpt-tokenizer stays off the startup import graph.
+import { TOKEN_ENCODINGS } from '../core/metrics/tokenEncodings.js';
 
 // Output style enum
 export const repomixOutputStyleSchema = v.picklist(['xml', 'markdown', 'json', 'plain']);

--- a/src/core/file/fileCollect.ts
+++ b/src/core/file/fileCollect.ts
@@ -7,8 +7,10 @@ import { readRawFile as defaultReadRawFile, type FileSkipReason } from './fileRe
 import type { RawFile } from './fileTypes.js';
 
 // Concurrency limit for parallel file reads on the main thread.
-// 50 balances I/O throughput with FD/memory safety across different machines.
-const FILE_COLLECT_CONCURRENCY = 50;
+// 128 captures most of the achievable readFile throughput on a typical
+// source repo (returns plateau past ~128) while staying well under the
+// FD soft limit (1024 on Linux, 256 on macOS).
+const FILE_COLLECT_CONCURRENCY = 128;
 
 export interface SkippedFileInfo {
   path: string;

--- a/src/core/file/fileProcess.ts
+++ b/src/core/file/fileProcess.ts
@@ -3,12 +3,21 @@ import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
 import { initTaskRunner } from '../../shared/processConcurrency.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
-import { type FileManipulator, getFileManipulator } from './fileManipulate.js';
+import type { FileManipulator, getFileManipulator as getFileManipulatorType } from './fileManipulate.js';
 import type { ProcessedFile, RawFile } from './fileTypes.js';
 import { truncateBase64Content } from './truncateBase64.js';
 import type { FileProcessTask } from './workers/fileProcessWorker.js';
 
 type GetFileManipulator = (filePath: string) => FileManipulator | null;
+
+// fileManipulate pulls in @repomix/strip-comments plus the per-language
+// manipulators. Main-thread code only needs it for removeEmptyLines; the
+// worker path has its own static import inside fileProcessContent.ts.
+let _fileManipulatePromise: Promise<typeof import('./fileManipulate.js')> | null = null;
+const loadFileManipulate = () => {
+  _fileManipulatePromise ??= import('./fileManipulate.js');
+  return _fileManipulatePromise;
+};
 
 /**
  * Apply lightweight transforms on the main thread after worker processing.
@@ -76,9 +85,11 @@ export const processFiles = async (
   rawFiles: RawFile[],
   config: RepomixConfigMerged,
   progressCallback: RepomixProgressCallback,
-  deps = {
+  deps: {
+    initTaskRunner: typeof initTaskRunner;
+    getFileManipulator?: typeof getFileManipulatorType;
+  } = {
     initTaskRunner,
-    getFileManipulator,
   },
 ): Promise<ProcessedFile[]> => {
   const startTime = process.hrtime.bigint();
@@ -86,6 +97,12 @@ export const processFiles = async (
 
   // Only compress (tree-sitter) and removeComments (AST manipulation) justify worker thread overhead
   const useWorkers = config.output.compress || config.output.removeComments;
+
+  // applyLightweightTransforms only calls getFileManipulator when
+  // removeEmptyLines is set, so gate the main-thread module load on that flag.
+  const resolvedGetFileManipulator: typeof getFileManipulatorType =
+    deps.getFileManipulator ??
+    (config.output.removeEmptyLines ? (await loadFileManipulate()).getFileManipulator : () => null);
 
   if (useWorkers) {
     // Phase 1: Heavy processing via workers (removeComments, compress)
@@ -127,12 +144,14 @@ export const processFiles = async (
     }
 
     // Phase 2: Lightweight transforms (no progress - already reported by workers)
-    files = applyLightweightTransforms(files, config, () => {}, deps);
+    files = applyLightweightTransforms(files, config, () => {}, { getFileManipulator: resolvedGetFileManipulator });
   } else {
     // No heavy processing needed - apply lightweight transforms directly
     logger.trace(`Starting file processing for ${rawFiles.length} files in main thread (lightweight mode)`);
     const inputFiles = rawFiles.map((rawFile) => ({ path: rawFile.path, content: rawFile.content }));
-    files = applyLightweightTransforms(inputFiles, config, progressCallback, deps);
+    files = applyLightweightTransforms(inputFiles, config, progressCallback, {
+      getFileManipulator: resolvedGetFileManipulator,
+    });
   }
 
   const endTime = process.hrtime.bigint();

--- a/src/core/file/fileRead.ts
+++ b/src/core/file/fileRead.ts
@@ -1,7 +1,10 @@
 import * as fs from 'node:fs/promises';
 import isBinaryPath from 'is-binary-path';
-import { isBinaryFile } from 'isbinaryfile';
+import { isBinaryFileSync } from 'isbinaryfile';
 import { logger } from '../../shared/logger.js';
+
+// Stateless without `stream: true`, so safe to reuse across concurrent calls.
+const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
 
 // Lazy-load encoding detection libraries to avoid their ~25ms combined import cost.
 // The fast UTF-8 path (covers ~99% of source code files) never needs these;
@@ -52,7 +55,9 @@ export const readRawFile = async (filePath: string, maxFileSize: number): Promis
       return { content: null, skippedReason: 'size-limit' };
     }
 
-    if (await isBinaryFile(buffer)) {
+    // Sync variant: same logic as `isBinaryFile(buffer)` without the
+    // per-call Promise allocation that serves no purpose for Buffer input.
+    if (isBinaryFileSync(buffer)) {
       logger.debug(`Skipping binary file (content check): ${filePath}`);
       return { content: null, skippedReason: 'binary-content' };
     }
@@ -61,7 +66,7 @@ export const readRawFile = async (filePath: string, maxFileSize: number): Promis
     // This skips the expensive jschardet.detect() which scans the entire buffer
     // through multiple encoding probers with frequency table lookups
     try {
-      let content = new TextDecoder('utf-8', { fatal: true }).decode(buffer);
+      let content = utf8Decoder.decode(buffer);
       if (content.charCodeAt(0) === 0xfeff) {
         content = content.slice(1); // strip UTF-8 BOM
       }

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -107,6 +107,12 @@ export const searchFiles = async (
   config: RepomixConfigMerged,
   explicitFiles?: string[],
 ): Promise<FileSearchResult> => {
+  // Pre-warm the globby dynamic import so its module-compile overlaps with the
+  // stat / permission / ignore-context awaits below, instead of running only at
+  // the `await loadGlobby()` call site later. `loadGlobby` caches its promise,
+  // so any rejection is re-thrown from the later await inside the outer try.
+  loadGlobby().catch(() => {});
+
   // Check if the path exists and get its type
   let pathStats: Stats;
   try {

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -1,7 +1,7 @@
 import type { Stats } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { type Options as GlobbyOptions, globby } from 'globby';
+import type { globby as GlobbyFn, Options as GlobbyOptions } from 'globby';
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { defaultIgnoreList } from '../../config/defaultIgnore.js';
 import { RepomixError } from '../../shared/errorHandle.js';
@@ -9,6 +9,19 @@ import { logger } from '../../shared/logger.js';
 import { sortPaths } from './filePathSort.js';
 
 import { checkDirectoryPermissions, PermissionError } from './permissionCheck.js';
+
+// Lazy-load `globby` (pulls in `fast-glob`, ~190ms cold load on the measured
+// critical path). Deferring the import defers that CPU cost off the module-load
+// phase so the pack pipeline can start sooner, overlapping globby's evaluation
+// with other async startup work (e.g. git subprocess spawns). The cached
+// promise ensures subsequent calls reuse the same module.
+let globbyPromise: Promise<typeof GlobbyFn> | null = null;
+const loadGlobby = (): Promise<typeof GlobbyFn> => {
+  if (globbyPromise === null) {
+    globbyPromise = import('globby').then((m) => m.globby);
+  }
+  return globbyPromise;
+};
 
 export interface FileSearchResult {
   filePaths: string[];
@@ -182,6 +195,7 @@ export const searchFiles = async (
     logger.debug('[globby] Starting file search...');
     const globbyStartTime = Date.now();
 
+    const globby = await loadGlobby();
     const filePaths = await globby(includePatterns, {
       ...createBaseGlobbyOptions(rootDir, config, adjustedIgnorePatterns, ignoreFilePatterns),
       onlyFiles: true,
@@ -393,6 +407,7 @@ export const getIgnorePatterns = async (rootDir: string, config: RepomixConfigMe
 export const listDirectories = async (rootDir: string, config: RepomixConfigMerged): Promise<string[]> => {
   const { adjustedIgnorePatterns, ignoreFilePatterns } = await prepareIgnoreContext(rootDir, config);
 
+  const globby = await loadGlobby();
   const directories = await globby(['**/*'], {
     ...createBaseGlobbyOptions(rootDir, config, adjustedIgnorePatterns, ignoreFilePatterns),
     onlyDirectories: true,
@@ -412,6 +427,7 @@ export const listDirectories = async (rootDir: string, config: RepomixConfigMerg
 export const listFiles = async (rootDir: string, config: RepomixConfigMerged): Promise<string[]> => {
   const { adjustedIgnorePatterns, ignoreFilePatterns } = await prepareIgnoreContext(rootDir, config);
 
+  const globby = await loadGlobby();
   const files = await globby(['**/*'], {
     ...createBaseGlobbyOptions(rootDir, config, adjustedIgnorePatterns, ignoreFilePatterns),
     onlyFiles: true,

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -31,24 +31,27 @@ export interface FileSearchResult {
 // No per-directory ignore-pattern check is needed here. The `directories` array
 // comes from globby with the same `ignore` patterns (e.g. `dist/**`), which
 // excludes both the directory contents AND the directory entry itself.
+//
+// `readdir` calls are issued in parallel so the kernel can overlap the per-entry
+// directory lookups instead of serializing them behind `await`. Each call is
+// independent and holds an FD only for the duration of the syscall, so even
+// several hundred concurrent probes stay well within the process FD limit.
 const findEmptyDirectories = async (rootDir: string, directories: string[]): Promise<string[]> => {
-  const emptyDirs: string[] = [];
-
-  for (const dir of directories) {
-    const fullPath = path.join(rootDir, dir);
-    try {
-      const entries = await fs.readdir(fullPath);
-      const hasVisibleContents = entries.some((entry) => !entry.startsWith('.'));
-
-      if (!hasVisibleContents) {
-        emptyDirs.push(dir);
+  const results = await Promise.all(
+    directories.map(async (dir) => {
+      const fullPath = path.join(rootDir, dir);
+      try {
+        const entries = await fs.readdir(fullPath);
+        const hasVisibleContents = entries.some((entry) => !entry.startsWith('.'));
+        return hasVisibleContents ? null : dir;
+      } catch (error) {
+        logger.debug(`Error checking directory ${dir}:`, error);
+        return null;
       }
-    } catch (error) {
-      logger.debug(`Error checking directory ${dir}:`, error);
-    }
-  }
+    }),
+  );
 
-  return emptyDirs;
+  return results.filter((dir): dir is string => dir !== null);
 };
 
 // Check if a path is a git worktree reference file

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -199,11 +199,42 @@ export const searchFiles = async (
     const globbyStartTime = Date.now();
 
     const globby = await loadGlobby();
-    const filePaths = await globby(includePatterns, {
-      ...createBaseGlobbyOptions(rootDir, config, adjustedIgnorePatterns, ignoreFilePatterns),
-      onlyFiles: true,
-    }).catch((error: unknown) => {
-      // Handle EPERM errors specifically
+    const baseGlobbyOptions = createBaseGlobbyOptions(rootDir, config, adjustedIgnorePatterns, ignoreFilePatterns);
+    const collectDirectories = config.output.includeEmptyDirectories === true;
+
+    // When empty-directory tracking is on, fold the files-and-directories query
+    // into a single globby scan: `objectMode` gives us each `Dirent` so we can
+    // partition by type without a second tree walk + micromatch pass. The
+    // `isFile()` / `isDirectory()` predicates produce the same file and
+    // directory sets that the previous `onlyFiles: true` and
+    // `onlyDirectories: true` scans did. Entries for which both predicates
+    // return false (symlinks under `followSymbolicLinks: false`, sockets,
+    // FIFOs, etc.) are dropped from both output arrays — matching the old
+    // behaviour, since neither of the old scans would have emitted them.
+    let filePaths: string[];
+    const directories: string[] = [];
+    try {
+      if (collectDirectories) {
+        const entries = await globby(includePatterns, {
+          ...baseGlobbyOptions,
+          onlyFiles: false,
+          objectMode: true,
+        });
+        filePaths = [];
+        for (const entry of entries) {
+          if (entry.dirent.isFile()) {
+            filePaths.push(entry.path);
+          } else if (entry.dirent.isDirectory()) {
+            directories.push(entry.path);
+          }
+        }
+      } else {
+        filePaths = await globby(includePatterns, {
+          ...baseGlobbyOptions,
+          onlyFiles: true,
+        });
+      }
+    } catch (error: unknown) {
       const code = (error as NodeJS.ErrnoException | { code?: string })?.code;
       if (code === 'EPERM' || code === 'EACCES') {
         throw new PermissionError(
@@ -212,24 +243,16 @@ export const searchFiles = async (
         );
       }
       throw error;
-    });
+    }
 
     const globbyElapsedTime = Date.now() - globbyStartTime;
-    logger.debug(`[globby] Completed in ${globbyElapsedTime}ms, found ${filePaths.length} files`);
+    logger.debug(
+      `[globby] Completed in ${globbyElapsedTime}ms, found ${filePaths.length} files` +
+        (collectDirectories ? ` and ${directories.length} directories` : ''),
+    );
 
     let emptyDirPaths: string[] = [];
-    if (config.output.includeEmptyDirectories) {
-      logger.debug('[empty dirs] Searching for empty directories...');
-      const emptyDirStartTime = Date.now();
-
-      const directories = await globby(includePatterns, {
-        ...createBaseGlobbyOptions(rootDir, config, adjustedIgnorePatterns, ignoreFilePatterns),
-        onlyDirectories: true,
-      });
-
-      const emptyDirElapsedTime = Date.now() - emptyDirStartTime;
-      logger.debug(`[empty dirs] Found ${directories.length} directories in ${emptyDirElapsedTime}ms`);
-
+    if (collectDirectories) {
       const filterStartTime = Date.now();
       emptyDirPaths = await findEmptyDirectories(rootDir, directories);
       const filterTime = Date.now() - filterStartTime;

--- a/src/core/file/truncateBase64.ts
+++ b/src/core/file/truncateBase64.ts
@@ -32,17 +32,39 @@ export const truncateBase64Content = (content: string): string => {
     return `data:${mimeType}${params || ''};base64,${preview}...`;
   });
 
-  // Replace standalone base64 strings
-  processedContent = processedContent.replace(standaloneBase64Pattern, (match, base64String) => {
-    // Check if this looks like actual base64 (not just a long string)
-    if (isLikelyBase64(base64String)) {
-      const preview = base64String.substring(0, TRUNCATION_LENGTH);
-      return `${preview}...`;
-    }
-    return match;
-  });
+  // Standalone base64 detection requires a run of ≥MIN_BASE64_LENGTH_STANDALONE chars in
+  // [A-Za-z0-9+/]. Any newline breaks that run, so if no single line reaches that length
+  // the regex cannot possibly match. Source-code repositories overwhelmingly consist of
+  // short lines, so this cheap pre-scan lets the vast majority of files skip an O(n) regex
+  // scan whose replace() also allocates a fresh string per call.
+  if (hasLineAtLeast(processedContent, MIN_BASE64_LENGTH_STANDALONE)) {
+    processedContent = processedContent.replace(standaloneBase64Pattern, (match, base64String) => {
+      // Check if this looks like actual base64 (not just a long string)
+      if (isLikelyBase64(base64String)) {
+        const preview = base64String.substring(0, TRUNCATION_LENGTH);
+        return `${preview}...`;
+      }
+      return match;
+    });
+  }
 
   return processedContent;
+};
+
+const hasLineAtLeast = (content: string, minLen: number): boolean => {
+  if (content.length < minLen) return false;
+  let start = 0;
+  while (start <= content.length - minLen) {
+    const nl = content.indexOf('\n', start);
+    if (nl === -1) {
+      return content.length - start >= minLen;
+    }
+    if (nl - start >= minLen) {
+      return true;
+    }
+    start = nl + 1;
+  }
+  return false;
 };
 
 /**

--- a/src/core/git/gitRepositoryHandle.ts
+++ b/src/core/git/gitRepositoryHandle.ts
@@ -24,18 +24,45 @@ export const getFileChangeCount = async (
   }
 };
 
-export const isGitRepository = async (
+// Share in-flight rev-parse promises so concurrent callers against the same
+// directory await one subprocess spawn instead of racing their own. Bypassed
+// for non-default `deps` so test mocks keep exact call-count semantics.
+const isGitRepositoryCache = new Map<string, Promise<boolean>>();
+
+export const clearIsGitRepositoryCache = (): void => {
+  isGitRepositoryCache.clear();
+};
+
+export const isGitRepository = (
   directory: string,
   deps = {
     execGitRevParse,
   },
 ): Promise<boolean> => {
-  try {
-    await deps.execGitRevParse(directory);
-    return true;
-  } catch {
-    return false;
+  const execRevParse = deps.execGitRevParse;
+  const runCheck = async (): Promise<boolean> => {
+    try {
+      await execRevParse(directory);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  // Non-default deps means a test mock — bypass cache to keep call-count
+  // assertions stable.
+  if (execRevParse !== execGitRevParse) {
+    return runCheck();
   }
+
+  const cached = isGitRepositoryCache.get(directory);
+  if (cached) {
+    return cached;
+  }
+
+  const pending = runCheck();
+  isGitRepositoryCache.set(directory, pending);
+  return pending;
 };
 
 export const isGitInstalled = async (

--- a/src/core/metrics/TokenCounter.ts
+++ b/src/core/metrics/TokenCounter.ts
@@ -1,10 +1,11 @@
 import { GptEncoding } from 'gpt-tokenizer/GptEncoding';
 import { resolveEncodingAsync } from 'gpt-tokenizer/resolveEncodingAsync';
 import { logger } from '../../shared/logger.js';
+import { TOKEN_ENCODINGS, type TokenEncoding } from './tokenEncodings.js';
 
-// Supported token encoding types (OpenAI encoding names)
-export const TOKEN_ENCODINGS = ['o200k_base', 'cl100k_base', 'p50k_base', 'p50k_edit', 'r50k_base'] as const;
-export type TokenEncoding = (typeof TOKEN_ENCODINGS)[number];
+// Re-export for backward compatibility with existing
+// `import { TOKEN_ENCODINGS, TokenEncoding } from './TokenCounter.js'` call sites.
+export { TOKEN_ENCODINGS, type TokenEncoding };
 
 interface CountTokensOptions {
   disallowedSpecial?: Set<string>;

--- a/src/core/metrics/calculateFileMetrics.ts
+++ b/src/core/metrics/calculateFileMetrics.ts
@@ -43,6 +43,11 @@ export const calculateFileMetrics = async (
       Math.ceil(filesToProcess.length / (maxThreads * TARGET_BATCHES_PER_WORKER)),
     );
 
+    // Largest-first so workers start on the slow batches immediately (Tinypool
+    // dispatches batches FIFO). Safe to reorder: the consumer builds its
+    // fileTokenCounts map by path lookup, so dispatch order is not observable.
+    filesToProcess.sort((a, b) => b.content.length - a.content.length);
+
     // Split files into batches to reduce IPC round-trips
     const batches: ProcessedFile[][] = [];
     for (let i = 0; i < filesToProcess.length; i += batchSize) {

--- a/src/core/metrics/calculateFileMetrics.ts
+++ b/src/core/metrics/calculateFileMetrics.ts
@@ -1,17 +1,23 @@
 import pc from 'picocolors';
 import { logger } from '../../shared/logger.js';
+import { getWorkerThreadCount } from '../../shared/processConcurrency.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
 import type { ProcessedFile } from '../file/fileTypes.js';
+import { METRICS_POOL_SIZING_ESTIMATE } from './metricsPoolConfig.js';
 import { type MetricsTaskRunner, runBatchTokenCount } from './metricsWorkerRunner.js';
 import type { TokenEncoding } from './TokenCounter.js';
 import type { FileMetrics } from './workers/types.js';
 
-// Batch size for grouping files into worker tasks to reduce IPC overhead.
-// Each batch is sent as a single message to a worker thread, avoiding
-// per-file round-trip costs (~0.5ms each) that dominate when processing many files.
-// A size of 10 keeps individual worker tasks small so that workers become available sooner,
-// enabling overlap between file metrics and output generation.
-const METRICS_BATCH_SIZE = 10;
+// Floor on batch size so IPC overhead stays amortised across multiple files
+// per round-trip, even on small repos.
+const MIN_METRICS_BATCH_SIZE = 50;
+
+// Target batches per worker. Trades off IPC overhead (fewer, bigger batches)
+// against load balance when file sizes vary (more, smaller batches). Empirically
+// ~8 keeps structured-clone + futex wake-ups under 10% of the file-metrics
+// stage while letting idle workers pick up single-shot tasks (git diff / git
+// log tokenization) scheduled on the same pool.
+const TARGET_BATCHES_PER_WORKER = 8;
 
 export const calculateFileMetrics = async (
   processedFiles: ProcessedFile[],
@@ -31,10 +37,16 @@ export const calculateFileMetrics = async (
     const startTime = process.hrtime.bigint();
     logger.trace(`Starting file metrics calculation for ${filesToProcess.length} files using worker pool`);
 
+    const { maxThreads } = getWorkerThreadCount(METRICS_POOL_SIZING_ESTIMATE);
+    const batchSize = Math.max(
+      MIN_METRICS_BATCH_SIZE,
+      Math.ceil(filesToProcess.length / (maxThreads * TARGET_BATCHES_PER_WORKER)),
+    );
+
     // Split files into batches to reduce IPC round-trips
     const batches: ProcessedFile[][] = [];
-    for (let i = 0; i < filesToProcess.length; i += METRICS_BATCH_SIZE) {
-      batches.push(filesToProcess.slice(i, i + METRICS_BATCH_SIZE));
+    for (let i = 0; i < filesToProcess.length; i += batchSize) {
+      batches.push(filesToProcess.slice(i, i + batchSize));
     }
 
     logger.trace(`Split ${filesToProcess.length} files into ${batches.length} batches for token counting`);

--- a/src/core/metrics/metricsPoolConfig.ts
+++ b/src/core/metrics/metricsPoolConfig.ts
@@ -1,0 +1,7 @@
+/**
+ * Task-count estimate passed to `createMetricsTaskRunner` before the real
+ * file count is known. Batch-size tuning in `calculateFileMetrics` queries
+ * the same value so the batch count stays in step with the pool's
+ * `maxThreads`.
+ */
+export const METRICS_POOL_SIZING_ESTIMATE = 400;

--- a/src/core/metrics/tokenEncodings.ts
+++ b/src/core/metrics/tokenEncodings.ts
@@ -1,0 +1,4 @@
+// Supported token encoding types (OpenAI encoding names). Kept in its own
+// module so configSchema's startup import does not drag in gpt-tokenizer.
+export const TOKEN_ENCODINGS = ['o200k_base', 'cl100k_base', 'p50k_base', 'p50k_edit', 'r50k_base'] as const;
+export type TokenEncoding = (typeof TOKEN_ENCODINGS)[number];

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -12,6 +12,7 @@ import type { ProcessedFile } from './file/fileTypes.js';
 import { getGitDiffs } from './git/gitDiffHandle.js';
 import { getGitLogs } from './git/gitLogHandle.js';
 import { calculateMetrics, createMetricsTaskRunner } from './metrics/calculateMetrics.js';
+import { METRICS_POOL_SIZING_ESTIMATE } from './metrics/metricsPoolConfig.js';
 import { prefetchSortData, sortOutputFiles } from './output/outputSort.js';
 import { produceOutput } from './packager/produceOutput.js';
 import { createSecurityTaskRunner, type SuspiciousFileResult } from './security/securityCheck.js';
@@ -105,7 +106,7 @@ export const pack = async (
     // the metrics-phase wall time. The pool is reused by `calculateMetrics` (which does
     // not re-create it), so this is the final thread cap.
     ({ taskRunner: metricsTaskRunner, warmupPromise: metricsWarmupPromise } = deps.createMetricsTaskRunner(
-      400,
+      METRICS_POOL_SIZING_ESTIMATE,
       config.tokenCount.encoding,
     ));
 

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -95,14 +95,17 @@ export const pack = async (
     // critical path. Launching here lets that load overlap with searchFiles, security
     // check, fileProcess, and sortOutputFiles, collapsing the later await to a near no-op.
     //
-    // `numOfTasks` is a fixed estimate (actual file count is not yet known) — with
-    // TASKS_PER_THREAD=100 in processConcurrency.ts this maps to `maxThreads=2`. Benchmarks
-    // on the gpt-tokenizer workload show 2 workers outperform higher thread counts because
-    // per-file batches are small (~10 files) and IPC overhead dominates tokenization time.
-    // The pool is reused by `calculateMetrics` (which does not re-create it), so this is
-    // the final thread cap — it intentionally stays small across repo sizes.
+    // `numOfTasks=400` is a fixed estimate (actual file count is not yet known) — with
+    // TASKS_PER_THREAD=100 in processConcurrency.ts this maps to `maxThreads=4` on machines
+    // with ≥4 logical CPUs (capped at `availableParallelism` on smaller hosts, so a
+    // 2-CPU runner still gets 2 workers). Two workers leave one tokenizer fully blocked
+    // by the ~600ms git-log token count whenever `output.git.includeLogs` is enabled,
+    // starving file-metrics batches of parallelism. Bumping to four lets the git-log task
+    // own one tokenizer while the remaining three drain the file-metrics queue, halving
+    // the metrics-phase wall time. The pool is reused by `calculateMetrics` (which does
+    // not re-create it), so this is the final thread cap.
     ({ taskRunner: metricsTaskRunner, warmupPromise: metricsWarmupPromise } = deps.createMetricsTaskRunner(
-      200,
+      400,
       config.tokenCount.encoding,
     ));
 
@@ -113,8 +116,10 @@ export const pack = async (
     // parallel with searchFiles, collectFiles, and processFiles. Skipped when the user
     // disables the security check so `--no-security-check` pays none of this cost.
     //
-    // `numOfTasks=200` mirrors the metrics pool: with TASKS_PER_THREAD=100 it maps to
-    // `maxThreads=2`, the same cap `runSecurityCheck` applies internally.
+    // `numOfTasks=200` matches the cap `runSecurityCheck` applies internally
+    // (`MAX_SECURITY_WORKERS=2`): with TASKS_PER_THREAD=100 this maps to `maxThreads=2`.
+    // Kept lower than the metrics pool because secretlint batches are CPU-cheap and
+    // extra workers would only duplicate the ~150ms preset load with no parallelism win.
     if (config.security.enableSecurityCheck) {
       securityRunnerWithWarmup = deps.createSecurityTaskRunner(200);
     }

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -14,7 +14,7 @@ import { getGitLogs } from './git/gitLogHandle.js';
 import { calculateMetrics, createMetricsTaskRunner } from './metrics/calculateMetrics.js';
 import { prefetchSortData, sortOutputFiles } from './output/outputSort.js';
 import { produceOutput } from './packager/produceOutput.js';
-import type { SuspiciousFileResult } from './security/securityCheck.js';
+import { createSecurityTaskRunner, type SuspiciousFileResult } from './security/securityCheck.js';
 import { validateFileSafety } from './security/validateFileSafety.js';
 import type { PackSkillParams } from './skill/packSkill.js';
 
@@ -43,6 +43,7 @@ const defaultDeps = {
   produceOutput,
   calculateMetrics,
   createMetricsTaskRunner,
+  createSecurityTaskRunner,
   sortPaths,
   sortOutputFiles,
   prefetchSortData,
@@ -79,26 +80,45 @@ export const pack = async (
 
   logMemoryUsage('Pack - Start');
 
-  // Pre-initialize the metrics worker pool BEFORE searchFiles to maximise warmup overlap.
-  // Previously, warmup began after searchFiles + sortPaths and its ~500ms gpt-tokenizer
-  // BPE load still blocked the later `await metricsWarmupPromise` for ~250ms on the
-  // critical path. Launching here lets that load overlap with searchFiles, security
-  // check, fileProcess, and sortOutputFiles, collapsing the later await to a near no-op.
-  //
-  // `numOfTasks` is a fixed estimate (actual file count is not yet known) — with
-  // TASKS_PER_THREAD=100 in processConcurrency.ts this maps to `maxThreads=2`. Benchmarks
-  // on the gpt-tokenizer workload show 2 workers outperform higher thread counts because
-  // per-file batches are small (~10 files) and IPC overhead dominates tokenization time.
-  // The pool is reused by `calculateMetrics` (which does not re-create it), so this is
-  // the final thread cap — it intentionally stays small across repo sizes.
-  const { taskRunner: metricsTaskRunner, warmupPromise: metricsWarmupPromise } = deps.createMetricsTaskRunner(
-    200,
-    config.tokenCount.encoding,
-  );
+  // Pools are declared here and assigned inside the `try` so that a throw from
+  // either `createXxxTaskRunner` constructor (e.g. Tinypool failing to spawn a
+  // worker) still hits the `finally` block and disposes of whichever pool was
+  // successfully created.
+  let metricsTaskRunner: Awaited<ReturnType<typeof deps.createMetricsTaskRunner>>['taskRunner'] | null = null;
+  let metricsWarmupPromise: Awaited<ReturnType<typeof deps.createMetricsTaskRunner>>['warmupPromise'] | null = null;
+  let securityRunnerWithWarmup: ReturnType<typeof deps.createSecurityTaskRunner> | null = null;
 
-  // Place the pool inside the outer try/finally below to guarantee cleanup if any
-  // pre-collect step (searchFiles, sortPaths, etc.) throws before the inner work.
   try {
+    // Pre-initialize the metrics worker pool BEFORE searchFiles to maximise warmup overlap.
+    // Previously, warmup began after searchFiles + sortPaths and its ~500ms gpt-tokenizer
+    // BPE load still blocked the later `await metricsWarmupPromise` for ~250ms on the
+    // critical path. Launching here lets that load overlap with searchFiles, security
+    // check, fileProcess, and sortOutputFiles, collapsing the later await to a near no-op.
+    //
+    // `numOfTasks` is a fixed estimate (actual file count is not yet known) — with
+    // TASKS_PER_THREAD=100 in processConcurrency.ts this maps to `maxThreads=2`. Benchmarks
+    // on the gpt-tokenizer workload show 2 workers outperform higher thread counts because
+    // per-file batches are small (~10 files) and IPC overhead dominates tokenization time.
+    // The pool is reused by `calculateMetrics` (which does not re-create it), so this is
+    // the final thread cap — it intentionally stays small across repo sizes.
+    ({ taskRunner: metricsTaskRunner, warmupPromise: metricsWarmupPromise } = deps.createMetricsTaskRunner(
+      200,
+      config.tokenCount.encoding,
+    ));
+
+    // Pre-initialize the security worker pool for the same reason as the metrics warmup:
+    // `@secretlint/core` + its recommended rule preset take ~150ms to load inside the
+    // worker, and without a pre-warmup that load sits on the critical path between
+    // `collectFiles` and the security result. Launching here lets secretlint load in
+    // parallel with searchFiles, collectFiles, and processFiles. Skipped when the user
+    // disables the security check so `--no-security-check` pays none of this cost.
+    //
+    // `numOfTasks=200` mirrors the metrics pool: with TASKS_PER_THREAD=100 it maps to
+    // `maxThreads=2`, the same cap `runSecurityCheck` applies internally.
+    if (config.security.enableSecurityCheck) {
+      securityRunnerWithWarmup = deps.createSecurityTaskRunner(200);
+    }
+
     // Pre-fetch git file-change counts for sortOutputFiles while search and
     // collection are in flight, so the later sortOutputFiles call is a cache hit.
     const sortDataPromise = deps.prefetchSortData(config).catch((error) => {
@@ -161,7 +181,9 @@ export const pack = async (
     // After both complete, filter out any suspicious files from the processed results.
     const [validationResult, allProcessedFiles] = await Promise.all([
       withMemoryLogging('Security Check', () =>
-        deps.validateFileSafety(rawFiles, progressCallback, config, gitDiffResult, gitLogResult),
+        deps.validateFileSafety(rawFiles, progressCallback, config, gitDiffResult, gitLogResult, {
+          securityTaskRunner: securityRunnerWithWarmup?.taskRunner,
+        }),
       ),
       withMemoryLogging('Process Files', () => {
         progressCallback('Processing files...');
@@ -249,7 +271,10 @@ export const pack = async (
           gitDiffResult,
           gitLogResult,
           {
-            taskRunner: metricsTaskRunner,
+            // Non-null: if the pool constructor had failed, the throw would
+            // have bypassed this point and gone straight to `finally`.
+            // biome-ignore lint/style/noNonNullAssertion: see comment above
+            taskRunner: metricsTaskRunner!,
           },
         ),
       ),
@@ -271,7 +296,17 @@ export const pack = async (
 
     return result;
   } finally {
-    await metricsWarmupPromise.catch(() => {});
-    await metricsTaskRunner.cleanup();
+    // Null checks guard against `createXxxTaskRunner` having thrown before
+    // assignment — in that case there's nothing to await or dispose.
+    if (metricsWarmupPromise) {
+      await metricsWarmupPromise.catch(() => {});
+    }
+    if (metricsTaskRunner) {
+      await metricsTaskRunner.cleanup();
+    }
+    if (securityRunnerWithWarmup) {
+      await securityRunnerWithWarmup.warmupPromise.catch(() => {});
+      await securityRunnerWithWarmup.taskRunner.cleanup();
+    }
   }
 };

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -79,48 +79,60 @@ export const pack = async (
 
   logMemoryUsage('Pack - Start');
 
-  // Pre-fetch git file-change counts for sortOutputFiles while search and
-  // collection are in flight, so the later sortOutputFiles call is a cache hit.
-  const sortDataPromise = deps.prefetchSortData(config).catch((error) => {
-    logger.trace('Failed to prefetch sort data:', error);
-  });
-
-  progressCallback('Searching for files...');
-  const searchResultsByDir = await withMemoryLogging('Search Files', async () =>
-    Promise.all(
-      rootDirs.map(async (rootDir) => {
-        const result = await deps.searchFiles(rootDir, config, explicitFiles);
-        return { rootDir, filePaths: result.filePaths, emptyDirPaths: result.emptyDirPaths };
-      }),
-    ),
-  );
-
-  // Deduplicate and sort empty directory paths for reuse during output generation,
-  // avoiding a redundant searchFiles call in buildOutputGeneratorContext.
-  const emptyDirPaths = config.output.includeEmptyDirectories
-    ? [...new Set(searchResultsByDir.flatMap((r) => r.emptyDirPaths))].sort()
-    : undefined;
-
-  // Sort file paths
-  progressCallback('Sorting files...');
-  const allFilePaths = searchResultsByDir.flatMap(({ filePaths }) => filePaths);
-  const sortedFilePaths = deps.sortPaths(allFilePaths);
-
-  // Regroup sorted file paths by rootDir using Set for O(1) membership checks
-  const filePathSetByDir = new Map(searchResultsByDir.map(({ rootDir, filePaths }) => [rootDir, new Set(filePaths)]));
-  const sortedFilePathsByDir = rootDirs.map((rootDir) => ({
-    rootDir,
-    filePaths: sortedFilePaths.filter((filePath) => filePathSetByDir.get(rootDir)?.has(filePath) ?? false),
-  }));
-
-  // Pre-initialize metrics worker pool to overlap gpt-tokenizer loading with subsequent pipeline stages
-  // (security check, file processing, output generation).
+  // Pre-initialize the metrics worker pool BEFORE searchFiles to maximise warmup overlap.
+  // Previously, warmup began after searchFiles + sortPaths and its ~500ms gpt-tokenizer
+  // BPE load still blocked the later `await metricsWarmupPromise` for ~250ms on the
+  // critical path. Launching here lets that load overlap with searchFiles, security
+  // check, fileProcess, and sortOutputFiles, collapsing the later await to a near no-op.
+  //
+  // `numOfTasks` is a fixed estimate (actual file count is not yet known) — with
+  // TASKS_PER_THREAD=100 in processConcurrency.ts this maps to `maxThreads=2`. Benchmarks
+  // on the gpt-tokenizer workload show 2 workers outperform higher thread counts because
+  // per-file batches are small (~10 files) and IPC overhead dominates tokenization time.
+  // The pool is reused by `calculateMetrics` (which does not re-create it), so this is
+  // the final thread cap — it intentionally stays small across repo sizes.
   const { taskRunner: metricsTaskRunner, warmupPromise: metricsWarmupPromise } = deps.createMetricsTaskRunner(
-    allFilePaths.length,
+    200,
     config.tokenCount.encoding,
   );
 
+  // Place the pool inside the outer try/finally below to guarantee cleanup if any
+  // pre-collect step (searchFiles, sortPaths, etc.) throws before the inner work.
   try {
+    // Pre-fetch git file-change counts for sortOutputFiles while search and
+    // collection are in flight, so the later sortOutputFiles call is a cache hit.
+    const sortDataPromise = deps.prefetchSortData(config).catch((error) => {
+      logger.trace('Failed to prefetch sort data:', error);
+    });
+
+    progressCallback('Searching for files...');
+    const searchResultsByDir = await withMemoryLogging('Search Files', async () =>
+      Promise.all(
+        rootDirs.map(async (rootDir) => {
+          const result = await deps.searchFiles(rootDir, config, explicitFiles);
+          return { rootDir, filePaths: result.filePaths, emptyDirPaths: result.emptyDirPaths };
+        }),
+      ),
+    );
+
+    // Deduplicate and sort empty directory paths for reuse during output generation,
+    // avoiding a redundant searchFiles call in buildOutputGeneratorContext.
+    const emptyDirPaths = config.output.includeEmptyDirectories
+      ? [...new Set(searchResultsByDir.flatMap((r) => r.emptyDirPaths))].sort()
+      : undefined;
+
+    // Sort file paths
+    progressCallback('Sorting files...');
+    const allFilePaths = searchResultsByDir.flatMap(({ filePaths }) => filePaths);
+    const sortedFilePaths = deps.sortPaths(allFilePaths);
+
+    // Regroup sorted file paths by rootDir using Set for O(1) membership checks
+    const filePathSetByDir = new Map(searchResultsByDir.map(({ rootDir, filePaths }) => [rootDir, new Set(filePaths)]));
+    const sortedFilePathsByDir = rootDirs.map((rootDir) => ({
+      rootDir,
+      filePaths: sortedFilePaths.filter((filePath) => filePathSetByDir.get(rootDir)?.has(filePath) ?? false),
+    }));
+
     // Run file collection and git operations in parallel since they are independent:
     // - collectFiles reads file contents from disk
     // - getGitDiffs/getGitLogs spawn git subprocesses

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -117,12 +117,14 @@ export const pack = async (
     // parallel with searchFiles, collectFiles, and processFiles. Skipped when the user
     // disables the security check so `--no-security-check` pays none of this cost.
     //
-    // `numOfTasks=200` matches the cap `runSecurityCheck` applies internally
-    // (`MAX_SECURITY_WORKERS=2`): with TASKS_PER_THREAD=100 this maps to `maxThreads=2`.
-    // Kept lower than the metrics pool because secretlint batches are CPU-cheap and
-    // extra workers would only duplicate the ~150ms preset load with no parallelism win.
+    // `numOfTasks=400` matches the cap `runSecurityCheck` applies internally
+    // (`MAX_SECURITY_WORKERS=4`): with TASKS_PER_THREAD=100 this maps to `maxThreads=4` on
+    // machines with ≥4 logical CPUs (capped at `availableParallelism` on smaller hosts, so
+    // a 2-CPU runner still gets 2 workers). Going from 2 to 4 workers roughly halves the
+    // secretlint wall time for a ~1000-file repo; the security pool runs during Phase 3
+    // while the metrics pool is idle, so the extra threads cost nothing.
     if (config.security.enableSecurityCheck) {
-      securityRunnerWithWarmup = deps.createSecurityTaskRunner(200);
+      securityRunnerWithWarmup = deps.createSecurityTaskRunner(400);
     }
 
     // Pre-fetch git file-change counts for sortOutputFiles while search and

--- a/src/core/packager/produceOutput.ts
+++ b/src/core/packager/produceOutput.ts
@@ -5,7 +5,7 @@ import type { FilesByRoot } from '../file/fileTreeGenerate.js';
 import type { ProcessedFile } from '../file/fileTypes.js';
 import type { GitDiffResult } from '../git/gitDiffHandle.js';
 import type { GitLogResult } from '../git/gitLogHandle.js';
-import { generateOutput as generateOutputDefault } from '../output/outputGenerate.js';
+import type { generateOutput as generateOutputType } from '../output/outputGenerate.js';
 import { generateSplitOutputParts } from '../output/outputSplit.js';
 import { copyToClipboardIfEnabled as copyToClipboardIfEnabledDefault } from './copyToClipboardIfEnabled.js';
 import { writeOutputToDisk as writeOutputToDiskDefault } from './writeOutputToDisk.js';
@@ -15,8 +15,19 @@ export interface ProduceOutputResult {
   outputForMetrics: string | string[];
 }
 
+// Lazy-load outputGenerate to keep its Handlebars dependency off the
+// `import(defaultAction)` static chain. Handlebars is only needed at output
+// time; `pack()` runs produceOutput in parallel with calculateMetrics, so the
+// deferred parse overlaps with the metrics phase rather than extending the
+// cold-start critical path before searchFiles begins. Mirrors the lazy-load
+// pattern used for packSkill in packager.ts.
+const defaultGenerateOutput: typeof generateOutputType = async (...args) => {
+  const { generateOutput } = await import('../output/outputGenerate.js');
+  return generateOutput(...args);
+};
+
 const defaultDeps = {
-  generateOutput: generateOutputDefault,
+  generateOutput: defaultGenerateOutput,
   writeOutputToDisk: writeOutputToDiskDefault,
   copyToClipboardIfEnabled: copyToClipboardIfEnabledDefault,
 };

--- a/src/core/security/securityCheck.ts
+++ b/src/core/security/securityCheck.ts
@@ -3,6 +3,7 @@ import { logger } from '../../shared/logger.js';
 import {
   getProcessConcurrency as defaultGetProcessConcurrency,
   initTaskRunner,
+  type TaskRunner,
 } from '../../shared/processConcurrency.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
 import type { RawFile } from '../file/fileTypes.js';
@@ -18,6 +19,13 @@ export interface SuspiciousFileResult {
   type: SecurityCheckType;
 }
 
+export type SecurityCheckTaskRunner = TaskRunner<SecurityCheckTask, (SuspiciousFileResult | null)[]>;
+
+export interface SecurityTaskRunnerWithWarmup {
+  taskRunner: SecurityCheckTaskRunner;
+  warmupPromise: Promise<unknown>;
+}
+
 // Batch size for grouping files into worker tasks to reduce IPC overhead.
 // Each batch is sent as a single message to a worker thread, avoiding
 // per-file round-trip costs that dominate when processing many files.
@@ -27,16 +35,56 @@ export interface SuspiciousFileResult {
 // is disabled, and needs a smaller batch size to avoid one batch monopolizing a worker.)
 const BATCH_SIZE = 50;
 
+// Cap security workers at 2 to reduce contention with the metrics worker pool that
+// runs concurrently. The security check uses coarse-grained batches (BATCH_SIZE=50),
+// so 2 workers provide sufficient parallelism even for large repos (1000 files = 20 batches).
+const MAX_SECURITY_WORKERS = 2;
+
+// Create a security worker task runner and fire a no-op warmup task per worker
+// so `@secretlint/core` and its rule preset load in parallel with the rest of
+// the pack pipeline (searchFiles, collectFiles, fileProcess), removing the
+// ~150ms worker-spawn + secretlint module-load cost from the critical path.
+// Mirrors `createMetricsTaskRunner` in shape.
+export const createSecurityTaskRunner = (
+  numOfTasks: number,
+  deps = {
+    initTaskRunner,
+    getProcessConcurrency: defaultGetProcessConcurrency,
+  },
+): SecurityTaskRunnerWithWarmup => {
+  const maxSecurityWorkers = Math.min(MAX_SECURITY_WORKERS, deps.getProcessConcurrency());
+  const taskRunner = deps.initTaskRunner<SecurityCheckTask, (SuspiciousFileResult | null)[]>({
+    numOfTasks,
+    workerType: 'securityCheck',
+    runtime: 'worker_threads',
+    maxWorkerThreads: maxSecurityWorkers,
+  });
+
+  // Each warmup task has an empty `items` array, so the worker's file loop is
+  // a no-op — only the module load cost is paid, once per worker.
+  const warmupPromise = Promise.all(
+    Array.from({ length: maxSecurityWorkers }, () => taskRunner.run({ items: [] }).catch(() => [])),
+  );
+
+  return { taskRunner, warmupPromise };
+};
+
 export const runSecurityCheck = async (
   rawFiles: RawFile[],
   progressCallback: RepomixProgressCallback = () => {},
   gitDiffResult?: GitDiffResult,
   gitLogResult?: GitLogResult,
-  deps = {
-    initTaskRunner,
-    getProcessConcurrency: defaultGetProcessConcurrency,
-  },
+  deps: {
+    initTaskRunner?: typeof initTaskRunner;
+    getProcessConcurrency?: typeof defaultGetProcessConcurrency;
+    // Pre-warmed task runner from `createSecurityTaskRunner`. When supplied
+    // the inner cleanup is skipped so the caller retains ownership of the
+    // pool (cleaned up in `pack()`'s outer `finally`).
+    taskRunner?: SecurityCheckTaskRunner;
+  } = {},
 ): Promise<SuspiciousFileResult[]> => {
+  const initTaskRunnerFn = deps.initTaskRunner ?? initTaskRunner;
+  const getProcessConcurrencyFn = deps.getProcessConcurrency ?? defaultGetProcessConcurrency;
   const gitDiffItems: SecurityCheckItem[] = [];
   const gitLogItems: SecurityCheckItem[] = [];
 
@@ -84,18 +132,18 @@ export const runSecurityCheck = async (
     return [];
   }
 
-  // Cap security workers at 2 to reduce contention with the metrics worker pool that
-  // runs concurrently. The security check uses coarse-grained batches (BATCH_SIZE=50),
-  // so 2 workers provide sufficient parallelism even for large repos (1000 files = 20 batches).
-  const maxSecurityWorkers = Math.min(2, deps.getProcessConcurrency());
-
+  // Reuse a pre-warmed task runner when provided by `pack()` via
+  // `createSecurityTaskRunner`; the caller then owns the pool lifecycle.
+  const ownedTaskRunner = deps.taskRunner ?? null;
   // numOfTasks uses totalItems (not batches.length) to avoid under-sizing the pool.
-  const taskRunner = deps.initTaskRunner<SecurityCheckTask, (SuspiciousFileResult | null)[]>({
-    numOfTasks: totalItems,
-    workerType: 'securityCheck',
-    runtime: 'worker_threads',
-    maxWorkerThreads: maxSecurityWorkers,
-  });
+  const taskRunner =
+    ownedTaskRunner ??
+    initTaskRunnerFn<SecurityCheckTask, (SuspiciousFileResult | null)[]>({
+      numOfTasks: totalItems,
+      workerType: 'securityCheck',
+      runtime: 'worker_threads',
+      maxWorkerThreads: Math.min(MAX_SECURITY_WORKERS, getProcessConcurrencyFn()),
+    });
 
   // Split items into batches to reduce IPC round-trips
   const batches: SecurityCheckItem[][] = [];
@@ -131,6 +179,10 @@ export const runSecurityCheck = async (
     logger.error('Error during security check:', error);
     throw error;
   } finally {
-    await taskRunner.cleanup();
+    // Only dispose of the pool when we created it ourselves. An externally
+    // owned pool (pre-warmed by `pack()`) is cleaned up by the caller.
+    if (!ownedTaskRunner) {
+      await taskRunner.cleanup();
+    }
   }
 };

--- a/src/core/security/securityCheck.ts
+++ b/src/core/security/securityCheck.ts
@@ -35,10 +35,16 @@ export interface SecurityTaskRunnerWithWarmup {
 // is disabled, and needs a smaller batch size to avoid one batch monopolizing a worker.)
 const BATCH_SIZE = 50;
 
-// Cap security workers at 2 to reduce contention with the metrics worker pool that
-// runs concurrently. The security check uses coarse-grained batches (BATCH_SIZE=50),
-// so 2 workers provide sufficient parallelism even for large repos (1000 files = 20 batches).
-const MAX_SECURITY_WORKERS = 2;
+// Cap security workers at 4. Earlier the cap was 2 to "reduce contention with the metrics
+// worker pool", but on the default pack path the two pools execute in sequential phases
+// — security inside `Promise.all([validateFileSafety, processFiles])`, and metrics inside
+// `Promise.all([produceOutput, calculateMetrics])` after `sortOutputFiles` — so the metrics
+// pool is idle during the security phase. (The `--skill-generate` path returns early before
+// the metrics pool runs, so still no concurrent use there.) Claiming 4 cores for secretlint
+// roughly halves security wall time on a ~1000-file repo. `getWorkerThreadCount` clips to
+// `availableParallelism`, so a 2-CPU host still gets 2 workers — no regression on
+// resource-constrained machines.
+const MAX_SECURITY_WORKERS = 4;
 
 // Create a security worker task runner and fire a no-op warmup task per worker
 // so `@secretlint/core` and its rule preset load in parallel with the rest of

--- a/src/core/security/validateFileSafety.ts
+++ b/src/core/security/validateFileSafety.ts
@@ -5,7 +5,7 @@ import type { RawFile } from '../file/fileTypes.js';
 import type { GitDiffResult } from '../git/gitDiffHandle.js';
 import type { GitLogResult } from '../git/gitLogHandle.js';
 import { filterOutUntrustedFiles } from './filterOutUntrustedFiles.js';
-import { runSecurityCheck, type SuspiciousFileResult } from './securityCheck.js';
+import { runSecurityCheck, type SecurityCheckTaskRunner, type SuspiciousFileResult } from './securityCheck.js';
 
 // Marks which files are suspicious and which are safe
 // Returns Git diff results separately so they can be included in the output
@@ -16,18 +16,32 @@ export const validateFileSafety = async (
   config: RepomixConfigMerged,
   gitDiffResult?: GitDiffResult,
   gitLogResult?: GitLogResult,
-  deps = {
-    runSecurityCheck,
-    filterOutUntrustedFiles,
-  },
+  deps: {
+    runSecurityCheck?: typeof runSecurityCheck;
+    filterOutUntrustedFiles?: typeof filterOutUntrustedFiles;
+    // Pre-warmed security worker pool supplied by `pack()` via
+    // `createSecurityTaskRunner`. When present we pass it through to
+    // `runSecurityCheck` so secretlint loading overlaps with the rest of the
+    // pack pipeline instead of blocking between collect and security.
+    securityTaskRunner?: SecurityCheckTaskRunner;
+  } = {},
 ) => {
+  const runSecurityCheckFn = deps.runSecurityCheck ?? runSecurityCheck;
+  const filterOutUntrustedFilesFn = deps.filterOutUntrustedFiles ?? filterOutUntrustedFiles;
+
   let suspiciousFilesResults: SuspiciousFileResult[] = [];
   let suspiciousGitDiffResults: SuspiciousFileResult[] = [];
   let suspiciousGitLogResults: SuspiciousFileResult[] = [];
 
   if (config.security.enableSecurityCheck) {
     progressCallback('Running security check...');
-    const allResults = await deps.runSecurityCheck(rawFiles, progressCallback, gitDiffResult, gitLogResult);
+    const allResults = await runSecurityCheckFn(
+      rawFiles,
+      progressCallback,
+      gitDiffResult,
+      gitLogResult,
+      deps.securityTaskRunner ? { taskRunner: deps.securityTaskRunner } : undefined,
+    );
 
     // Separate Git diff and Git log results from regular file results
     suspiciousFilesResults = allResults.filter((result) => result.type === 'file');
@@ -38,7 +52,7 @@ export const validateFileSafety = async (
     logSuspiciousContentWarning('Git logs', suspiciousGitLogResults);
   }
 
-  const safeRawFiles = deps.filterOutUntrustedFiles(rawFiles, suspiciousFilesResults);
+  const safeRawFiles = filterOutUntrustedFilesFn(rawFiles, suspiciousFilesResults);
   const safeFilePaths = safeRawFiles.map((file) => file.path);
   logger.trace('Safe files count:', safeRawFiles.length);
 

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -109,9 +109,25 @@ describe('fileSearch', () => {
       const mockFilePaths = ['src/file1.js', 'src/file2.js'];
       const mockEmptyDirs = ['src/empty', 'empty-root'];
 
+      // A single combined scan (`objectMode: true`) returns `GlobEntry`-shaped
+      // objects so the caller can partition by `dirent.isFile()` /
+      // `dirent.isDirectory()` without a second walk.
+      const makeEntry = (path: string, type: 'file' | 'dir') => ({
+        path,
+        name: path,
+        dirent: {
+          isFile: () => type === 'file',
+          isDirectory: () => type === 'dir',
+          isSymbolicLink: () => false,
+        },
+      });
       vi.mocked(globby).mockImplementation(async (_: unknown, options: unknown) => {
-        if ((options as Record<string, unknown>)?.onlyDirectories) {
-          return mockEmptyDirs;
+        const opts = options as Record<string, unknown>;
+        if (opts?.objectMode === true) {
+          return [
+            ...mockFilePaths.map((p) => makeEntry(p, 'file')),
+            ...mockEmptyDirs.map((p) => makeEntry(p, 'dir')),
+          ] as unknown as string[];
         }
         return mockFilePaths;
       });
@@ -122,6 +138,8 @@ describe('fileSearch', () => {
 
       expect(result.filePaths).toEqual(mockFilePaths);
       expect(result.emptyDirPaths.sort()).toEqual(mockEmptyDirs.sort());
+      // Single combined scan rather than two back-to-back globby calls.
+      expect(globby).toHaveBeenCalledTimes(1);
     });
 
     test('should not collect empty directories when disabled', async () => {
@@ -134,7 +152,8 @@ describe('fileSearch', () => {
       const mockFilePaths = ['src/file1.js', 'src/file2.js'];
 
       vi.mocked(globby).mockImplementation(async (_: unknown, options: unknown) => {
-        if ((options as Record<string, unknown>)?.onlyDirectories) {
+        const opts = options as Record<string, unknown>;
+        if (opts?.onlyDirectories === true || opts?.objectMode === true) {
           throw new Error('Should not search for directories when disabled');
         }
         return mockFilePaths;
@@ -145,6 +164,47 @@ describe('fileSearch', () => {
       expect(result.filePaths).toEqual(mockFilePaths);
       expect(result.emptyDirPaths).toEqual([]);
       expect(globby).toHaveBeenCalledTimes(1);
+    });
+
+    test('should exclude symlinks (to files or directories) from both results', async () => {
+      const mockConfig = createMockConfig({
+        output: {
+          includeEmptyDirectories: true,
+        },
+      });
+
+      // Simulates globby's behaviour under `followSymbolicLinks: false`:
+      // symlink dirents report neither isFile() nor isDirectory() as true.
+      // Those entries must not appear in either the files or directories list.
+      vi.mocked(globby).mockImplementation(async (_: unknown, options: unknown) => {
+        const opts = options as Record<string, unknown>;
+        if (opts?.objectMode === true) {
+          return [
+            {
+              path: 'src/file.js',
+              name: 'file.js',
+              dirent: { isFile: () => true, isDirectory: () => false, isSymbolicLink: () => false },
+            },
+            {
+              path: 'src/empty',
+              name: 'empty',
+              dirent: { isFile: () => false, isDirectory: () => true, isSymbolicLink: () => false },
+            },
+            {
+              path: 'src/link-to-dir',
+              name: 'link-to-dir',
+              dirent: { isFile: () => false, isDirectory: () => false, isSymbolicLink: () => true },
+            },
+          ] as unknown as string[];
+        }
+        return [] as string[];
+      });
+      vi.mocked(fs.readdir).mockResolvedValue([]);
+
+      const result = await searchFiles('/mock/root', mockConfig);
+
+      expect(result.filePaths).toEqual(['src/file.js']);
+      expect(result.emptyDirPaths).toEqual(['src/empty']);
     });
   });
 
@@ -928,9 +988,9 @@ node_modules
       await listDirectories('/test/root', mockConfig);
       await listFiles('/test/root', mockConfig);
 
-      // searchFiles calls globby twice (files + directories if includeEmptyDirectories is true)
-      // listDirectories calls globby once
-      // listFiles calls globby once
+      // searchFiles, listDirectories, and listFiles each issue one globby call
+      // with the default config here (no `includeEmptyDirectories`, so
+      // searchFiles takes the `onlyFiles: true` branch).
       const calls = vi.mocked(globby).mock.calls;
 
       // Verify all calls have consistent base options

--- a/tests/core/git/gitRepositoryHandle.test.ts
+++ b/tests/core/git/gitRepositoryHandle.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { getFileChangeCount, isGitInstalled, isGitRepository } from '../../../src/core/git/gitRepositoryHandle.js';
+import * as gitCommand from '../../../src/core/git/gitCommand.js';
+import {
+  clearIsGitRepositoryCache,
+  getFileChangeCount,
+  isGitInstalled,
+  isGitRepository,
+} from '../../../src/core/git/gitRepositoryHandle.js';
 import { logger } from '../../../src/shared/logger.js';
 
 vi.mock('../../../src/shared/logger');
@@ -7,6 +13,9 @@ vi.mock('../../../src/shared/logger');
 describe('gitRepositoryHandle', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    // Default-deps callers share a module-level cache; reset between tests
+    // so stale entries never leak across cases.
+    clearIsGitRepositoryCache();
   });
 
   describe('getFileChangeCount', () => {
@@ -71,6 +80,35 @@ describe('gitRepositoryHandle', () => {
 
       expect(result).toBe(false);
       expect(mockExecGitRevParse).toHaveBeenCalledWith('/test/dir');
+    });
+
+    test('should dedupe concurrent default-deps calls for the same directory', async () => {
+      // Spy on the real `execGitRevParse` so the default-deps path hits the
+      // cache. Each invocation would otherwise spawn its own subprocess.
+      const spy = vi.spyOn(gitCommand, 'execGitRevParse').mockResolvedValue('true');
+
+      const [r1, r2, r3] = await Promise.all([
+        isGitRepository('/cached/dir'),
+        isGitRepository('/cached/dir'),
+        isGitRepository('/cached/dir'),
+      ]);
+
+      expect([r1, r2, r3]).toEqual([true, true, true]);
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      spy.mockRestore();
+    });
+
+    test('clearIsGitRepositoryCache forces the next default-deps call to re-run', async () => {
+      const spy = vi.spyOn(gitCommand, 'execGitRevParse').mockResolvedValue('true');
+
+      await isGitRepository('/reset/dir');
+      clearIsGitRepositoryCache();
+      await isGitRepository('/reset/dir');
+
+      expect(spy).toHaveBeenCalledTimes(2);
+
+      spy.mockRestore();
     });
   });
 

--- a/tests/core/metrics/calculateFileMetrics.test.ts
+++ b/tests/core/metrics/calculateFileMetrics.test.ts
@@ -48,7 +48,8 @@ describe('calculateFileMetrics', () => {
       taskRunner: mockInitTaskRunner({ numOfTasks: 1, workerType: 'calculateMetrics', runtime: 'worker_threads' }),
     });
 
-    expect(result).toEqual([
+    // sort before compare — result order is not part of the function's contract
+    expect(result.sort((a, b) => a.path.localeCompare(b.path))).toEqual([
       { path: 'file1.txt', charCount: 100, tokenCount: 13 },
       { path: 'file3.txt', charCount: 300, tokenCount: 75 },
     ]);

--- a/tests/core/packager.test.ts
+++ b/tests/core/packager.test.ts
@@ -58,6 +58,13 @@ describe('packager', () => {
         },
         warmupPromise: Promise.resolve(),
       }),
+      createSecurityTaskRunner: vi.fn().mockReturnValue({
+        taskRunner: {
+          run: vi.fn().mockResolvedValue([]),
+          cleanup: vi.fn().mockResolvedValue(undefined),
+        },
+        warmupPromise: Promise.resolve(),
+      }),
       calculateMetrics: vi.fn().mockResolvedValue({
         totalFiles: 2,
         totalCharacters: 11,
@@ -92,6 +99,7 @@ describe('packager', () => {
       mockConfig,
       undefined,
       undefined,
+      expect.anything(),
     );
     expect(mockDeps.processFiles).toHaveBeenCalledWith(mockRawFiles, mockConfig, progressCallback);
     expect(mockDeps.produceOutput).toHaveBeenCalledWith(

--- a/tests/core/packager/diffsFunctionality.test.ts
+++ b/tests/core/packager/diffsFunctionality.test.ts
@@ -80,6 +80,13 @@ index 123..456 100644
       },
       warmupPromise: Promise.resolve(),
     });
+    const mockCreateSecurityTaskRunner = vi.fn().mockReturnValue({
+      taskRunner: {
+        run: vi.fn().mockResolvedValue([]),
+        cleanup: vi.fn().mockResolvedValue(undefined),
+      },
+      warmupPromise: Promise.resolve(),
+    });
 
     // Config with diffs disabled
     if (mockConfig.output.git) {
@@ -94,6 +101,7 @@ index 123..456 100644
       produceOutput: mockProduceOutput,
       calculateMetrics: mockCalculateMetrics,
       createMetricsTaskRunner: mockCreateMetricsTaskRunner,
+      createSecurityTaskRunner: mockCreateSecurityTaskRunner,
       sortPaths: mockSortPaths,
     });
 
@@ -138,6 +146,13 @@ index 123..456 100644
       },
       warmupPromise: Promise.resolve(),
     });
+    const mockCreateSecurityTaskRunner = vi.fn().mockReturnValue({
+      taskRunner: {
+        run: vi.fn().mockResolvedValue([]),
+        cleanup: vi.fn().mockResolvedValue(undefined),
+      },
+      warmupPromise: Promise.resolve(),
+    });
 
     // Config with diffs enabled
     if (mockConfig.output.git) {
@@ -152,6 +167,7 @@ index 123..456 100644
       produceOutput: mockProduceOutput,
       calculateMetrics: mockCalculateMetrics,
       createMetricsTaskRunner: mockCreateMetricsTaskRunner,
+      createSecurityTaskRunner: mockCreateSecurityTaskRunner,
       sortPaths: mockSortPaths,
     });
 

--- a/tests/core/packager/splitOutput.test.ts
+++ b/tests/core/packager/splitOutput.test.ts
@@ -62,6 +62,13 @@ describe('packager split output', () => {
         },
         warmupPromise: Promise.resolve(),
       }),
+      createSecurityTaskRunner: vi.fn().mockReturnValue({
+        taskRunner: {
+          run: vi.fn().mockResolvedValue([]),
+          cleanup: vi.fn().mockResolvedValue(undefined),
+        },
+        warmupPromise: Promise.resolve(),
+      }),
     });
 
     expect(produceOutput).toHaveBeenCalledWith(

--- a/tests/core/security/validateFileSafety.test.ts
+++ b/tests/core/security/validateFileSafety.test.ts
@@ -27,7 +27,7 @@ describe('validateFileSafety', () => {
 
     const result = await validateFileSafety(rawFiles, progressCallback, config, undefined, undefined, deps);
 
-    expect(deps.runSecurityCheck).toHaveBeenCalledWith(rawFiles, progressCallback, undefined, undefined);
+    expect(deps.runSecurityCheck).toHaveBeenCalledWith(rawFiles, progressCallback, undefined, undefined, undefined);
     expect(deps.filterOutUntrustedFiles).toHaveBeenCalledWith(rawFiles, suspiciousFilesResults);
     expect(result).toEqual({
       safeRawFiles,

--- a/tests/integration-tests/packager.test.ts
+++ b/tests/integration-tests/packager.test.ts
@@ -122,6 +122,13 @@ describe.runIf(!isWindows)('packager integration', () => {
           },
           warmupPromise: Promise.resolve(),
         }),
+        createSecurityTaskRunner: () => ({
+          taskRunner: {
+            run: async () => [],
+            cleanup: async () => {},
+          },
+          warmupPromise: Promise.resolve(),
+        }),
         calculateMetrics: async (
           processedFiles,
           _output,


### PR DESCRIPTION
## Summary

This PR collects automated performance-tuning commits that together shave the `node bin/repomix.cjs` critical path. Each commit is benchmarked in its own body; the latest commit is summarised below.

### Latest commit: `perf(file): Raise file-collect concurrency from 50 to 128`

`collectFiles` reads file contents through a `promisePool` capped at `FILE_COLLECT_CONCURRENCY = 50`. That cap was conservative — well below what a modern Node runtime sustains on a few hundred files of typical source code. A 1,024-file `fs.readFile` micro-benchmark on this repo showed the I/O phase plateau between 100 and 128 (50→97 ms, 100→79 ms, 128→78 ms, 200→71 ms — diminishing returns past 128), so 128 captures the bulk of the available speedup without pushing the in-flight FD count past the macOS soft limit of 256 (Linux is 1024). Memory remains negligible: at ~5 KB average per file, 128 in-flight reads peak around 640 KB.

The `promisePool` implementation already handles backpressure correctly — only the constant changes. Output is byte-identical (md5 verified across 60 paired runs and again by an independent reviewer).

## Benchmark

Interleaved A/B `node bin/repomix.cjs --quiet -o /tmp/out.xml` on this repo (1041 files, default xml output, `includeDiffs` / `includeLogs` / `sortByChanges` enabled), 16-CPU Linux/v9fs host, 5 warmup runs + 60 measured runs per side, hyperfine `--shell=none`:

| n  | base mean | patch mean | delta   | improvement |
|---:|----------:|-----------:|--------:|------------:|
| 60 | 2.454 s   | 2.339 s    | -115 ms | 4.69 %      |

Hyperfine ratio: patched ran 1.05 ± 0.08× faster than baseline. Mean delta SE ≈ 24 ms (60 paired samples), t ≈ 4.8, well above the 2 % / ~49 ms acceptance bar.

An independent re-benchmark by the perf-claim reviewer (n=30) measured a *larger* effect: median delta 198.5 ms / 8.85 %, mean delta 153.9 ms / 6.88 %, Welch t = 4.69, p ≪ 0.001. MD5 of the generated 4.4 MB XML was identical between baseline and patched.

### Investigation summary

Five parallel investigation sub-agents covered: file collection / processing pipeline, token counting & tiktoken, output generation phase, worker-pool / IPC architecture, and startup / module-loading cost. Their best candidates by estimated impact:

| Candidate                                                                  | Estimated | Outcome |
|----------------------------------------------------------------------------|----------:|---------|
| Raise `FILE_COLLECT_CONCURRENCY` from 50 to 128                            | ~35-70 ms | **Selected.** A/B benchmark: -115 ms / 4.69 % (n=60); independent re-bench: -154 ms / 6.88 % (n=30). |
| `minThreads = maxThreads` so all 4 metrics workers spawn upfront           | ~150-200 ms | Not selected — verbose-trace timing showed the 4 BPE loads already complete in ~270-440 ms (workers spawn lazily but in parallel via the 4-task `Promise.all` warmup). The `await metricsWarmupPromise` later in the pipeline is already a near-no-op because warmup finishes during `searchFiles`+`collectFiles` (~600 ms). |
| Bump `METRICS_POOL_SIZING_ESTIMATE` from 400 to 600 (4→6 metrics workers) | ~50-130 ms | A/B tested: actually *slowed* the metrics phase — 6 parallel BPE loads contended on memory bandwidth, blowing up per-worker init from 270 ms to 670-890 ms and pushing warmup *onto* the critical path. Reverted. |
| Skip `calculateMarkdownDelimiter` / `calculateFileLineCounts` for non-markdown styles | ~30-60 ms | Not selected — the verbose run shows output generation finishes well before metrics on a 1041-file repo, so trimming output-side work doesn't move the wall-clock number when metrics is the long pole. |
| Pre-warm `outputGenerate` (Handlebars) at `pack()` start                   | ~140 ms (per startup CPU profile) | Not selected — the existing PR description (commit history) records this was tried and reverted previously because output phase finishes 218 ms below the file-metrics critical path on this repo. |
| Parallel pool teardown via `Promise.all` of metrics + security cleanup     | ~10-16 ms | Not selected — below the 2 % / ~34 ms threshold. |

## Test plan

- [x] `npm run lint` — only 2 pre-existing warnings in unrelated files
- [x] `npm run test` — 116 files / **1147** tests passing, no test changes required
- [x] Output byte-equivalence: md5 matches on the generated 4.4 MB XML across both variants
- [x] 60-run interleaved A/B benchmark; statistically significant delta (t ≈ 4.8, p < 0.001)
- [x] Independent re-benchmark by perf-claim reviewer (n=30) confirmed effect; ratio 1.07× faster
- [x] Reviewed by three local reviewers in parallel (correctness / code-quality / perf-claim-robustness). Correctness reviewer noted the original comment claimed "ulimit -n of 1024" without acknowledging macOS's 256 soft limit; code-quality reviewer asked the four hardware-specific timing numbers be lifted out of the source comment into the commit body. Both addressed in an `--amend` (commit body still carries the timing data; source comment now mentions both the Linux 1024 and macOS 256 FD soft limits, well above the 128 cap).

https://claude.ai/code/session_018zSwTJKKh23WQr6nxXof6N