### PR TITLE
docs(contributing): Require issue discussion before submitting PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,13 @@ Repomix is maintained by Yamadashy ([@yamadashy](https://github.com/yamadashy)).
 
 ## Pull Requests
 
-Before submitting a Pull Request, please ensure:
+For new features, behavior changes, or non-trivial fixes, please open
+or comment on an issue first to discuss the direction. This helps us
+align on design and scope before any code is written, and avoids wasted
+effort on both sides. PRs submitted without prior discussion may be
+closed.
+
+Before submitting, please ensure:
 
 1. Your code passes all tests: Run `npm run test`
 2. Your code adheres to our linting standards: Run `npm run lint`


### PR DESCRIPTION
## Summary

Update `CONTRIBUTING.md` to ask contributors to discuss the direction in an issue before opening a PR for new features, behavior changes, or non-trivial fixes. Notes that PRs submitted without prior discussion may be closed.

The current guide only describes technical requirements (tests, lint, docs), so the expectation around prior issue discussion was implicit. Making it explicit helps both human and automated contributors avoid wasted effort.

## Checklist

- [x] Run `npm run test` (no code changes; docs only)
- [x] Run `npm run lint` (no code changes; docs only)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
