### PR TITLE
perf(core): Automated performance tuning by Claude

### DIFF
--- a/src/core/metrics/calculateFileMetrics.ts
+++ b/src/core/metrics/calculateFileMetrics.ts
@@ -9,9 +9,11 @@ import type { FileMetrics } from './workers/types.js';
 // Batch size for grouping files into worker tasks to reduce IPC overhead.
 // Each batch is sent as a single message to a worker thread, avoiding
 // per-file round-trip costs (~0.5ms each) that dominate when processing many files.
-// A size of 10 keeps individual worker tasks small so that workers become available sooner,
-// enabling overlap between file metrics and output generation.
-const METRICS_BATCH_SIZE = 10;
+// 50 strikes the balance: with ~1000 files in a typical repo it produces ~20
+// batches — enough granularity for 4 workers to load-balance even when batches
+// have variable token-counting cost, while cutting IPC round-trips by 5x vs a
+// size of 10 (saves ~30-50ms of serialization overhead on large repos).
+const METRICS_BATCH_SIZE = 50;
 
 export const calculateFileMetrics = async (
   processedFiles: ProcessedFile[],

--- a/src/core/metrics/workers/calculateMetricsWorker.ts
+++ b/src/core/metrics/workers/calculateMetricsWorker.ts
@@ -7,7 +7,7 @@ import { freeTokenCounters, getTokenCounter } from '../tokenCounterFactory.js';
  *
  * Supports both single-content and batch modes. Batch mode reduces IPC overhead
  * by processing multiple files per worker round-trip (~0.5ms overhead per round-trip).
- * For 991 files, batching with size 10 reduces round-trips from 991 to ~100.
+ * Batch size is set in calculateFileMetrics.ts (METRICS_BATCH_SIZE).
  */
 
 // Initialize logger configuration from workerData at module load time


### PR DESCRIPTION
## Summary

Reduces the file-metrics IPC round-trip count by 5x to shave a measurable slice off the default `pack()` critical path.

`calculateFileMetrics` dispatches one Tinypool task per batch of files and currently uses `BATCH_SIZE = 10`. For a typical ~1000-file repo this means ~100 main↔worker round-trips, each costing ~0.5ms of message serialization. Raising the batch size to 50 cuts that to ~20 round-trips while still leaving enough granularity (~20 batches across 4 workers) for load balancing under variable per-file tokenization cost.

Per-file token counts and char counts are still computed individually; only the batching fan-out changes. Generated pack output is byte-identical (verified via md5).

## Investigation

I ran 5 parallel research agents (sonnet) over non-overlapping scopes (CLI startup, file I/O, metrics/tokenization, output generation, config/git). Across the candidates I tried (lazy-loading handlebars, `FILE_COLLECT_CONCURRENCY` 50→100, parallelising config `fs.stat`, dispatch reorder in `calculateMetrics`), this batch-size bump was the only single-file change that consistently cleared the 2% threshold under paired alternating runs without behavior changes.

Several other candidates either had no measurable end-to-end effect (handlebars lazy-load shifted ~19ms off module init but most of it landed back inside `produceOutput` because the dynamic import in CJS is essentially synchronous), or were within noise (concurrency bump, dispatch reorder).

## Benchmark

Paired alternating runs of `node bin/repomix.cjs --quiet` on this repo (1037 files, default config including `includeDiffs`/`includeLogs`/`sortByChanges`).

```
Run A (n=30, primary):
  BEFORE   mean=1375ms  median=1363ms  trimmed-mean=1371ms
  AFTER    mean=1339ms  median=1344ms  trimmed-mean=1341ms
  DIFF     mean=-36ms (-2.61%)  trimmed-mean=-30ms (-2.18%)

Run B (n=10, independent reproduction by separate review agent,
       stable-phase pairs only):
  BEFORE   mean=1435ms  stdev=22ms
  AFTER    mean=1400ms  stdev=16ms
  DIFF     mean=-35ms (-2.43%)  ~2.9σ paired
```

Both stable-phase means clear the 2% target. Single-shot verbose timings on the metrics phase (~50–100ms stdev) are noisier than the paired wall-clock comparison, so the wall-clock mean shift is the trustworthy figure.

## Risks / Caveats

- Pure tuning constant change. No API, behavior, or output change.
- Worker-pool sizing (`maxThreads`) is computed from file count via `TASKS_PER_THREAD = 100`, independent of the batch size, so concurrency is unchanged.
- Smaller repos (≤50 files) already produced a single batch under both values, so they see no regression.
- Larger repos: a 50-file batch serializes the same content that already lived in the main thread's `processedFiles`, so there is no new memory pressure — only one batch is in flight per worker at a time.
- The constant is now aligned with `securityCheck.ts:28`'s independent `BATCH_SIZE = 50`; the two pools remain decoupled.

## Checklist

- [x] Run `npm run test` — 1249 passed (120 files)
- [x] Run `npm run lint` — 0 errors (2 pre-existing unrelated warnings)
- [x] Verified pack output byte-identical (md5 match) before vs after

---
_Generated by [Claude Code](https://claude.ai/code/session_01AoLcC6NMv1NK71gRRATTDh)_