### PR TITLE
chore(skills): Mark agent-memory and contextual-commit as internal

### DIFF
--- a/.claude/skills/agent-memory/SKILL.md
+++ b/.claude/skills/agent-memory/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: agent-memory
 description: "Use this skill when the user asks to save, remember, recall, or organize memories. Triggers on: 'remember this', 'save this', 'note this', 'what did we discuss about...', 'check your notes', 'clean up memories'. Also use proactively when discovering valuable findings worth preserving."
+metadata:
+  internal: true
 ---
 
 # Agent Memory

--- a/.claude/skills/contextual-commit/SKILL.md
+++ b/.claude/skills/contextual-commit/SKILL.md
@@ -7,6 +7,8 @@ description: >-
   action lines in the commit body that preserve WHY code was written, not
   just WHAT changed.
 license: MIT
+metadata:
+  internal: true
 ---
 
 # Contextual Commits


### PR DESCRIPTION
## Summary

- Add `metadata.internal: true` to the frontmatter of `.claude/skills/agent-memory/SKILL.md` and `.claude/skills/contextual-commit/SKILL.md`.
- These skills are intended for the maintainer's local Claude Code workflow, not as part of Repomix's user-facing skills. The `internal` flag keeps them out of skill listings and discovery flows so they aren't treated as newly added public skills.
- No runtime behavior of Repomix changes.

## Checklist

- [ ] Run `npm run test`
- [ ] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->