### PR TITLE
perf(core): Automated performance tuning by Claude

### DIFF
--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -19,23 +19,21 @@ export interface FileSearchResult {
 // comes from globby with the same `ignore` patterns (e.g. `dist/**`), which
 // excludes both the directory contents AND the directory entry itself.
 const findEmptyDirectories = async (rootDir: string, directories: string[]): Promise<string[]> => {
-  const emptyDirs: string[] = [];
-
-  for (const dir of directories) {
-    const fullPath = path.join(rootDir, dir);
-    try {
-      const entries = await fs.readdir(fullPath);
-      const hasVisibleContents = entries.some((entry) => !entry.startsWith('.'));
-
-      if (!hasVisibleContents) {
-        emptyDirs.push(dir);
+  const results = await Promise.all(
+    directories.map(async (dir) => {
+      const fullPath = path.join(rootDir, dir);
+      try {
+        const entries = await fs.readdir(fullPath);
+        const hasVisibleContents = entries.some((entry) => !entry.startsWith('.'));
+        return hasVisibleContents ? null : dir;
+      } catch (error) {
+        logger.debug(`Error checking directory ${dir}:`, error);
+        return null;
       }
-    } catch (error) {
-      logger.debug(`Error checking directory ${dir}:`, error);
-    }
-  }
+    }),
+  );
 
-  return emptyDirs;
+  return results.filter((dir): dir is string => dir !== null);
 };
 
 // Check if a path is a git worktree reference file
@@ -182,8 +180,12 @@ export const searchFiles = async (
     logger.debug('[globby] Starting file search...');
     const globbyStartTime = Date.now();
 
-    const filePaths = await globby(includePatterns, {
-      ...createBaseGlobbyOptions(rootDir, config, adjustedIgnorePatterns, ignoreFilePatterns),
+    const baseGlobbyOptions = createBaseGlobbyOptions(rootDir, config, adjustedIgnorePatterns, ignoreFilePatterns);
+
+    // Run the files and directories globby passes concurrently so the second
+    // traversal overlaps with the first instead of starting after it.
+    const filesPromise = globby(includePatterns, {
+      ...baseGlobbyOptions,
       onlyFiles: true,
     }).catch((error: unknown) => {
       // Handle EPERM errors specifically
@@ -197,21 +199,21 @@ export const searchFiles = async (
       throw error;
     });
 
+    const directoriesPromise = config.output.includeEmptyDirectories
+      ? globby(includePatterns, {
+          ...baseGlobbyOptions,
+          onlyDirectories: true,
+        })
+      : Promise.resolve<string[]>([]);
+
+    const [filePaths, directories] = await Promise.all([filesPromise, directoriesPromise]);
+
     const globbyElapsedTime = Date.now() - globbyStartTime;
     logger.debug(`[globby] Completed in ${globbyElapsedTime}ms, found ${filePaths.length} files`);
 
     let emptyDirPaths: string[] = [];
     if (config.output.includeEmptyDirectories) {
-      logger.debug('[empty dirs] Searching for empty directories...');
-      const emptyDirStartTime = Date.now();
-
-      const directories = await globby(includePatterns, {
-        ...createBaseGlobbyOptions(rootDir, config, adjustedIgnorePatterns, ignoreFilePatterns),
-        onlyDirectories: true,
-      });
-
-      const emptyDirElapsedTime = Date.now() - emptyDirStartTime;
-      logger.debug(`[empty dirs] Found ${directories.length} directories in ${emptyDirElapsedTime}ms`);
+      logger.debug(`[empty dirs] Found ${directories.length} directories`);
 
       const filterStartTime = Date.now();
       emptyDirPaths = await findEmptyDirectories(rootDir, directories);


### PR DESCRIPTION
## Summary

Parallelize the directory-globby pass and the empty-directory `readdir` loop in `searchFiles`, removing a serialized section of the `searchFiles` critical path that runs before file collection.

## What changed

When `output.includeEmptyDirectories` is enabled, `searchFiles` previously did three operations strictly in sequence:

1. `globby({ onlyFiles: true })` (full tree walk, files only)
2. `globby({ onlyDirectories: true })` (full tree walk, directories only, serial **after** 1)
3. `findEmptyDirectories` — a `for ... of` loop awaiting `fs.readdir` per candidate directory one at a time

Steps 2 and 3 are independent of step 1, and the per-directory readdir calls in step 3 are independent of each other.

- Fire the two globby passes concurrently via `Promise.all`. The second globby is skipped entirely when `includeEmptyDirectories` is false (semantically identical to before).
- Replace the serial readdir loop in `findEmptyDirectories` with `Promise.all(directories.map(...))`.

Behavior is preserved: identical globby options/ignore patterns on both sides (only `onlyFiles` vs `onlyDirectories` differs), and the final `emptyDirPaths` order is deterministic via the existing `sortPaths` call.

## Benchmark

10 alternating A/B pairs, 1031 files / 247 candidate directories on this repository, `node bin/repomix.cjs --quiet --output /tmp/out.xml`:

|               | mean       | median     | stdev     |
| ------------- | ---------- | ---------- | --------- |
| baseline      | 2113.4 ms  | 2108.5 ms  | 48.0 ms   |
| patched       | 2051.8 ms  | 2069.0 ms  | 58.9 ms   |
| **paired Δ**  | **61.6 ms** | **68.5 ms** | 76.0 ms (t ≈ 2.56) |

~2.9% mean / ~3.3% median wall-time reduction.

`--verbose` breakdown:

| Stage                  | Before  | After   |
| ---------------------- | ------- | ------- |
| `[globby]` files       | ~185 ms | (combined parallel) |
| `[globby]` directories | ~87 ms (sequential) | (combined parallel) |
| globby combined        | —       | ~267 ms |
| empty-dir readdir      | ~61 ms (serial × 247) | ~15 ms (parallel) |

## Checklist

- [x] Run `npm run test` — 1144 passing
- [x] Run `npm run lint` — no new warnings or errors

<sub>Notes: this PR is the output of an automated perf-tuning run. Five investigation sub-agents explored different scopes (critical path, module loading, I/O, parallelism, algorithms); the I/O scope found the highest-impact measurable change. Two review sub-agents flagged null-sentinel filter and speculative comments, both addressed before pushing.</sub>


---
_Generated by [Claude Code](https://claude.ai/code/session_01W9EzCyHbrNnroUFTKk2FqJ)_