### PR TITLE
perf(core): Automated performance tuning by Claude

### DIFF
--- a/src/core/metrics/calculateMetrics.ts
+++ b/src/core/metrics/calculateMetrics.ts
@@ -29,6 +29,10 @@ export interface MetricsTaskRunnerWithWarmup {
   warmupPromise: Promise<unknown>;
 }
 
+// Capping at 4 bounds the `pool.destroy()` cost awaited in `pack()`'s finally
+// block, which scales linearly with thread count and sits on the exit path.
+const MAX_WORKER_THREADS = 4;
+
 /**
  * Create a metrics task runner and warm up all worker threads by triggering
  * gpt-tokenizer initialization in parallel. This allows the expensive module
@@ -40,9 +44,10 @@ export const createMetricsTaskRunner = (numOfTasks: number, encoding: TokenEncod
     numOfTasks,
     workerType: 'calculateMetrics',
     runtime: 'worker_threads',
+    maxWorkerThreads: MAX_WORKER_THREADS,
   });
 
-  const { maxThreads } = getWorkerThreadCount(numOfTasks);
+  const { maxThreads } = getWorkerThreadCount(numOfTasks, MAX_WORKER_THREADS);
   const warmupPromise = Promise.all(
     Array.from({ length: maxThreads }, () => taskRunner.run({ content: '', encoding }).catch(() => 0)),
   );
@@ -118,6 +123,7 @@ export const calculateMetrics = async (
       numOfTasks: processedFiles.length,
       workerType: 'calculateMetrics',
       runtime: 'worker_threads',
+      maxWorkerThreads: MAX_WORKER_THREADS,
     });
 
   try {

--- a/tests/core/metrics/calculateMetrics.test.ts
+++ b/tests/core/metrics/calculateMetrics.test.ts
@@ -135,4 +135,13 @@ describe('createMetricsTaskRunner', () => {
     expect(Array.isArray(resolved)).toBe(true);
     expect((resolved as number[]).every((v) => v === 0)).toBe(true);
   });
+
+  it('should cap the worker pool at 4 threads', async () => {
+    const { initTaskRunner } = await import('../../../src/shared/processConcurrency.js');
+    (initTaskRunner as Mock).mockClear();
+
+    createMetricsTaskRunner(10000, 'o200k_base');
+
+    expect(initTaskRunner).toHaveBeenCalledWith(expect.objectContaining({ maxWorkerThreads: 4 }));
+  });
 });


### PR DESCRIPTION
## Summary

Cap the metrics worker pool at 4 threads to shrink `pool.destroy()` time on
the critical path to process exit.

On a 16-core machine running against this repo (126 files), the metrics pool
previously spawned 11 threads (`ceil(numOfTasks / 100)` capped only by CPU
count). Tokenization throughput saturates far below that, but `pool.destroy()`
is awaited in `pack()`'s `finally` block and scales linearly with thread
count. Capping at 4 cuts teardown from ~120-190ms to ~25-30ms without
regressing metrics computation (fewer threads also reduce context-switch
overhead during tokenization).

## Change

- `maxWorkerThreads: MAX_WORKER_THREADS` added to both pool-init sites:
  - `createMetricsTaskRunner` (warm-up path used by the normal pipeline)
  - the fallback `initTaskRunner` inside `calculateMetrics` (used when
    callers like `packSkill` do not provide a pre-warmed runner)
- `getWorkerThreadCount(numOfTasks, cap)` is passed the same cap so the
  warm-up loop sizes itself to the effective pool size.
- New test asserts `initTaskRunner` receives `maxWorkerThreads: 4`.

No functional change — output content, exit codes, and error handling are
identical. Warm-up remains hidden behind the pipeline (completes ~340ms
after init vs ~930ms until first `await`; blocking time stays at 0).

## Benchmark

`time node bin/repomix.cjs --quiet` on this repo, 16-core Linux, 12 runs
per variant interleaved in a Latin-square-style ordering across 6 rounds
(B/4/3, 3/B/4, 4/3/B, B/3/4, 4/B/3, 3/4/B) to eliminate systemic bias.

| Variant | Mean | Δ vs baseline |
|---|---|---|
| Baseline (11 threads) | 2.164s | – |
| **Cap=4 (this PR)** | **2.025s** | **−139ms (−6.4%)** |
| Cap=3 (alt tested) | 2.088s | −76ms (−3.5%) |

Raw samples (seconds):
```
Baseline: 2.149 2.111 2.190 2.162 2.172 2.183 2.159 2.115 2.200 2.133 2.237 2.159
Cap=4:    2.063 2.044 1.988 2.046 2.014 2.020 2.002 1.995 2.037 2.035 2.024 2.035
Cap=3:    2.081 2.120 2.096 2.054 2.109 2.064 2.091 2.094 2.048 2.092 2.109 2.102
```

Isolated measurements:
- `pool.destroy()` with 11 threads: 126–191ms (3 runs)
- `pool.destroy()` with  4 threads:  25–31ms  (3 runs)
- Tokenization (1031 items, warm): 11t=80ms, 4t=47ms

## Checklist

- [x] Run `npm run test` — 1144 / 1144 pass
- [x] Run `npm run lint` — clean (the 2 warnings are pre-existing, unrelated)
