### PR TITLE
perf(core): Automated performance tuning by Claude

### DIFF
--- a/src/core/metrics/calculateFileMetrics.ts
+++ b/src/core/metrics/calculateFileMetrics.ts
@@ -7,11 +7,11 @@ import type { TokenEncoding } from './TokenCounter.js';
 import type { FileMetrics } from './workers/types.js';
 
 // Batch size for grouping files into worker tasks to reduce IPC overhead.
-// Each batch is sent as a single message to a worker thread, avoiding
-// per-file round-trip costs (~0.5ms each) that dominate when processing many files.
-// A size of 10 keeps individual worker tasks small so that workers become available sooner,
-// enabling overlap between file metrics and output generation.
-const METRICS_BATCH_SIZE = 10;
+// Each batch is one structured-clone message to a worker (~0.5ms per round-trip),
+// so for 1000+ files batches of 10 became the throughput ceiling. 50 matches
+// the security check batch size and still produces ~20 batches across the
+// worker pool — enough for the work-stealing scheduler to distribute load evenly.
+const METRICS_BATCH_SIZE = 50;
 
 export const calculateFileMetrics = async (
   processedFiles: ProcessedFile[],


### PR DESCRIPTION
## Summary

Increase `METRICS_BATCH_SIZE` in the file-metrics worker dispatch from **10 → 50**.

The per-batch IPC overhead (one structured-clone message to a worker per round-trip) was the throughput ceiling for the file-metrics step on repos with 1000+ files. The original "smaller batches enable earlier overlap with output generation" rationale didn't hold in practice — output generation completes well before file metrics on every measured XML/MD/plain config, so the overlap window is bounded by metrics regardless of batch granularity.

50 (matching the security-check batch size) cuts round-trips ~5× while still producing ~20 batches across the 4-worker pool, which the work-stealing scheduler distributes evenly. The invariant `numBatches ≥ numWorkers` always holds because `TASKS_PER_THREAD = 100` in `processConcurrency.ts` already gates worker spawning at `ceil(n/100)`, so no worker can be idle.

## Benchmark

Paired alternating runs (B = baseline batch=10, A = after batch=50), repomix self-pack on a 4-core machine, 20 pairs:

| metric            | baseline (B) | after (A)  | Δ             |
|-------------------|--------------|------------|---------------|
| Wall time mean    | 1.4027 s     | 1.3722 s   | **−30.5 ms (−2.17%)** |
| File-metrics step | ~418 ms      | ~373 ms    | −45 ms (−10.8% of step) |

Paired t-test on the wall-time differences: t = 2.53, p ≈ 0.02.

Sanity-checked across repo sizes (no regressions; all are neutral or faster):

| Repo size            | files | baseline | after  | Δ       |
|----------------------|-------|----------|--------|---------|
| Small (`metrics/calculate*.ts`) | ~6    | 0.529 s  | 0.524 s | −5 ms   |
| Medium (`src/**`)               | ~150  | 0.736 s  | 0.711 s | −25 ms  |
| Full (self-pack)                | ~1037 | 1.403 s  | 1.372 s | −31 ms  |

The math also rules out worker-underutilization regressions: for n < 100 only 1 worker spawns regardless, and for 100–199 files batch=50 still produces 2–4 batches (≥ 2 workers).

## Test plan

- [x] `npm run lint`
- [x] `npm run test` (1249/1249 pass)
- [x] Wall-clock benchmark (paired, 20 runs each side) — 2.17% improvement
- [x] Cross-size verification (small / medium / full) — no regression at any size
- [x] Verbose-log review confirms only the file-metrics step time changed (token counts unchanged)

https://claude.ai/code/session_01BjFXrpUrX7wfV3fQNaDtym

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjFXrpUrX7wfV3fQNaDtym)_