### PR TITLE
perf(core): Automated performance tuning by Claude

### DIFF
--- a/src/core/metrics/calculateFileMetrics.ts
+++ b/src/core/metrics/calculateFileMetrics.ts
@@ -7,11 +7,13 @@ import type { TokenEncoding } from './TokenCounter.js';
 import type { FileMetrics } from './workers/types.js';
 
 // Batch size for grouping files into worker tasks to reduce IPC overhead.
-// Each batch is sent as a single message to a worker thread, avoiding
-// per-file round-trip costs (~0.5ms each) that dominate when processing many files.
-// A size of 10 keeps individual worker tasks small so that workers become available sooner,
-// enabling overlap between file metrics and output generation.
-const METRICS_BATCH_SIZE = 10;
+// Each batch is sent as a single message to a worker thread; measured minimum
+// batch durations are ~2ms, dominated by tinypool serialization and dispatch.
+// At ~1000 files on a 4-core host (~20 batches, ~5 per thread), this cuts the
+// estimated per-thread IPC overhead from ~50ms (batch=10) to ~10ms while
+// keeping load balance comparable. Larger batches (e.g. 100) hurt because a
+// single oversized batch can monopolize a worker and stretch the critical path.
+const METRICS_BATCH_SIZE = 50;
 
 export const calculateFileMetrics = async (
   processedFiles: ProcessedFile[],

--- a/src/core/metrics/workers/calculateMetricsWorker.ts
+++ b/src/core/metrics/workers/calculateMetricsWorker.ts
@@ -6,8 +6,9 @@ import { freeTokenCounters, getTokenCounter } from '../tokenCounterFactory.js';
  * Token counting worker for metrics calculation.
  *
  * Supports both single-content and batch modes. Batch mode reduces IPC overhead
- * by processing multiple files per worker round-trip (~0.5ms overhead per round-trip).
- * For 991 files, batching with size 10 reduces round-trips from 991 to ~100.
+ * by processing multiple files per worker round-trip (~2ms minimum per round-trip,
+ * dominated by tinypool serialization and dispatch).
+ * For ~1000 files, batching with size 50 reduces round-trips from ~1000 to ~20.
  */
 
 // Initialize logger configuration from workerData at module load time

--- a/tests/core/metrics/calculateFileMetrics.test.ts
+++ b/tests/core/metrics/calculateFileMetrics.test.ts
@@ -65,4 +65,39 @@ describe('calculateFileMetrics', () => {
 
     expect(result).toEqual([]);
   });
+
+  // Guards the batching path: files spanning multiple batches must still
+  // produce correctly-ordered, complete results, and the progress callback
+  // must fire once per batch (not per file, not just once at the end).
+  it('preserves order and reports progress across multiple batches', async () => {
+    const fileCount = 120; // forces multiple batches at any plausible METRICS_BATCH_SIZE (≤120)
+    const processedFiles: ProcessedFile[] = Array.from({ length: fileCount }, (_, i) => ({
+      path: `file${i}.txt`,
+      content: 'x'.repeat(i + 1),
+    }));
+    const targetFilePaths = processedFiles.map((f) => f.path);
+    const progressCallback: RepomixProgressCallback = vi.fn();
+
+    const taskRunner = mockInitTaskRunner({
+      numOfTasks: fileCount,
+      workerType: 'calculateMetrics',
+      runtime: 'worker_threads',
+    });
+    const runSpy = vi.spyOn(taskRunner, 'run');
+
+    const result = await calculateFileMetrics(processedFiles, targetFilePaths, 'o200k_base', progressCallback, {
+      taskRunner,
+    });
+
+    expect(result).toHaveLength(fileCount);
+    expect(result.map((r) => r.path)).toEqual(targetFilePaths);
+    for (const r of result) {
+      expect(r.charCount).toBeGreaterThan(0);
+      expect(r.tokenCount).toBeGreaterThan(0);
+    }
+
+    // Multiple batches → multiple taskRunner.run calls and progress callbacks
+    expect(runSpy.mock.calls.length).toBeGreaterThan(1);
+    expect(progressCallback).toHaveBeenCalledTimes(runSpy.mock.calls.length);
+  });
 });


### PR DESCRIPTION
## Summary

Automated performance tuning. Increases `METRICS_BATCH_SIZE` in
`src/core/metrics/calculateFileMetrics.ts` from **10 to 50**, cutting
per-thread IPC overhead in the metrics worker pool by ~80%. Also adds a
multi-batch regression test that asserts result order, completeness, and
per-batch progress callback frequency on the batching path.

The previous size of 10 was tuned for fast worker availability so that
file metrics could overlap with output generation, but tinypool
round-trips were measured at ~2 ms minimum (small batches bottom out
there). At ~1000 files the dispatched task count drops from ~100 to
~20 (~5 batches per thread on a 4-thread pool instead of ~25), saving
~40 estimated worker-ms of pure serialization/dispatch per worker on
the critical path. Going further (e.g. 100) hurts because a single
oversized batch can monopolize a worker and stretch the tail.

## Benchmark

This repo (1016 files, 4 cores), 100 paired interleaved runs alternating
BATCH=10 and BATCH=50 with the same prebuilt JS, swapping only the
constant. Full pipeline timed end-to-end with `time`:

| | BATCH=10 (baseline) | BATCH=50 (this PR) |
|---|---|---|
| mean | 1.5589 s | **1.5111 s** |
| median | 1.5480 s | **1.5030 s** |
| stdev | 0.0966 s | 0.0625 s |
| min | 1.4280 s | 1.3770 s |

- **Saved: 47.8 ms (3.07%) mean / 45.0 ms (2.91%) median** (trimmed mean 41.0 ms, dropping top/bottom 10%)
- 69/100 paired runs faster with BATCH=50
- Paired t-test: t = 4.545, df = 99, **p < 0.001**
- 95% CI on mean improvement: **[27.2 ms, 68.4 ms]**
- Sign test 2-sided p = 0.0002

The improvement is statistically significant and exceeds the 2%
threshold robustly. Output is byte-identical for the same source tree.

## Test plan

- [x] `npm run test` (1250 tests pass; new multi-batch test included)
- [x] `npm run lint` (no new warnings/errors)
- [x] Verified output byte-identical between BATCH=10 and BATCH=50 builds on the same source tree
- [x] Verified statistical significance (paired t-test, sign test, 95% CI)

https://claude.ai/code/session_013WKUpvimxCEAf1TZes9ENC

---
_Generated by [Claude Code](https://claude.ai/code/session_013WKUpvimxCEAf1TZes9ENC)_