### PR TITLE
chore(website): Temporarily disable auto-pack on repo query param

### DIFF
--- a/website/client/components/Home/TryIt.vue
+++ b/website/client/components/Home/TryIt.vue
@@ -249,16 +249,16 @@ onMounted(() => {
   // If repository parameter exists and is valid, trigger packing automatically
   // Skip auto-execution for bots/crawlers to prevent unintended API calls
   // (e.g., Applebot executing JS on permalink URLs causes mass pack requests)
-  if (urlParams.repo && isValidRemoteValue(urlParams.repo.trim()) && !isBot()) {
-    // Use nextTick to ensure all reactive values are properly initialized
-    nextTick(async () => {
-      try {
-        await handleSubmit();
-      } catch (error) {
-        console.error('Auto-execution failed:', error);
-      }
-    });
-  }
+  // if (urlParams.repo && isValidRemoteValue(urlParams.repo.trim()) && !isBot()) {
+  //   // Use nextTick to ensure all reactive values are properly initialized
+  //   nextTick(async () => {
+  //     try {
+  //       await handleSubmit();
+  //     } catch (error) {
+  //       console.error('Auto-execution failed:', error);
+  //     }
+  //   });
+  // }
 });
 </script>
 


### PR DESCRIPTION
## Summary

- Comment out the auto-execution block in `website/client/components/Home/TryIt.vue` so pages loaded with `?repo=...` no longer trigger an automatic pack on mount.
- URL parameter parsing and form reflection are preserved — the query still pre-fills the input; only the implicit submit is suppressed.
- Intended as a temporary measure; restoring is a matter of uncommenting the block.

## Checklist

- [ ] Run `npm run test`
- [ ] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
