### PR TITLE
perf(core): Automated performance tuning by Claude

### DIFF
--- a/src/core/file/truncateBase64.ts
+++ b/src/core/file/truncateBase64.ts
@@ -13,6 +13,32 @@ const dataUriPattern = new RegExp(
 const standaloneBase64Pattern = new RegExp(`([A-Za-z0-9+/]{${MIN_BASE64_LENGTH_STANDALONE},}={0,2})`, 'g');
 
 /**
+ * Cheap precondition for `standaloneBase64Pattern`: scans for any run of
+ * `[A-Za-z0-9+/]` reaching `MIN_BASE64_LENGTH_STANDALONE`, the smallest body
+ * the regex can match. When this returns false, the regex provably has zero
+ * matches, so we can skip the much more expensive backtracking scan over the
+ * whole content. The hot loop avoids regex engine overhead and runs ~4x faster
+ * than the original `replace`, which dominated `applyLightweightTransforms`
+ * CPU on profiles of repos with `truncateBase64: true`.
+ */
+const hasLongBase64Run = (content: string): boolean => {
+  const len = content.length;
+  if (len < MIN_BASE64_LENGTH_STANDALONE) return false;
+  let run = 0;
+  for (let i = 0; i < len; i++) {
+    const c = content.charCodeAt(i);
+    // [A-Z]:65-90, [a-z]:97-122, [0-9]:48-57, '+':43, '/':47
+    if ((c >= 65 && c <= 90) || (c >= 97 && c <= 122) || (c >= 48 && c <= 57) || c === 43 || c === 47) {
+      run++;
+      if (run >= MIN_BASE64_LENGTH_STANDALONE) return true;
+    } else {
+      run = 0;
+    }
+  }
+  return false;
+};
+
+/**
  * Truncates base64 encoded data in content to reduce file size
  * Detects common base64 patterns like data URIs and standalone base64 strings
  *
@@ -20,27 +46,31 @@ const standaloneBase64Pattern = new RegExp(`([A-Za-z0-9+/]{${MIN_BASE64_LENGTH_S
  * @returns Content with base64 data truncated
  */
 export const truncateBase64Content = (content: string): string => {
-  // Reset lastIndex since patterns are global and reused across calls
-  dataUriPattern.lastIndex = 0;
-  standaloneBase64Pattern.lastIndex = 0;
-
   let processedContent = content;
 
-  // Replace data URIs
-  processedContent = processedContent.replace(dataUriPattern, (_match, mimeType, params, base64Data) => {
-    const preview = base64Data.substring(0, TRUNCATION_LENGTH);
-    return `data:${mimeType}${params || ''};base64,${preview}...`;
-  });
+  // Replace data URIs. The substring guard skips the regex on the vast majority
+  // of source files that contain no data URI.
+  if (content.includes(';base64,')) {
+    dataUriPattern.lastIndex = 0;
+    processedContent = processedContent.replace(dataUriPattern, (_match, mimeType, params, base64Data) => {
+      const preview = base64Data.substring(0, TRUNCATION_LENGTH);
+      return `data:${mimeType}${params || ''};base64,${preview}...`;
+    });
+  }
 
-  // Replace standalone base64 strings
-  processedContent = processedContent.replace(standaloneBase64Pattern, (match, base64String) => {
-    // Check if this looks like actual base64 (not just a long string)
-    if (isLikelyBase64(base64String)) {
-      const preview = base64String.substring(0, TRUNCATION_LENGTH);
-      return `${preview}...`;
-    }
-    return match;
-  });
+  // Replace standalone base64 strings. `hasLongBase64Run` is a fast linear scan
+  // that determines whether any match is possible at all.
+  if (hasLongBase64Run(processedContent)) {
+    standaloneBase64Pattern.lastIndex = 0;
+    processedContent = processedContent.replace(standaloneBase64Pattern, (match, base64String) => {
+      // Check if this looks like actual base64 (not just a long string)
+      if (isLikelyBase64(base64String)) {
+        const preview = base64String.substring(0, TRUNCATION_LENGTH);
+        return `${preview}...`;
+      }
+      return match;
+    });
+  }
 
   return processedContent;
 };

--- a/tests/core/file/truncateBase64.test.ts
+++ b/tests/core/file/truncateBase64.test.ts
@@ -103,4 +103,36 @@ describe('truncateBase64Content', () => {
     const result = truncateBase64Content(input);
     expect(result).toBe(input);
   });
+
+  it('should handle empty input', () => {
+    expect(truncateBase64Content('')).toBe('');
+  });
+
+  it('should preserve base64-like runs of exactly 255 chars (just below threshold)', () => {
+    // One char below MIN_BASE64_LENGTH_STANDALONE — `hasLongBase64Run` precondition
+    // must return false so the regex is skipped and content is untouched.
+    const just255 = longBase64.slice(0, 255);
+    const input = `const data = "${just255}";`;
+    const result = truncateBase64Content(input);
+    expect(result).toBe(input);
+  });
+
+  it('should preserve content where no single base64 run reaches the threshold', () => {
+    // Two 200-char base64-like runs separated by a non-base64 char (`=` is only
+    // valid as trailing padding, not inside the run). Neither run hits 256, so
+    // the regex must not match and the precondition must reset on the separator.
+    const run = longBase64.slice(0, 200);
+    const input = `${run} = ${run}`;
+    const result = truncateBase64Content(input);
+    expect(result).toBe(input);
+  });
+
+  it('should leave non-base64 data URIs untouched', () => {
+    // `data:text/plain,hello` has no `;base64,` literal, so the dataUriPattern
+    // cannot match. Verifies the `includes(';base64,')` guard short-circuits
+    // correctly without accidentally rewriting plain data URIs.
+    const input = 'const url = "data:text/plain;charset=utf-8,Hello%20World";';
+    const result = truncateBase64Content(input);
+    expect(result).toBe(input);
+  });
 });


### PR DESCRIPTION
## Summary

Skip the `standaloneBase64Pattern` regex when content cannot possibly match. CPU profiles of `node bin/repomix.cjs --quiet` showed `RegExp ([A-Za-z0-9+/]{256,}={0,2})` consuming ~7% of main-thread ticks (~95 ms of CPU on a 1.3 s run) inside `applyLightweightTransforms`, even though source code rarely contains 256+ char base64 runs.

The fix adds two cheap necessary-condition guards to `truncateBase64Content`:

- A new `hasLongBase64Run(content)` linear `charCodeAt` scan that returns true only if some run of `[A-Za-z0-9+/]` reaches the regex's minimum body length. When false, the regex provably has zero matches, so we skip `String.prototype.replace` entirely.
- `content.includes(';base64,')` short-circuits `dataUriPattern` (the literal substring is unescaped in the pattern, so it is required for any match).

Public behavior is unchanged: both pre-checks are necessary conditions for the regex to match, so any input that previously had matches still flows through the same replace logic.

## Investigation

Five parallel sub-agents (`sonnet`) explored token counting, file search, security check, output generation, and CLI startup. The largest measurable opportunity that survived a side-by-side benchmark turned out to be the base64 regex hot spot — found via `node --prof`, where it accounted for 57/790 main-thread ticks. Other candidates considered (parallelizing `searchFiles` I/O setup, lazy-loading `globby`/`tinypool`/`handlebars`, dropping `calculateFileLineCounts` outside the skill path) either fell below the 2 % bar after measurement or carried more risk for the same gain.

## Benchmark

`hyperfine --warmup 3 --runs 15 'node bin/repomix.cjs --quiet'`, self-pack of repomix repo, default `truncateBase64: true` from `repomix.config.json`:

| | Wall (mean ± σ) | User CPU |
| --- | --- | --- |
| Before | 1.301 s ± 0.037 s | 3.070 s |
| After  | 1.244 s ± 0.018 s | 2.944 s |
| Delta  | **−57 ms (−4.4 %)** | **−126 ms** |

Variance also tightened (σ 37 ms → 18 ms), suggesting the eliminated work was bursty.

## Local review

Two follow-up review agents inspected the diff:
- **Correctness**: confirmed both guards are mathematically provable necessary conditions, the conditional `lastIndex` reset is equivalent to the prior unconditional reset (`String.prototype.replace` resets `lastIndex` on completion per spec), and all 13 existing `truncateBase64` tests pass. Verdict: SAFE.
- **Code quality**: lint clean, comments are why-not-what, consistent with file style. Verdict: APPROVE.

## Test plan

- [x] `npm run test` — 1151/1151 passed
- [x] `npm run lint` — 0 errors (2 pre-existing warnings unrelated to this change)
- [x] `npx vitest run tests/integration-tests/packager.test.ts` — 4/4 passed
- [x] Side-by-side `hyperfine` confirms ≥ 2 % wall-clock improvement


---
_Generated by [Claude Code](https://claude.ai/code/session_01DkVh4DcBs9Hs2sx5JFZrq2)_