### PR TITLE
docs(website): Add English page metadata

### DIFF
--- a/website/client/src/en/guide/agent-skills-generation.md
+++ b/website/client/src/en/guide/agent-skills-generation.md
@@ -1,3 +1,8 @@
+---
+title: Agent Skills Generation
+description: Generate Claude Agent Skills from local or remote repositories so AI assistants can reuse codebase references, project structure, and implementation patterns.
+---
+
 # Agent Skills Generation
 
 Repomix can generate [Claude Agent Skills](https://docs.anthropic.com/en/docs/claude-code/skills) format output, creating a structured Skills directory that can be used as a reusable codebase reference for AI assistants.

--- a/website/client/src/en/guide/claude-code-plugins.md
+++ b/website/client/src/en/guide/claude-code-plugins.md
@@ -1,3 +1,8 @@
+---
+title: Claude Code Plugins
+description: Install and use official Repomix Claude Code plugins for MCP, slash commands, and AI-powered repository exploration.
+---
+
 # Claude Code Plugins
 
 Repomix provides official plugins for [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) that integrate seamlessly with the AI-powered development environment. These plugins make it easy to analyze and pack codebases directly within Claude Code using natural language commands.

--- a/website/client/src/en/guide/code-compress.md
+++ b/website/client/src/en/guide/code-compress.md
@@ -1,3 +1,8 @@
+---
+title: Code Compression
+description: Use Tree-sitter based code compression in Repomix to reduce token usage while preserving imports, exports, classes, functions, interfaces, and structure.
+---
+
 # Code Compression
 
 Code compression is a powerful feature that intelligently extracts essential code structures while removing implementation details. This is particularly useful for reducing token count while maintaining important structural information about your codebase.

--- a/website/client/src/en/guide/command-line-options.md
+++ b/website/client/src/en/guide/command-line-options.md
@@ -1,3 +1,8 @@
+---
+title: Command Line Options
+description: Reference every Repomix CLI option for input, output, file selection, remote repositories, configuration, security, token counting, MCP, and agent skills.
+---
+
 # Command Line Options
 
 ## Basic Options

--- a/website/client/src/en/guide/comment-removal.md
+++ b/website/client/src/en/guide/comment-removal.md
@@ -1,3 +1,7 @@
+---
+title: Comment Removal
+description: Remove code comments from Repomix output to reduce noise and token usage while preserving source files and supported language behavior.
+---
 
 # Comment Removal
 

--- a/website/client/src/en/guide/community-projects.md
+++ b/website/client/src/en/guide/community-projects.md
@@ -1,3 +1,8 @@
+---
+title: Community Projects
+description: Discover community tools, editor extensions, desktop apps, language implementations, and integrations built around Repomix.
+---
+
 # Community Projects
 
 Discover amazing projects created by the Repomix community! These projects extend Repomix's capabilities, provide implementations in other languages, or integrate Repomix into larger toolsets.
@@ -46,4 +51,3 @@ CLI toolset for AI agents with multiple capabilities including web search via Pe
 - [Installation](/guide/installation) - Install Repomix CLI or browser extension
 - [MCP Server](/guide/mcp-server) - Use Repomix as an MCP server for AI assistants
 - [Claude Code Plugins](/guide/claude-code-plugins) - Official plugins for Claude Code
-

--- a/website/client/src/en/guide/configuration.md
+++ b/website/client/src/en/guide/configuration.md
@@ -1,3 +1,8 @@
+---
+title: Configuration
+description: Configure Repomix with JSON, JSONC, JSON5, JavaScript, or TypeScript files, including output formats, include and ignore patterns, and advanced options.
+---
+
 # Configuration
 
 Repomix can be configured using a configuration file or command-line options. The configuration file allows you to customize various aspects of how Repomix processes and outputs your codebase.

--- a/website/client/src/en/guide/custom-instructions.md
+++ b/website/client/src/en/guide/custom-instructions.md
@@ -1,3 +1,8 @@
+---
+title: Custom Instructions
+description: Add project-specific instructions to Repomix output so AI assistants understand coding standards, architecture context, review goals, and response requirements.
+---
+
 # Custom Instructions
 
 Repomix allows you to provide custom instructions that will be included in the output file. This can be useful for adding context or specific guidelines for AI systems processing the repository.
@@ -48,4 +53,3 @@ This repository contains the source code for the Repomix tool. Please follow the
 - [Output Formats](/guide/output) - Learn about the different output formats
 - [Prompt Examples](/guide/prompt-examples) - Example prompts for AI analysis
 - [Use Cases](/guide/use-cases) - Real-world examples of using Repomix with AI
-

--- a/website/client/src/en/guide/development/index.md
+++ b/website/client/src/en/guide/development/index.md
@@ -1,3 +1,8 @@
+---
+title: Contributing to Repomix
+description: Set up the Repomix development environment, run tests, lint code, understand the project structure, and contribute changes to the open source project.
+---
+
 # Contributing to Repomix
 
 Thank you for your interest in **Repomix**! 🚀 We'd love your help to make it even better. This guide will help you get started with contributing to the project.

--- a/website/client/src/en/guide/development/using-repomix-as-a-library.md
+++ b/website/client/src/en/guide/development/using-repomix-as-a-library.md
@@ -1,3 +1,8 @@
+---
+title: Using Repomix as a Library
+description: Use Repomix as a Node.js library to pack local directories or remote repositories, access core APIs, and integrate AI-ready codebase output into applications.
+---
+
 # Using Repomix as a Library
 
 In addition to using Repomix as a CLI tool, you can integrate its functionality directly into your Node.js applications.

--- a/website/client/src/en/guide/github-actions.md
+++ b/website/client/src/en/guide/github-actions.md
@@ -1,3 +1,8 @@
+---
+title: Using Repomix with GitHub Actions
+description: Automate Repomix in GitHub Actions to package repositories for AI analysis, CI workflows, artifacts, code review, and compressed output.
+---
+
 # Using Repomix with GitHub Actions
 
 You can automate the process of packing your codebase for AI analysis by integrating Repomix into your GitHub Actions workflows. This is useful for continuous integration (CI), code review, or preparing your repository for LLM-based tools.

--- a/website/client/src/en/guide/index.md
+++ b/website/client/src/en/guide/index.md
@@ -1,3 +1,8 @@
+---
+title: Getting Started with Repomix
+description: Start using Repomix to pack a repository into AI-friendly context for ChatGPT, Claude, Gemini, Grok, DeepSeek, Perplexity, and other LLMs.
+---
+
 # Getting Started with Repomix
 
 <script setup>

--- a/website/client/src/en/guide/installation.md
+++ b/website/client/src/en/guide/installation.md
@@ -1,3 +1,8 @@
+---
+title: Installation
+description: Install Repomix with npx, npm, Yarn, Bun, Homebrew, Docker, VS Code extensions, or browser extensions and verify the CLI setup.
+---
+
 # Installation
 
 ## Using npx (No Installation Required)

--- a/website/client/src/en/guide/mcp-server.md
+++ b/website/client/src/en/guide/mcp-server.md
@@ -1,3 +1,8 @@
+---
+title: MCP Server
+description: Run Repomix as a Model Context Protocol server so AI assistants can pack, search, and read local or remote codebases directly.
+---
+
 # MCP Server
 
 Repomix supports the [Model Context Protocol (MCP)](https://modelcontextprotocol.io), allowing AI assistants to directly interact with your codebase. When run as an MCP server, Repomix provides tools that enable AI assistants to package local or remote repositories for analysis without requiring manual file preparation.

--- a/website/client/src/en/guide/output.md
+++ b/website/client/src/en/guide/output.md
@@ -1,3 +1,8 @@
+---
+title: Output Formats
+description: Compare Repomix XML, Markdown, JSON, and plain text output formats and choose the best structure for Claude, ChatGPT, Gemini, APIs, and automation.
+---
+
 # Output Formats
 
 Repomix supports four output formats:

--- a/website/client/src/en/guide/privacy.md
+++ b/website/client/src/en/guide/privacy.md
@@ -1,3 +1,8 @@
+---
+title: Privacy Policy
+description: Understand how the Repomix CLI, website, and browser extension handle repository data, telemetry, temporary uploads, and security responsibilities.
+---
+
 # Privacy Policy
 
 ## Repomix CLI Tool

--- a/website/client/src/en/guide/prompt-examples.md
+++ b/website/client/src/en/guide/prompt-examples.md
@@ -1,3 +1,8 @@
+---
+title: Prompt Examples
+description: Copy prompt templates for using Repomix output in AI code reviews, security analysis, performance reviews, documentation, testing, and quality checks.
+---
+
 # Prompt Examples
 
 ## Code Review

--- a/website/client/src/en/guide/remote-repository-processing.md
+++ b/website/client/src/en/guide/remote-repository-processing.md
@@ -1,3 +1,8 @@
+---
+title: GitHub Repository Processing
+description: Pack GitHub repositories with Repomix using full URLs, user/repo shorthand, branches, tags, commits, Docker, and remote config trust controls.
+---
+
 # GitHub Repository Processing
 
 ## Basic Usage

--- a/website/client/src/en/guide/repomix-explorer-skill.md
+++ b/website/client/src/en/guide/repomix-explorer-skill.md
@@ -1,13 +1,13 @@
 ---
 title: Repomix Explorer Skill (Agent Skills)
-description: Install the Repomix Explorer agent skill to analyze local and remote codebases with AI assistants such as Claude Code, Cursor, Codex, and GitHub Copilot.
+description: Install the Repomix Explorer agent skill to analyze local and remote codebases with Claude Code and other AI assistants that support the Agent Skills format.
 ---
 
 # Repomix Explorer Skill (Agent Skills)
 
 Repomix provides a ready-to-use **Repomix Explorer** skill that enables AI coding assistants to analyze and explore codebases using Repomix CLI.
 
-This skill is designed to work with various AI tools including Claude Code, Cursor, Codex, GitHub Copilot, and more.
+This skill is designed for Claude Code and other AI assistants that support the Agent Skills format.
 
 ## Quick Install
 

--- a/website/client/src/en/guide/repomix-explorer-skill.md
+++ b/website/client/src/en/guide/repomix-explorer-skill.md
@@ -1,3 +1,8 @@
+---
+title: Repomix Explorer Skill (Agent Skills)
+description: Install the Repomix Explorer agent skill to analyze local and remote codebases with AI assistants such as Claude Code, Cursor, Codex, and GitHub Copilot.
+---
+
 # Repomix Explorer Skill (Agent Skills)
 
 Repomix provides a ready-to-use **Repomix Explorer** skill that enables AI coding assistants to analyze and explore codebases using Repomix CLI.

--- a/website/client/src/en/guide/security.md
+++ b/website/client/src/en/guide/security.md
@@ -1,3 +1,8 @@
+---
+title: Security
+description: Learn how Repomix uses Secretlint and safety checks to detect secrets, API keys, tokens, credentials, and sensitive repository content before packing.
+---
+
 # Security
 
 ## Security Check Feature

--- a/website/client/src/en/guide/tips/best-practices.md
+++ b/website/client/src/en/guide/tips/best-practices.md
@@ -1,3 +1,8 @@
+---
+title: "AI-Assisted Development Best Practices: From My Experience"
+description: Practical AI-assisted development tips for using existing code, modular implementation, tests, planning, and Repomix-based context sharing.
+---
+
 # AI-Assisted Development Best Practices: From My Experience
 
 While I haven't successfully completed a large-scale project using AI yet, I'd like to share what I've learned so far from my experience working with AI in development.

--- a/website/client/src/en/guide/usage.md
+++ b/website/client/src/en/guide/usage.md
@@ -1,3 +1,8 @@
+---
+title: Basic Usage
+description: Use Repomix CLI to pack directories, remote repositories, selected files, git diffs, commit logs, split outputs, token counts, and compressed code.
+---
+
 # Basic Usage
 
 ## Quick Start

--- a/website/client/src/en/guide/use-cases.md
+++ b/website/client/src/en/guide/use-cases.md
@@ -1,3 +1,8 @@
+---
+title: Use Cases
+description: Explore practical Repomix workflows for AI code review, bug investigation, refactoring, documentation, onboarding, security audits, and architecture analysis.
+---
+
 <script setup>
 import YouTubeVideo from '../../../components/YouTubeVideo.vue';
 </script>

--- a/website/client/src/en/index.md
+++ b/website/client/src/en/index.md
@@ -2,6 +2,7 @@
 layout: home
 title: Repomix
 titleTemplate: Pack your codebase into AI-friendly formats
+description: Pack local or remote repositories into AI-friendly XML, Markdown, JSON, or plain text for Claude, ChatGPT, Gemini, MCP, and code review workflows.
 aside: false
 editLink: false
 


### PR DESCRIPTION
## Summary

Add page-specific frontmatter metadata to the English website docs so VitePress can emit per-page meta descriptions and the generated llms.txt includes useful page summaries.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
