### PR TITLE
perf(core): Automated performance tuning by Claude

### DIFF
--- a/src/shared/processConcurrency.ts
+++ b/src/shared/processConcurrency.ts
@@ -39,8 +39,13 @@ const getWorkerPath = (workerType: WorkerType): string => {
   }
 };
 
-// Worker initialization is expensive, so we prefer fewer threads unless there are many files
-const TASKS_PER_THREAD = 100;
+// Worker initialization is expensive (each metrics worker synchronously loads
+// gpt-tokenizer's ~2MB BPE-ranks file, ~290ms of CPU per worker). The bundled-up
+// parallel CPU time of many warm-up threads contends with file collection on the
+// main thread, which dominates wall time on repos of ~1000 files. Prefer a
+// smaller pool so fewer workers need to warm up; metrics work runs in parallel
+// with output generation, so the extra work per worker rarely extends the tail.
+const TASKS_PER_THREAD = 300;
 
 export const getProcessConcurrency = (): number => {
   return typeof os.availableParallelism === 'function' ? os.availableParallelism() : os.cpus().length;

--- a/tests/shared/processConcurrency.test.ts
+++ b/tests/shared/processConcurrency.test.ts
@@ -54,7 +54,7 @@ describe('processConcurrency', () => {
       const { minThreads, maxThreads } = getWorkerThreadCount(1000);
 
       expect(minThreads).toBe(1);
-      expect(maxThreads).toBe(8); // Limited by CPU count: Math.min(8, 1000/100) = 8
+      expect(maxThreads).toBe(4); // Limited by task count: Math.min(8, ceil(1000/300)) = 4
     });
 
     it('should scale max threads based on task count', () => {
@@ -68,7 +68,7 @@ describe('processConcurrency', () => {
       const { minThreads, maxThreads } = getWorkerThreadCount(10000);
 
       expect(minThreads).toBe(1);
-      expect(maxThreads).toBe(8); // Limited by CPU count: Math.min(8, 10000/100) = 8
+      expect(maxThreads).toBe(8); // Limited by CPU count: Math.min(8, ceil(10000/300)) = 8
     });
 
     it('should handle zero tasks', () => {
@@ -79,21 +79,21 @@ describe('processConcurrency', () => {
     });
 
     it('should cap max threads when maxWorkerThreads is provided', () => {
-      // CPU has 8 cores, 1000 tasks would normally give 8 threads
+      // CPU has 8 cores, 1000 tasks would normally give ceil(1000/300)=4 threads
       const { maxThreads } = getWorkerThreadCount(1000, 3);
 
       expect(maxThreads).toBe(3);
     });
 
     it('should not exceed task-based limit even with higher maxWorkerThreads', () => {
-      // 200 tasks → ceil(200/100) = 2 threads, maxWorkerThreads=6 should not increase it
-      const { maxThreads } = getWorkerThreadCount(200, 6);
+      // 600 tasks → ceil(600/300) = 2 threads, maxWorkerThreads=6 should not increase it
+      const { maxThreads } = getWorkerThreadCount(600, 6);
 
       expect(maxThreads).toBe(2);
     });
 
     it('should ignore maxWorkerThreads when undefined', () => {
-      const { maxThreads } = getWorkerThreadCount(1000, undefined);
+      const { maxThreads } = getWorkerThreadCount(10000, undefined);
 
       expect(maxThreads).toBe(8);
     });
@@ -111,13 +111,13 @@ describe('processConcurrency', () => {
     });
 
     it('should initialize Tinypool with correct configuration', () => {
-      const tinypool = createWorkerPool({ numOfTasks: 500, workerType: 'fileProcess', runtime: 'child_process' });
+      const tinypool = createWorkerPool({ numOfTasks: 1500, workerType: 'fileProcess', runtime: 'child_process' });
 
       expect(Tinypool).toHaveBeenCalledWith({
         filename: expect.stringContaining('fileProcessWorker.js'),
         runtime: 'child_process',
         minThreads: 1,
-        maxThreads: 4, // Math.min(4, 500/100) = 4
+        maxThreads: 4, // Math.min(4, ceil(1500/300)) = 4
         idleTimeout: 5000,
         teardown: 'onWorkerTermination',
         workerData: {
@@ -134,13 +134,13 @@ describe('processConcurrency', () => {
     });
 
     it('should initialize Tinypool with worker_threads runtime when specified', () => {
-      const tinypool = createWorkerPool({ numOfTasks: 500, workerType: 'securityCheck', runtime: 'worker_threads' });
+      const tinypool = createWorkerPool({ numOfTasks: 1500, workerType: 'securityCheck', runtime: 'worker_threads' });
 
       expect(Tinypool).toHaveBeenCalledWith({
         filename: expect.stringContaining('securityCheckWorker.js'),
         runtime: 'worker_threads',
         minThreads: 1,
-        maxThreads: 4, // Math.min(4, 500/100) = 4
+        maxThreads: 4, // Math.min(4, ceil(1500/300)) = 4
         idleTimeout: 5000,
         teardown: 'onWorkerTermination',
         workerData: {


### PR DESCRIPTION
## Summary

Raises `TASKS_PER_THREAD` in `src/shared/processConcurrency.ts` from `100` to `300` to cut worker-pool warmup contention that dominated the file-collection phase on mid-sized repos (≈1000 files).

## Why

Each metrics worker synchronously imports gpt-tokenizer's ~2 MB BPE-ranks file the first time it runs — ~290 ms of CPU per worker. At the previous `TASKS_PER_THREAD=100`, the 1010-file repomix repo spawned **11 workers** (`ceil(1010 / 100)`, capped by CPU count) that all warmed up in parallel during file collection, stealing roughly **3.2 CPU-seconds** from the main thread while it was I/O- and CPU-bound reading files. Fewer workers → less warmup contention → faster collect.

## Change

One-line constant tweak, plus a slightly expanded comment explaining the rationale:

```diff
-const TASKS_PER_THREAD = 100;
+const TASKS_PER_THREAD = 300;
```

Four assertions in `tests/shared/processConcurrency.test.ts` that hardcoded thread-count math against the old constant are updated to match the new math.

## Trade-off

For a 1010-file repo on 16 CPUs, the metrics pool drops from 11 → 4 workers, so metrics calculation takes somewhat longer. But metrics runs concurrently with output generation, so the extra per-worker wall time is largely absorbed by that overlap. Collect shortens more than metrics lengthens — net wall-time improvement.

- **Small repos (<300 files):** still use 1 worker; identical to before.
- **Very large repos (≈3000+ files on 16 CPUs):** already CPU-capped, unaffected.
- **Pools with explicit `maxWorkerThreads`** (security check = 2): unaffected because the cap is applied before the `TASKS_PER_THREAD` division.

## Benchmark

On this repo (1010 files, Node 22, 16 CPUs, `--stdout`, 30 interleaved A/B pairs):

| Metric   | Baseline      | Patched       | Δ                  |
|----------|---------------|---------------|--------------------|
| Median   | 2272 ms       | 2050 ms       | **−221 ms (−9.73%)** |
| Mean     | 2270 ms       | 2046 ms       | **−224 ms (−9.87%)** |
| Trimmed mean | 2270 ms   | 2044 ms       | **−226 ms (−9.94%)** |
| Stdev    | 36 ms         | 42 ms         | —                  |

Welch t-statistic: **22.26** (highly statistically significant).

Verbose-log phase breakdown on a representative run:

| Phase | Baseline | Patched | Δ |
|---|---|---|---|
| File collection | 732 ms | 546 ms | **−186 ms** |
| File metrics calculation | 253 ms | 343 ms | +90 ms (absorbed by output-generation overlap) |

## Correctness

- Output is byte-identical to `main` (diffed full XML output for this repo).
- Full test suite passes (116 files / 1144 tests).
- `npm run lint` clean (2 pre-existing warnings unrelated to this change).
- Reviewed locally by two independent sub-agents (correctness + test coverage); no issues beyond a stale comment, which was corrected before push.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
