### PR TITLE
perf(core): Automated performance tuning by Claude

### DIFF
--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -1,5 +1,5 @@
 import * as v from 'valibot';
-import { TOKEN_ENCODINGS } from '../core/metrics/TokenCounter.js';
+import { TOKEN_ENCODINGS } from '../core/metrics/TokenEncoding.js';
 
 // Output style enum
 export const repomixOutputStyleSchema = v.picklist(['xml', 'markdown', 'json', 'plain']);

--- a/src/core/metrics/TokenCounter.ts
+++ b/src/core/metrics/TokenCounter.ts
@@ -1,10 +1,10 @@
 import { GptEncoding } from 'gpt-tokenizer/GptEncoding';
 import { resolveEncodingAsync } from 'gpt-tokenizer/resolveEncodingAsync';
 import { logger } from '../../shared/logger.js';
+import { TOKEN_ENCODINGS, type TokenEncoding } from './TokenEncoding.js';
 
-// Supported token encoding types (OpenAI encoding names)
-export const TOKEN_ENCODINGS = ['o200k_base', 'cl100k_base', 'p50k_base', 'p50k_edit', 'r50k_base'] as const;
-export type TokenEncoding = (typeof TOKEN_ENCODINGS)[number];
+// Re-export for backward compatibility with consumers of this module.
+export { TOKEN_ENCODINGS, type TokenEncoding };
 
 interface CountTokensOptions {
   disallowedSpecial?: Set<string>;

--- a/src/core/metrics/TokenEncoding.ts
+++ b/src/core/metrics/TokenEncoding.ts
@@ -1,0 +1,8 @@
+// Token encoding names are declared separately from TokenCounter so that
+// consumers who only need the encoding list (e.g. configSchema validation)
+// can import them without pulling in the gpt-tokenizer module graph.
+// TokenCounter re-exports these values for backward compatibility.
+
+// Supported token encoding types (OpenAI encoding names)
+export const TOKEN_ENCODINGS = ['o200k_base', 'cl100k_base', 'p50k_base', 'p50k_edit', 'r50k_base'] as const;
+export type TokenEncoding = (typeof TOKEN_ENCODINGS)[number];

--- a/src/core/metrics/calculateFileMetrics.ts
+++ b/src/core/metrics/calculateFileMetrics.ts
@@ -3,7 +3,7 @@ import { logger } from '../../shared/logger.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
 import type { ProcessedFile } from '../file/fileTypes.js';
 import { type MetricsTaskRunner, runBatchTokenCount } from './metricsWorkerRunner.js';
-import type { TokenEncoding } from './TokenCounter.js';
+import type { TokenEncoding } from './TokenEncoding.js';
 import type { FileMetrics } from './workers/types.js';
 
 // Batch size for grouping files into worker tasks to reduce IPC overhead.

--- a/src/core/metrics/calculateMetrics.ts
+++ b/src/core/metrics/calculateMetrics.ts
@@ -11,7 +11,7 @@ import { calculateGitDiffMetrics } from './calculateGitDiffMetrics.js';
 import { calculateGitLogMetrics } from './calculateGitLogMetrics.js';
 import { calculateOutputMetrics } from './calculateOutputMetrics.js';
 import { type MetricsTaskRunner, runTokenCount } from './metricsWorkerRunner.js';
-import type { TokenEncoding } from './TokenCounter.js';
+import type { TokenEncoding } from './TokenEncoding.js';
 import type { MetricsWorkerResult, MetricsWorkerTask } from './workers/calculateMetricsWorker.js';
 
 export interface CalculateMetricsResult {

--- a/src/core/metrics/calculateOutputMetrics.ts
+++ b/src/core/metrics/calculateOutputMetrics.ts
@@ -1,6 +1,6 @@
 import { logger } from '../../shared/logger.js';
 import { type MetricsTaskRunner, runTokenCount } from './metricsWorkerRunner.js';
-import type { TokenEncoding } from './TokenCounter.js';
+import type { TokenEncoding } from './TokenEncoding.js';
 
 // Target ~200K characters per chunk to balance tokenization throughput and worker round-trip overhead.
 // Benchmarks show 200K is the sweet spot: fewer round-trips than 100K with enough chunks

--- a/src/core/metrics/workers/calculateMetricsWorker.ts
+++ b/src/core/metrics/workers/calculateMetricsWorker.ts
@@ -1,5 +1,5 @@
 import { logger, setLogLevelByWorkerData } from '../../../shared/logger.js';
-import type { TokenEncoding } from '../TokenCounter.js';
+import type { TokenEncoding } from '../TokenEncoding.js';
 import { freeTokenCounters, getTokenCounter } from '../tokenCounterFactory.js';
 
 /**


### PR DESCRIPTION
## Summary

Split `TOKEN_ENCODINGS` into a dedicated `src/core/metrics/TokenEncoding.ts` file so the main-thread module graph no longer transitively loads `gpt-tokenizer`.

### Why

`src/config/configSchema.ts` previously imported `TOKEN_ENCODINGS` from `src/core/metrics/TokenCounter.ts`. `TokenCounter.ts` has static ESM imports of `gpt-tokenizer/GptEncoding` and `gpt-tokenizer/resolveEncodingAsync`, which in turn pull in `BytePairEncodingCore`, `constants`, `mapping`, `functionCalling`, `modelParams`, `specialTokens`, `utfUtil`, and `util`. Because `configSchema.ts` is on the main-thread startup path (loaded by `defaultAction` → `configLoad`), every CLI invocation paid the cost of compiling that entire module subtree even though token counting itself runs only inside the metrics worker pool.

### What

- `src/core/metrics/TokenEncoding.ts` (new): single source of truth for the `TOKEN_ENCODINGS` tuple and `TokenEncoding` type, with no runtime dependencies.
- `src/core/metrics/TokenCounter.ts`: imports the constant/type from the new file and re-exports them so external consumers of the public API (`src/index.ts` exports `TokenCounter`) keep working unchanged.
- `src/config/configSchema.ts`: imports `TOKEN_ENCODINGS` from the new file directly.
- `calculateFileMetrics.ts`, `calculateMetrics.ts`, `calculateOutputMetrics.ts`, `workers/calculateMetricsWorker.ts`: updated `import type { TokenEncoding }` to point at the new canonical module for consistency (pure type imports, erased at runtime).

Worker-side code (`tokenCounterFactory.ts` → `TokenCounter.ts` → `gpt-tokenizer`) is unchanged — tokenization still happens with the real library inside worker threads.

### Benchmark

Setup: `node /bin/repomix.cjs --quiet` against a copy of the repomix `src/` tree (127 files), 30 alternating paired runs (baseline ↔ change with order swapped each iteration), warm compile cache.

|                     | baseline  | change    | delta           |
| ------------------- | --------- | --------- | --------------- |
| mean                | 1472 ms   | 1420 ms   | -52 ms (-3.5%)  |
| median              | 1470 ms   | 1412 ms   | -58 ms (-3.9%)  |
| trimmed mean (±3)   | 1468 ms   | 1409 ms   | -59 ms (-4.1%)  |

Paired comparison (per-iteration wall clock): change was faster in 21/30 runs, tied in 1, slower in 8.

Isolated module import timing (warm node cache, measured via `node -e "import('./lib/config/configSchema.js')"`):

- before: `configSchema.js` load = 98 ms
- after:  `configSchema.js` load = 21 ms (**-77 ms**)

## Test plan

- [x] `npm run lint` — passes (only 2 pre-existing warnings unrelated to this change)
- [x] `npm run test` — 1144/1144 passing
- [x] Manual smoke test: `node bin/repomix.cjs` on a small repo produces a valid `repomix-output.xml` identical to the baseline
- [x] Verified `v.picklist(TOKEN_ENCODINGS)` in `configSchema.ts:121` still validates the same five encoding names

https://claude.ai/code/session_01LLEiqYdunyBduAc3XSQb9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLEiqYdunyBduAc3XSQb9w)_