### PR TITLE
perf(config): Extract TOKEN_ENCODINGS to avoid gpt-tokenizer load at startup

### DIFF
--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -1,5 +1,6 @@
 import * as v from 'valibot';
-import { TOKEN_ENCODINGS } from '../core/metrics/TokenCounter.js';
+// Use the lightweight tokenEncodings module so gpt-tokenizer stays off the startup import graph.
+import { TOKEN_ENCODINGS } from '../core/metrics/tokenEncodings.js';
 
 // Output style enum
 export const repomixOutputStyleSchema = v.picklist(['xml', 'markdown', 'json', 'plain']);

--- a/src/core/metrics/TokenCounter.ts
+++ b/src/core/metrics/TokenCounter.ts
@@ -1,10 +1,11 @@
 import { GptEncoding } from 'gpt-tokenizer/GptEncoding';
 import { resolveEncodingAsync } from 'gpt-tokenizer/resolveEncodingAsync';
 import { logger } from '../../shared/logger.js';
+import { TOKEN_ENCODINGS, type TokenEncoding } from './tokenEncodings.js';
 
-// Supported token encoding types (OpenAI encoding names)
-export const TOKEN_ENCODINGS = ['o200k_base', 'cl100k_base', 'p50k_base', 'p50k_edit', 'r50k_base'] as const;
-export type TokenEncoding = (typeof TOKEN_ENCODINGS)[number];
+// Re-export for backward compatibility with existing
+// `import { TOKEN_ENCODINGS, TokenEncoding } from './TokenCounter.js'` call sites.
+export { TOKEN_ENCODINGS, type TokenEncoding };
 
 interface CountTokensOptions {
   disallowedSpecial?: Set<string>;

--- a/src/core/metrics/tokenEncodings.ts
+++ b/src/core/metrics/tokenEncodings.ts
@@ -1,0 +1,4 @@
+// Supported token encoding types (OpenAI encoding names). Kept in its own
+// module so configSchema's startup import does not drag in gpt-tokenizer.
+export const TOKEN_ENCODINGS = ['o200k_base', 'cl100k_base', 'p50k_base', 'p50k_edit', 'r50k_base'] as const;
+export type TokenEncoding = (typeof TOKEN_ENCODINGS)[number];


### PR DESCRIPTION
## Summary

Move the \`TOKEN_ENCODINGS\` constant and \`TokenEncoding\` type out of \`TokenCounter.ts\` into a tiny new module \`src/core/metrics/tokenEncodings.ts\`, and point \`configSchema.ts\` at that new module. \`TokenCounter.ts\` re-exports both names so library consumers and existing test mocks keep working.

## Why

\`configSchema.ts\` sits on the startup critical path: it is pulled in by \`configLoad.ts\` during \`runDefaultAction\`, before \`pack()\` runs. Its only external value import was \`TOKEN_ENCODINGS\` (a 5-element string array used by \`v.picklist\`) — but that import forced the transitive load of \`gpt-tokenizer/GptEncoding\` + \`resolveEncodingAsync\`, costing ~35-50ms during cold start.

Extracting \`TOKEN_ENCODINGS\` into a standalone module breaks that transitive dependency: configSchema only loads the tiny constants module, and gpt-tokenizer is loaded later when actually needed by metrics workers.

## Benchmark

Re-measurement on this machine (3 rounds, A/B interleaved, 10 runs each):

| Round | main | branch | Δ |
|-------|------|--------|---|
| 1 | 375.0ms ± 10.1 | 380.8ms ± 20.0 | +5.8ms |
| 2 | 387.1ms ± 14.8 | 370.2ms ± 8.8 | -16.9ms |
| 3 | 382.7ms ± 21.0 | 373.6ms ± 14.4 | -9.1ms |
| **avg** | **381.6** | **374.9** | **-6.7ms (-1.8%)** |

Noise is high (σ 8-21ms), so the effect is within the noise floor on this machine. CI may show a clearer signal — the original measurement claimed ~35-50ms saved at the gpt-tokenizer load step.

## Verification

- [x] \`npm run lint\` passes
- [x] \`npm run test\` (1144 passing)
- \`TokenCounter.ts\` re-exports \`TOKEN_ENCODINGS\` and \`TokenEncoding\` so existing imports keep working

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
