### PR TITLE
fix(monitoring): Correct dashboard legend template variable syntax

### DIFF
--- a/website/server/monitoring/dashboard.json
+++ b/website/server/monitoring/dashboard.json
@@ -215,7 +215,7 @@
                 },
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
-                "legendTemplate": "cached=${metric.label.cached}"
+                "legendTemplate": "cached=${metric.labels.cached}"
               }
             ],
             "yAxis": { "label": "count / 5min", "scale": "LINEAR" }
@@ -480,7 +480,7 @@
                 },
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
-                "legendTemplate": "compress=${metric.label.compress}"
+                "legendTemplate": "compress=${metric.labels.compress}"
               }
             ],
             "yAxis": { "label": "count / 5min", "scale": "LINEAR" }
@@ -510,7 +510,7 @@
                 },
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
-                "legendTemplate": "removeComments=${metric.label.remove_comments}"
+                "legendTemplate": "removeComments=${metric.labels.remove_comments}"
               }
             ],
             "yAxis": { "label": "count / 5min", "scale": "LINEAR" }
@@ -540,7 +540,7 @@
                 },
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
-                "legendTemplate": "outputParsable=${metric.label.output_parsable}"
+                "legendTemplate": "outputParsable=${metric.labels.output_parsable}"
               }
             ],
             "yAxis": { "label": "count / 5min", "scale": "LINEAR" }
@@ -570,7 +570,7 @@
                 },
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
-                "legendTemplate": "hasIncludePatterns=${metric.label.has_include_patterns}"
+                "legendTemplate": "hasIncludePatterns=${metric.labels.has_include_patterns}"
               }
             ],
             "yAxis": { "label": "count / 5min", "scale": "LINEAR" }


### PR DESCRIPTION
## Summary

Option-usage and cache-hit panels on the GCP monitoring dashboard were rendering with empty legend values (`compress=`, `removeComments=`, etc.), making it impossible to distinguish `true` vs `false` series visually.

Root cause: the legend templates used `\${metric.label.X}` (singular) where GCP Cloud Monitoring's widget API expects `\${metric.labels.X}` (plural). The singular form silently resolves to an empty string instead of erroring out.

Fixed all 5 occurrences. Applied to the live GCP dashboard via \`gcloud monitoring dashboards update\` before committing — legends now render as \`compress=true\` / \`compress=false\` correctly.

### Before
![before](https://github.com/user-attachments/assets/placeholder-before)
Legend shows: `compress=`, `compress=` (both empty, indistinguishable)

### After
Legend shows: `compress=true`, `compress=false` (distinguishable)

## Checklist

- [x] \`npm run test\` — unaffected (dashboard.json is not in test scope)
- [x] \`npm run lint\` — clean
- [x] JSON syntactically valid
- [x] Applied to live GCP dashboard (verified in Console)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
