### PR TITLE
perf(core): Automated performance tuning by Claude

### DIFF
--- a/src/core/metrics/calculateMetrics.ts
+++ b/src/core/metrics/calculateMetrics.ts
@@ -1,6 +1,6 @@
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
-import { getWorkerThreadCount, initTaskRunner } from '../../shared/processConcurrency.js';
+import { getProcessConcurrency, getWorkerThreadCount, initTaskRunner } from '../../shared/processConcurrency.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
 import type { ProcessedFile } from '../file/fileTypes.js';
 import type { GitDiffResult } from '../git/gitDiffHandle.js';
@@ -29,6 +29,12 @@ export interface MetricsTaskRunnerWithWarmup {
   warmupPromise: Promise<unknown>;
 }
 
+// Reserve cores for the security-check pool (max 2) and the main thread so the
+// metric workers' gpt-tokenizer init (~270-465 ms each) doesn't contend with
+// security workers and slip past the collectFiles window into the security-check
+// window. Symmetric with the security pool's own `Math.min(2, ...)` cap.
+const getMetricWorkerCap = (): number => Math.max(1, getProcessConcurrency() - 2);
+
 /**
  * Create a metrics task runner and warm up all worker threads by triggering
  * gpt-tokenizer initialization in parallel. This allows the expensive module
@@ -36,13 +42,16 @@ export interface MetricsTaskRunnerWithWarmup {
  * output generation).
  */
 export const createMetricsTaskRunner = (numOfTasks: number, encoding: TokenEncoding): MetricsTaskRunnerWithWarmup => {
+  const metricWorkerCap = getMetricWorkerCap();
+
   const taskRunner = initTaskRunner<MetricsWorkerTask, MetricsWorkerResult>({
     numOfTasks,
     workerType: 'calculateMetrics',
     runtime: 'worker_threads',
+    maxWorkerThreads: metricWorkerCap,
   });
 
-  const { maxThreads } = getWorkerThreadCount(numOfTasks);
+  const { maxThreads } = getWorkerThreadCount(numOfTasks, metricWorkerCap);
   const warmupPromise = Promise.all(
     Array.from({ length: maxThreads }, () => taskRunner.run({ content: '', encoding }).catch(() => 0)),
   );
@@ -118,6 +127,7 @@ export const calculateMetrics = async (
       numOfTasks: processedFiles.length,
       workerType: 'calculateMetrics',
       runtime: 'worker_threads',
+      maxWorkerThreads: getMetricWorkerCap(),
     });
 
   try {

--- a/tests/core/metrics/calculateMetrics.test.ts
+++ b/tests/core/metrics/calculateMetrics.test.ts
@@ -279,4 +279,24 @@ describe('createMetricsTaskRunner', () => {
     expect(Array.isArray(resolved)).toBe(true);
     expect((resolved as number[]).every((v) => v === 0)).toBe(true);
   });
+
+  // The metric pool is intentionally capped to leave headroom for the security-check
+  // pool (max 2 workers) + main thread on the same machine. Without this cap,
+  // 4 metric workers would contend with 2 security workers during gpt-tokenizer init.
+  it('should pass a capped maxWorkerThreads to initTaskRunner', async () => {
+    const processConcurrency = await import('../../../src/shared/processConcurrency.js');
+    const initTaskRunner = processConcurrency.initTaskRunner as Mock;
+    initTaskRunner.mockClear();
+
+    createMetricsTaskRunner(1000, 'o200k_base');
+
+    expect(initTaskRunner).toHaveBeenCalledTimes(1);
+    const callArg = initTaskRunner.mock.calls[0][0];
+    expect(callArg).toMatchObject({
+      workerType: 'calculateMetrics',
+      runtime: 'worker_threads',
+    });
+    expect(callArg.maxWorkerThreads).toBeGreaterThanOrEqual(1);
+    expect(callArg.maxWorkerThreads).toBe(Math.max(1, processConcurrency.getProcessConcurrency() - 2));
+  });
 });

--- a/website/client/src/public/schemas/1.14.0/schema.json
+++ b/website/client/src/public/schemas/1.14.0/schema.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "input": {
+      "type": "object",
+      "properties": {
+        "maxFileSize": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
+    },
+    "output": {
+      "type": "object",
+      "properties": {
+        "filePath": {
+          "type": "string"
+        },
+        "style": {
+          "enum": [
+            "xml",
+            "markdown",
+            "json",
+            "plain"
+          ],
+          "type": "string"
+        },
+        "parsableStyle": {
+          "type": "boolean"
+        },
+        "headerText": {
+          "type": "string"
+        },
+        "instructionFilePath": {
+          "type": "string"
+        },
+        "fileSummary": {
+          "type": "boolean"
+        },
+        "directoryStructure": {
+          "type": "boolean"
+        },
+        "files": {
+          "type": "boolean"
+        },
+        "removeComments": {
+          "type": "boolean"
+        },
+        "removeEmptyLines": {
+          "type": "boolean"
+        },
+        "compress": {
+          "type": "boolean"
+        },
+        "topFilesLength": {
+          "type": "number"
+        },
+        "showLineNumbers": {
+          "type": "boolean"
+        },
+        "truncateBase64": {
+          "type": "boolean"
+        },
+        "copyToClipboard": {
+          "type": "boolean"
+        },
+        "includeEmptyDirectories": {
+          "type": "boolean"
+        },
+        "includeFullDirectoryStructure": {
+          "type": "boolean"
+        },
+        "splitOutput": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9007199254740991
+        },
+        "tokenCountTree": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "git": {
+          "type": "object",
+          "properties": {
+            "sortByChanges": {
+              "type": "boolean"
+            },
+            "sortByChangesMaxCommits": {
+              "type": "number"
+            },
+            "includeDiffs": {
+              "type": "boolean"
+            },
+            "includeLogs": {
+              "type": "boolean"
+            },
+            "includeLogsCount": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "include": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "ignore": {
+      "type": "object",
+      "properties": {
+        "useGitignore": {
+          "type": "boolean"
+        },
+        "useDotIgnore": {
+          "type": "boolean"
+        },
+        "useDefaultPatterns": {
+          "type": "boolean"
+        },
+        "customPatterns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "security": {
+      "type": "object",
+      "properties": {
+        "enableSecurityCheck": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "tokenCount": {
+      "type": "object",
+      "properties": {
+        "encoding": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "title": "Repomix Configuration",
+  "description": "Schema for repomix.config.json configuration file"
+}


### PR DESCRIPTION
## Summary

Caps the `calculateMetrics` worker pool at `max(1, availableParallelism() - 2)` so it doesn't fight with the concurrent security-check pool (capped at 2) for CPU during `gpt-tokenizer` initialization. End-to-end CLI run drops by ~3.4% on this repo on a 4-core machine.

## Why

Previously the metric worker pool was sized at `availableParallelism()` (4 on a 4-core CI runner), while the security-check pool runs concurrently with up to 2 workers plus the main thread. That's 7 contending threads on 4 cores during the `collectFiles → securityCheck` transition.

Each metric worker has to parse ~2.2 MB of `gpt-tokenizer` BPE rank data on first use (~270–465 ms). With contention, the 2nd–4th metric worker inits get serialized onto the security-check window instead of finishing during the earlier `collectFiles` phase as intended by the warm-up.

The fix leaves 2 cores for the security pool. Token counting itself is fast (~1 ms / batch of 10 files), so the smaller metric pool is still amply fast for the fast-path metrics — wall-clock time was previously dominated by tokenizer initialization, not token counting.

The cap is applied in both `createMetricsTaskRunner` (the warm-up entry called from `pack()`) and the fallback `initTaskRunner` inside `calculateMetrics` itself, so both code paths stay symmetric.

## Effect

Per-stage timings (verbose output, this repo, custom `repomix.config.json`):

|                              | baseline       | patched      |
|------------------------------|----------------|--------------|
| TokenCounter init (×N)       | 240/254/309/350 ms | 217/230 ms |
| File collection completed    | ~500–527 ms    | ~307–321 ms  |
| Security check completed     | ~250 ms        | ~211 ms      |

End-to-end (10 runs each):

|             | mean      | median    | min       |
|-------------|-----------|-----------|-----------|
| baseline    | 1768 ms   | 1757 ms   | 1733 ms   |
| patched     | 1701 ms   | 1705 ms   | 1621 ms   |
| Δ           | −67 ms (−3.8%) | −52 ms (−3.0%) | −112 ms (−6.5%) |

Comfortably above the 2% / ~36 ms automated-tuning target.

## Notes

- No behavior change: the same number of token-count batches are still processed, just on a slightly smaller pool that better matches available cores.
- Lower bound of 1 keeps single- and two-core environments working (`max(1, 1-2) = max(1, 2-2) = 1`).
- The security-check pool already self-caps at 2 workers (see `runSecurityCheck`); subtracting 2 here keeps the two pools symmetric.
- On 8-core machines the cap becomes 6, but `getWorkerThreadCount`'s task-based ceiling (`ceil(numOfTasks / 100)`) is typically the binding constraint there anyway, so the cap rarely matters on larger machines.

## Checklist

- [x] Run `npm run test` — 1250 / 1250 passing (added 1 new test)
- [x] Run `npm run lint` — 0 errors, 2 pre-existing warnings unrelated to this change

## Test plan

- [x] `npx vitest run tests/core/metrics tests/shared/processConcurrency.test.ts` — 101 / 101 passing
- [x] Full `npm run test` — 1250 / 1250 passing
- [x] `npm run lint` — clean
- [x] Manual `time node bin/repomix.cjs --quiet` × 10 runs before/after, verified ≥3% improvement on mean/median/min


---
_Generated by [Claude Code](https://claude.ai/code/session_01C6a8EfZmrr1N1vxPkJmsxL)_