### PR TITLE
feat(website): Add Cloudflare Turnstile to /api/pack

### DIFF
--- a/website/client/.vitepress/config.ts
+++ b/website/client/.vitepress/config.ts
@@ -14,8 +14,7 @@ import { configDe } from './config/configDe';
 //
 // `CF_PAGES_BRANCH` is auto-injected by Cloudflare Pages with the configured
 // production branch name.
-const isCfPagesProductionDeploy =
-  process.env.CF_PAGES === '1' && process.env.CF_PAGES_BRANCH === 'main';
+const isCfPagesProductionDeploy = process.env.CF_PAGES === '1' && process.env.CF_PAGES_BRANCH === 'main';
 if (isCfPagesProductionDeploy && !process.env.VITE_TURNSTILE_SITE_KEY) {
   throw new Error(
     'VITE_TURNSTILE_SITE_KEY must be set for the Cloudflare Pages production deploy. Configure it in Pages → Settings → Environment variables (Production) and retry.',

--- a/website/client/.vitepress/config.ts
+++ b/website/client/.vitepress/config.ts
@@ -1,13 +1,24 @@
 import { defineConfig } from 'vitepress';
 import { configDe } from './config/configDe';
 
-// Production builds must inject a real Turnstile site key. VitePress's SSR
-// catches in-component throws and exits 0, so a missing env var would silently
-// ship the always-passes test sitekey. Throwing at config load fails the build
-// immediately — the deploy step (Cloudflare Pages, CI) sees a non-zero exit.
-if (process.env.NODE_ENV === 'production' && !process.env.VITE_TURNSTILE_SITE_KEY) {
+// Cloudflare Pages production deploy must inject a real Turnstile site key.
+// VitePress's SSR catches in-component throws and exits 0, so a missing env
+// var would silently ship the always-passes test sitekey. Throwing at config
+// load fails the build immediately so the deploy is surfaced as broken.
+//
+// Scope: only the production-branch Cloudflare Pages deploy. Preview deploys
+// (PRs, branch builds), local `docs:build`, and CI builds run without the
+// env var by design — those use the test sitekey. The runtime throw inside
+// useTurnstile() is the second line of defence: any actual production page
+// load with the test key fallback fails the form mount loudly.
+//
+// `CF_PAGES_BRANCH` is auto-injected by Cloudflare Pages with the configured
+// production branch name.
+const isCfPagesProductionDeploy =
+  process.env.CF_PAGES === '1' && process.env.CF_PAGES_BRANCH === 'main';
+if (isCfPagesProductionDeploy && !process.env.VITE_TURNSTILE_SITE_KEY) {
   throw new Error(
-    'VITE_TURNSTILE_SITE_KEY must be set for production builds. Configure it in Cloudflare Pages env vars and retry.',
+    'VITE_TURNSTILE_SITE_KEY must be set for the Cloudflare Pages production deploy. Configure it in Pages → Settings → Environment variables (Production) and retry.',
   );
 }
 

--- a/website/client/.vitepress/config.ts
+++ b/website/client/.vitepress/config.ts
@@ -1,5 +1,16 @@
 import { defineConfig } from 'vitepress';
 import { configDe } from './config/configDe';
+
+// Production builds must inject a real Turnstile site key. VitePress's SSR
+// catches in-component throws and exits 0, so a missing env var would silently
+// ship the always-passes test sitekey. Throwing at config load fails the build
+// immediately — the deploy step (Cloudflare Pages, CI) sees a non-zero exit.
+if (process.env.NODE_ENV === 'production' && !process.env.VITE_TURNSTILE_SITE_KEY) {
+  throw new Error(
+    'VITE_TURNSTILE_SITE_KEY must be set for production builds. Configure it in Cloudflare Pages env vars and retry.',
+  );
+}
+
 import { configEnUs } from './config/configEnUs';
 import { configEs } from './config/configEs';
 import { configFr } from './config/configFr';

--- a/website/client/components/Home/TryIt.vue
+++ b/website/client/components/Home/TryIt.vue
@@ -101,6 +101,11 @@
           @repack="handleRepack"
         />
       </div>
+
+      <!-- Cloudflare Turnstile (invisible). Rendered into this element by
+           useTurnstile so the script tag and widget instance live alongside
+           the form that needs them. -->
+      <div ref="turnstileContainer" class="turnstile-container" />
     </form>
   </div>
 </template>
@@ -151,7 +156,14 @@ const {
   repackWithSelectedFiles,
   resetOptions,
   cancelRequest,
+  setTurnstileContainer,
 } = usePackRequest();
+
+// Wire the template ref into useTurnstile so the widget renders into the
+// element below the form. Using a ref function lets us pass the DOM node to
+// the composable without exposing the ref to the rest of the component.
+const turnstileContainer = ref<HTMLElement | null>(null);
+watch(turnstileContainer, (el) => setTurnstileContainer(el));
 
 // Check if reset button should be shown
 const shouldShowReset = computed(() => {

--- a/website/client/components/api/client.ts
+++ b/website/client/components/api/client.ts
@@ -88,7 +88,11 @@ interface StreamErrorEvent {
 
 type StreamEvent = ProgressEvent | ResultEvent | StreamErrorEvent;
 
-export async function packRepository(request: PackRequest, callbacks?: PackStreamCallbacks): Promise<PackResult> {
+export async function packRepository(
+  request: PackRequest,
+  callbacks?: PackStreamCallbacks,
+  turnstileToken?: string,
+): Promise<PackResult> {
   const formData = new FormData();
 
   if (request.file) {
@@ -99,8 +103,14 @@ export async function packRepository(request: PackRequest, callbacks?: PackStrea
   formData.append('format', request.format);
   formData.append('options', JSON.stringify(request.options));
 
+  // Token rides as a header rather than a form field to keep packRequestSchema
+  // free of cross-cutting concerns; the server-side turnstileMiddleware reads
+  // it before the schema validation runs.
+  const headers: HeadersInit = turnstileToken ? { 'X-Turnstile-Token': turnstileToken } : {};
+
   const response = await fetch(`${API_BASE_URL}/api/pack`, {
     method: 'POST',
+    headers,
     body: formData,
     signal: callbacks?.signal,
   });

--- a/website/client/components/utils/requestHandlers.ts
+++ b/website/client/components/utils/requestHandlers.ts
@@ -9,6 +9,7 @@ interface RequestHandlerOptions {
   onProgress?: (stage: PackProgressStage, message?: string) => void;
   signal?: AbortSignal;
   file?: File;
+  turnstileToken?: string;
 }
 
 /**
@@ -20,7 +21,7 @@ export async function handlePackRequest(
   options: PackOptions,
   handlerOptions: RequestHandlerOptions = {},
 ): Promise<void> {
-  const { onSuccess, onError, onAbort, onProgress, signal, file } = handlerOptions;
+  const { onSuccess, onError, onAbort, onProgress, signal, file, turnstileToken } = handlerOptions;
   const processedUrl = url.trim();
 
   // Track pack start
@@ -34,10 +35,14 @@ export async function handlePackRequest(
       file,
     };
 
-    const response = await packRepository(request, {
-      onProgress,
-      signal,
-    });
+    const response = await packRepository(
+      request,
+      {
+        onProgress,
+        signal,
+      },
+      turnstileToken,
+    );
 
     // Track successful pack
     if (response.metadata.summary) {

--- a/website/client/composables/usePackRequest.ts
+++ b/website/client/composables/usePackRequest.ts
@@ -92,15 +92,29 @@ export function usePackRequest() {
     const timeoutId = setTimeout(controller.abort.bind(controller, 'timeout'), TIMEOUT_MS);
 
     // Obtain a 1-shot Turnstile token before issuing the pack request. If the
-    // widget fails (e.g. script blocked by an ad blocker, network error) we
-    // continue without a token — the server-side middleware decides the policy
-    // (it returns 403 if TURNSTILE_SECRET_KEY is set, or skips verification
-    // otherwise so dev/preview environments stay functional).
+    // widget fails (e.g. script blocked by an ad blocker, network error) the
+    // policy is environment-specific:
+    // - In production: surface a user-facing error and skip the request.
+    //   The server-side middleware would 403 anyway, so calling /api/pack
+    //   without a token only wastes a server round-trip.
+    // - In dev/preview: continue without a token. The server skips
+    //   verification when TURNSTILE_SECRET_KEY is unset, so contributors
+    //   without a Cloudflare account can still exercise the pack flow.
     let turnstileToken: string | undefined;
     try {
       turnstileToken = await turnstile.getToken();
     } catch (turnstileError) {
       console.warn('Turnstile token acquisition failed:', turnstileError);
+      if (import.meta.env.PROD) {
+        clearTimeout(timeoutId);
+        if (requestController === controller) {
+          loading.value = false;
+          requestController = null;
+        }
+        error.value = 'Verification failed. Please reload the page and try again.';
+        errorType.value = 'error';
+        return;
+      }
     }
 
     try {
@@ -130,8 +144,15 @@ export function usePackRequest() {
       );
     } finally {
       clearTimeout(timeoutId);
-      loading.value = false;
-      requestController = null;
+      // Only reset shared state if no newer submitRequest() has taken over the
+      // slot. Without this guard, a slow finally from a cancelled (or
+      // superseded) request would clobber a fresh in-flight request: setting
+      // loading=false hides the spinner, and nulling requestController breaks
+      // a subsequent cancelRequest() call.
+      if (requestController === controller) {
+        loading.value = false;
+        requestController = null;
+      }
     }
   }
 

--- a/website/client/composables/usePackRequest.ts
+++ b/website/client/composables/usePackRequest.ts
@@ -70,6 +70,13 @@ export function usePackRequest() {
       requestController.abort();
     }
     requestController = new AbortController();
+    // Capture the controller in a local const before any await. cancelRequest()
+    // can null out the shared `requestController` while we're awaiting
+    // turnstile.getToken(); reading `requestController.signal` after that
+    // would throw TypeError. The local reference still points to the original
+    // (already-aborted) controller, so the downstream signal check in
+    // handlePackRequest still works correctly.
+    const controller = requestController;
 
     loading.value = true;
     error.value = null;
@@ -82,7 +89,7 @@ export function usePackRequest() {
 
     // Set up automatic timeout
     // Use .bind() to avoid capturing the surrounding scope in the closure
-    const timeoutId = setTimeout(requestController.abort.bind(requestController, 'timeout'), TIMEOUT_MS);
+    const timeoutId = setTimeout(controller.abort.bind(controller, 'timeout'), TIMEOUT_MS);
 
     // Obtain a 1-shot Turnstile token before issuing the pack request. If the
     // widget fails (e.g. script blocked by an ad blocker, network error) we
@@ -116,7 +123,7 @@ export function usePackRequest() {
             progressStage.value = stage;
             progressMessage.value = message ?? null;
           },
-          signal: requestController.signal,
+          signal: controller.signal,
           file: mode.value === 'file' || mode.value === 'folder' ? uploadedFile.value || undefined : undefined,
           turnstileToken,
         },

--- a/website/client/composables/usePackRequest.ts
+++ b/website/client/composables/usePackRequest.ts
@@ -102,16 +102,44 @@ export function usePackRequest() {
     //   without a Cloudflare account can still exercise the pack flow.
     let turnstileToken: string | undefined;
     try {
-      turnstileToken = await turnstile.getToken();
+      // Pass the controller signal so cancelling the pack request also
+      // aborts an in-flight Turnstile challenge — otherwise a hung widget
+      // would delay the cancel response by up to 15s.
+      turnstileToken = await turnstile.getToken(controller.signal);
     } catch (turnstileError) {
       console.warn('Turnstile token acquisition failed:', turnstileError);
+      if (controller.signal.aborted) {
+        // The user (or the 30s timeout) cancelled while the challenge was
+        // in flight. Mirror handlePackRequest's onAbort messaging since we
+        // short-circuit before calling it.
+        clearTimeout(timeoutId);
+        if (requestController === controller) {
+          loading.value = false;
+          requestController = null;
+        }
+        if (controller.signal.reason === 'timeout') {
+          error.value =
+            'Request timed out.\nPlease consider using Include Patterns or Ignore Patterns to reduce the scope.';
+        } else {
+          error.value = 'Request was cancelled.';
+        }
+        errorType.value = 'warning';
+        return;
+      }
       if (import.meta.env.PROD) {
         clearTimeout(timeoutId);
         if (requestController === controller) {
           loading.value = false;
           requestController = null;
         }
-        error.value = 'Verification failed. Please reload the page and try again.';
+        // Distinguish "Turnstile script blocked" (likely an extension) from
+        // generic verification failure so the user has a path to recovery
+        // instead of just being told "try again".
+        const msg = turnstileError instanceof Error ? turnstileError.message : '';
+        const isScriptIssue = /script|load|missing/i.test(msg);
+        error.value = isScriptIssue
+          ? 'Bot protection failed to load. Please disable ad blockers or privacy extensions blocking challenges.cloudflare.com and reload.'
+          : 'Verification failed. Please reload the page and try again.';
         errorType.value = 'error';
         return;
       }

--- a/website/client/composables/usePackRequest.ts
+++ b/website/client/composables/usePackRequest.ts
@@ -230,6 +230,13 @@ export function usePackRequest() {
   function cancelRequest() {
     if (requestController) {
       requestController.abort('cancel');
+      // The downstream onAbort callback would normally surface the
+      // "Request was cancelled" warning, but since we're about to null
+      // requestController the isCurrent() guard inside onAbort treats it
+      // as stale and skips the message. Set it here directly so the user
+      // gets immediate feedback.
+      error.value = 'Request was cancelled.';
+      errorType.value = 'warning';
       requestController = null;
     }
     loading.value = false;

--- a/website/client/composables/usePackRequest.ts
+++ b/website/client/composables/usePackRequest.ts
@@ -145,7 +145,7 @@ export function usePackRequest() {
           const msg = turnstileError instanceof Error ? turnstileError.message : '';
           const isScriptIssue = /script|load|missing/i.test(msg);
           error.value = isScriptIssue
-            ? 'Bot protection failed to load. Please disable ad blockers or privacy extensions blocking challenges.cloudflare.com and reload.'
+            ? 'Bot protection failed to load. Please disable ad blockers or privacy extensions blocking challenges.cloudflare.com and reload, or use the CLI: npx repomix --remote owner/repo.'
             : 'Verification failed. Please reload the page and try again.';
           errorType.value = 'error';
         }

--- a/website/client/composables/usePackRequest.ts
+++ b/website/client/composables/usePackRequest.ts
@@ -4,6 +4,7 @@ import { handlePackRequest } from '../components/utils/requestHandlers';
 import { isValidRemoteValue } from '../components/utils/validation';
 import { parseUrlParameters } from '../utils/urlParams';
 import { usePackOptions } from './usePackOptions';
+import { useTurnstile } from './useTurnstile';
 
 export type InputMode = 'url' | 'file' | 'folder';
 
@@ -11,6 +12,8 @@ export function usePackRequest() {
   const packOptionsComposable = usePackOptions();
   const { packOptions, getPackRequestOptions, resetOptions, applyUrlParameters, DEFAULT_PACK_OPTIONS } =
     packOptionsComposable;
+
+  const turnstile = useTurnstile();
 
   // Input states
   const inputUrl = ref('');
@@ -81,6 +84,18 @@ export function usePackRequest() {
     // Use .bind() to avoid capturing the surrounding scope in the closure
     const timeoutId = setTimeout(requestController.abort.bind(requestController, 'timeout'), TIMEOUT_MS);
 
+    // Obtain a 1-shot Turnstile token before issuing the pack request. If the
+    // widget fails (e.g. script blocked by an ad blocker, network error) we
+    // continue without a token — the server-side middleware decides the policy
+    // (it returns 403 if TURNSTILE_SECRET_KEY is set, or skips verification
+    // otherwise so dev/preview environments stay functional).
+    let turnstileToken: string | undefined;
+    try {
+      turnstileToken = await turnstile.getToken();
+    } catch (turnstileError) {
+      console.warn('Turnstile token acquisition failed:', turnstileError);
+    }
+
     try {
       await handlePackRequest(
         mode.value === 'url' ? inputUrl.value : '',
@@ -103,6 +118,7 @@ export function usePackRequest() {
           },
           signal: requestController.signal,
           file: mode.value === 'file' || mode.value === 'folder' ? uploadedFile.value || undefined : undefined,
+          turnstileToken,
         },
       );
     } finally {
@@ -196,6 +212,9 @@ export function usePackRequest() {
     submitRequest,
     repackWithSelectedFiles,
     cancelRequest,
+
+    // Turnstile widget container (Vue ref callback consumer)
+    setTurnstileContainer: turnstile.setContainer,
 
     // Pack option actions
     resetOptions,

--- a/website/client/composables/usePackRequest.ts
+++ b/website/client/composables/usePackRequest.ts
@@ -100,6 +100,14 @@ export function usePackRequest() {
     // - In dev/preview: continue without a token. The server skips
     //   verification when TURNSTILE_SECRET_KEY is unset, so contributors
     //   without a Cloudflare account can still exercise the pack flow.
+    // All UI mutations from this point forward are guarded by `isCurrent()`.
+    // Without the guard, a slow request whose user hit cancel-and-resubmit
+    // could clobber the new request's `loading` / `result` / `error` state
+    // mid-flight (e.g. an old onAbort firing "Request was cancelled" while a
+    // fresh pack is still loading). Anchoring to the local AbortController
+    // identity is the cleanest way to detect supersession.
+    const isCurrent = () => requestController === controller;
+
     let turnstileToken: string | undefined;
     try {
       // Pass the controller signal so cancelling the pack request also
@@ -113,34 +121,34 @@ export function usePackRequest() {
         // in flight. Mirror handlePackRequest's onAbort messaging since we
         // short-circuit before calling it.
         clearTimeout(timeoutId);
-        if (requestController === controller) {
+        if (isCurrent()) {
           loading.value = false;
           requestController = null;
+          if (controller.signal.reason === 'timeout') {
+            error.value =
+              'Request timed out.\nPlease consider using Include Patterns or Ignore Patterns to reduce the scope.';
+          } else {
+            error.value = 'Request was cancelled.';
+          }
+          errorType.value = 'warning';
         }
-        if (controller.signal.reason === 'timeout') {
-          error.value =
-            'Request timed out.\nPlease consider using Include Patterns or Ignore Patterns to reduce the scope.';
-        } else {
-          error.value = 'Request was cancelled.';
-        }
-        errorType.value = 'warning';
         return;
       }
       if (import.meta.env.PROD) {
         clearTimeout(timeoutId);
-        if (requestController === controller) {
+        if (isCurrent()) {
           loading.value = false;
           requestController = null;
+          // Distinguish "Turnstile script blocked" (likely an extension) from
+          // generic verification failure so the user has a path to recovery
+          // instead of just being told "try again".
+          const msg = turnstileError instanceof Error ? turnstileError.message : '';
+          const isScriptIssue = /script|load|missing/i.test(msg);
+          error.value = isScriptIssue
+            ? 'Bot protection failed to load. Please disable ad blockers or privacy extensions blocking challenges.cloudflare.com and reload.'
+            : 'Verification failed. Please reload the page and try again.';
+          errorType.value = 'error';
         }
-        // Distinguish "Turnstile script blocked" (likely an extension) from
-        // generic verification failure so the user has a path to recovery
-        // instead of just being told "try again".
-        const msg = turnstileError instanceof Error ? turnstileError.message : '';
-        const isScriptIssue = /script|load|missing/i.test(msg);
-        error.value = isScriptIssue
-          ? 'Bot protection failed to load. Please disable ad blockers or privacy extensions blocking challenges.cloudflare.com and reload.'
-          : 'Verification failed. Please reload the page and try again.';
-        errorType.value = 'error';
         return;
       }
     }
@@ -152,16 +160,20 @@ export function usePackRequest() {
         getPackRequestOptions.value,
         {
           onSuccess: (response) => {
+            if (!isCurrent()) return;
             result.value = response;
           },
           onError: (errorMessage) => {
+            if (!isCurrent()) return;
             error.value = errorMessage;
           },
           onAbort: (message) => {
+            if (!isCurrent()) return;
             error.value = message;
             errorType.value = 'warning';
           },
           onProgress: (stage, message) => {
+            if (!isCurrent()) return;
             progressStage.value = stage;
             progressMessage.value = message ?? null;
           },

--- a/website/client/composables/useTurnstile.ts
+++ b/website/client/composables/useTurnstile.ts
@@ -81,6 +81,11 @@ function loadTurnstileScript(): Promise<TurnstileGlobal> {
     }
 
     window[READY_CALLBACK] = () => {
+      // Drop the global once it has fired. Keeps the success path symmetric
+      // with the retry path (which also deletes via resetForRetry) and avoids
+      // leaving a stale function on `window` that could be invoked again if
+      // the script tag is re-injected by some other code on the page.
+      delete window[READY_CALLBACK];
       if (window.turnstile) {
         resolve(window.turnstile);
       } else {
@@ -126,17 +131,17 @@ export function useTurnstile() {
   //    has fired.
   let currentGen = 0;
 
-  const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY ?? FALLBACK_TEST_SITE_KEY;
+  // Production builds must inject a real site key. A console.error is too
+  // easy to miss during smoke tests, so throw at first useTurnstile() call —
+  // the form fails to initialise loudly and the misconfig is unmissable.
+  // Test/dev builds fall through to the always-passes test sitekey so
+  // contributors without a Cloudflare account can still exercise the flow.
   if (import.meta.env.PROD && !import.meta.env.VITE_TURNSTILE_SITE_KEY) {
-    // Production builds must inject a real site key. Falling through to the
-    // test key (always-passes) silently neutralises Turnstile if the server
-    // also uses a test secret, or causes universal 403s if it uses a real
-    // secret. A loud console.error makes the misconfiguration obvious during
-    // smoke tests.
-    console.error(
-      'VITE_TURNSTILE_SITE_KEY is not set; falling back to the Cloudflare test site key. Turnstile will not protect /api/pack.',
+    throw new Error(
+      'VITE_TURNSTILE_SITE_KEY is not set in this production build. Configure the env var in Cloudflare Pages and redeploy.',
     );
   }
+  const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY ?? FALLBACK_TEST_SITE_KEY;
 
   async function ensureWidget(el: HTMLElement): Promise<TurnstileGlobal> {
     const turnstile = await loadTurnstileScript();
@@ -188,13 +193,30 @@ export function useTurnstile() {
   // already aborted.
   async function getToken(signal?: AbortSignal): Promise<string> {
     error.value = null;
-    if (signal?.aborted) {
-      throw new Error('Turnstile challenge aborted');
-    }
+    const checkAborted = () => {
+      if (signal?.aborted) throw new Error('Turnstile challenge aborted');
+    };
+    checkAborted();
     if (!containerEl.value) {
       throw new Error('Turnstile container element not registered');
     }
-    const turnstile = await ensureWidget(containerEl.value);
+    // Race the script-load step against the caller's abort signal so a
+    // user-initiated cancel during a slow script load (CDN stall, ad
+    // blocker, network blip) doesn't have to wait for the surrounding 30s
+    // pack timeout. The signal is also re-checked before listener setup
+    // below to cover the race where the abort fired during the await.
+    const widgetPromise = ensureWidget(containerEl.value);
+    const turnstile = signal
+      ? await Promise.race([
+          widgetPromise,
+          new Promise<never>((_, reject) => {
+            const onPreAbort = () => reject(new Error('Turnstile challenge aborted'));
+            if (signal.aborted) onPreAbort();
+            else signal.addEventListener('abort', onPreAbort, { once: true });
+          }),
+        ])
+      : await widgetPromise;
+    checkAborted();
     if (!widgetId.value) {
       throw new Error('Turnstile widget failed to render');
     }

--- a/website/client/composables/useTurnstile.ts
+++ b/website/client/composables/useTurnstile.ts
@@ -131,16 +131,19 @@ export function useTurnstile() {
   //    has fired.
   let currentGen = 0;
 
-  // Production builds must inject a real site key. A console.error is too
-  // easy to miss during smoke tests, so throw at first useTurnstile() call —
-  // the form fails to initialise loudly and the misconfig is unmissable.
-  // Test/dev builds fall through to the always-passes test sitekey so
-  // contributors without a Cloudflare account can still exercise the flow.
-  if (import.meta.env.PROD && !import.meta.env.VITE_TURNSTILE_SITE_KEY) {
-    throw new Error(
-      'VITE_TURNSTILE_SITE_KEY is not set in this production build. Configure the env var in Cloudflare Pages and redeploy.',
-    );
-  }
+  // Site key resolution. The production-only safety net lives in
+  // `.vitepress/config.ts` (it throws at build time when the Cloudflare Pages
+  // production deploy is missing VITE_TURNSTILE_SITE_KEY). We deliberately do
+  // *not* duplicate that check here with `import.meta.env.PROD`, because PROD
+  // is true for all `vitepress build` outputs — CF Pages preview deploys,
+  // local `docs:build`, and CI builds all set PROD=true and are documented to
+  // fall through to the test sitekey. Adding a runtime throw scoped to PROD
+  // would crash the form in those non-production environments.
+  //
+  // Defense in depth: the server-side middleware fail-closes when it has a
+  // real TURNSTILE_SECRET_KEY but receives a token issued by the test
+  // sitekey (action/hostname mismatch), so an actual production deploy that
+  // somehow shipped the test sitekey would still 403 every pack.
   const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY ?? FALLBACK_TEST_SITE_KEY;
 
   async function ensureWidget(el: HTMLElement): Promise<TurnstileGlobal> {

--- a/website/client/composables/useTurnstile.ts
+++ b/website/client/composables/useTurnstile.ts
@@ -1,8 +1,13 @@
 import { onBeforeUnmount, ref } from 'vue';
+import { loadTurnstileScript, type TurnstileGlobal } from './useTurnstileScript';
 
 // Cloudflare Turnstile integration. Used by usePackRequest to obtain a 1-shot
 // verification token that the server-side turnstileMiddleware verifies before
 // running /api/pack.
+//
+// The script-loading mechanics (script tag injection, READY_CALLBACK,
+// retry-on-failure) live in `useTurnstileScript.ts` so this file stays
+// focused on widget lifecycle / token requests / abort propagation.
 //
 // Site key resolution:
 // - Build-time env var `VITE_TURNSTILE_SITE_KEY` overrides the default
@@ -14,103 +19,11 @@ import { onBeforeUnmount, ref } from 'vue';
 //   server, or set both to real values together.
 const FALLBACK_TEST_SITE_KEY = '1x00000000000000000000AA';
 
-const SCRIPT_SRC =
-  'https://challenges.cloudflare.com/turnstile/v0/api.js?onload=__repomixTurnstileOnload&render=explicit';
-const SCRIPT_ID = 'repomix-turnstile-script';
-const READY_CALLBACK = '__repomixTurnstileOnload';
 // Upper bound on how long getToken() will wait for a callback. Cloudflare's
 // `timeout-callback` only fires for interactive challenges, so an invisible
 // widget that hangs (CDN stall, iframe never resolves) would otherwise leave
 // the caller's promise pending forever and freeze the loading spinner.
 const GET_TOKEN_TIMEOUT_MS = 15_000;
-
-interface TurnstileGlobal {
-  render: (el: HTMLElement, options: TurnstileRenderOptions) => string;
-  execute: (widgetId: string) => void;
-  reset: (widgetId: string) => void;
-  remove: (widgetId: string) => void;
-  getResponse: (widgetId: string) => string | undefined;
-}
-
-interface TurnstileRenderOptions {
-  sitekey: string;
-  size?: 'normal' | 'compact' | 'invisible';
-  // `action` is bound into the issued token and verified server-side, so a
-  // token minted for /api/pack can't be replayed at a future endpoint that
-  // expects a different action.
-  action?: string;
-  callback?: (token: string) => void;
-  'error-callback'?: (errorCode: string) => void;
-  'expired-callback'?: () => void;
-  'timeout-callback'?: () => void;
-}
-
-declare global {
-  interface Window {
-    turnstile?: TurnstileGlobal;
-    __repomixTurnstileOnload?: () => void;
-  }
-}
-
-let scriptPromise: Promise<TurnstileGlobal> | null = null;
-
-// Load the Turnstile script exactly once per page. Multiple components can
-// share the same script tag and the same `window.turnstile` instance.
-function loadTurnstileScript(): Promise<TurnstileGlobal> {
-  if (scriptPromise) return scriptPromise;
-
-  // Reset state on rejection so a transient CDN failure (ad blocker, network
-  // blip) doesn't permanently lock the page out of Turnstile. Without this,
-  // the rejected promise would be cached forever and every subsequent
-  // getToken() call would inherit the same stale rejection.
-  //
-  // Belt-and-suspenders: also drop the global onload callback so a late-
-  // arriving script load (e.g. extension interference resolving after
-  // onerror) can't reach into a stale closure and resolve a long-gone
-  // promise.
-  const resetForRetry = () => {
-    scriptPromise = null;
-    document.getElementById(SCRIPT_ID)?.remove();
-    delete window[READY_CALLBACK];
-  };
-
-  scriptPromise = new Promise<TurnstileGlobal>((resolve, reject) => {
-    if (window.turnstile) {
-      resolve(window.turnstile);
-      return;
-    }
-
-    window[READY_CALLBACK] = () => {
-      // Drop the global once it has fired. Keeps the success path symmetric
-      // with the retry path (which also deletes via resetForRetry) and avoids
-      // leaving a stale function on `window` that could be invoked again if
-      // the script tag is re-injected by some other code on the page.
-      delete window[READY_CALLBACK];
-      if (window.turnstile) {
-        resolve(window.turnstile);
-      } else {
-        resetForRetry();
-        reject(new Error('Turnstile script loaded but window.turnstile is missing'));
-      }
-    };
-
-    let script = document.getElementById(SCRIPT_ID) as HTMLScriptElement | null;
-    if (!script) {
-      script = document.createElement('script');
-      script.id = SCRIPT_ID;
-      script.src = SCRIPT_SRC;
-      script.async = true;
-      script.defer = true;
-      script.onerror = () => {
-        resetForRetry();
-        reject(new Error('Failed to load Turnstile script'));
-      };
-      document.head.appendChild(script);
-    }
-  });
-
-  return scriptPromise;
-}
 
 export function useTurnstile() {
   const widgetId = ref<string | null>(null);

--- a/website/client/composables/useTurnstile.ts
+++ b/website/client/composables/useTurnstile.ts
@@ -18,6 +18,11 @@ const SCRIPT_SRC =
   'https://challenges.cloudflare.com/turnstile/v0/api.js?onload=__repomixTurnstileOnload&render=explicit';
 const SCRIPT_ID = 'repomix-turnstile-script';
 const READY_CALLBACK = '__repomixTurnstileOnload';
+// Upper bound on how long getToken() will wait for a callback. Cloudflare's
+// `timeout-callback` only fires for interactive challenges, so an invisible
+// widget that hangs (CDN stall, iframe never resolves) would otherwise leave
+// the caller's promise pending forever and freeze the loading spinner.
+const GET_TOKEN_TIMEOUT_MS = 15_000;
 
 interface TurnstileGlobal {
   render: (el: HTMLElement, options: TurnstileRenderOptions) => string;
@@ -50,6 +55,15 @@ let scriptPromise: Promise<TurnstileGlobal> | null = null;
 function loadTurnstileScript(): Promise<TurnstileGlobal> {
   if (scriptPromise) return scriptPromise;
 
+  // Reset state on rejection so a transient CDN failure (ad blocker, network
+  // blip) doesn't permanently lock the page out of Turnstile. Without this,
+  // the rejected promise would be cached forever and every subsequent
+  // getToken() call would inherit the same stale rejection.
+  const resetForRetry = () => {
+    scriptPromise = null;
+    document.getElementById(SCRIPT_ID)?.remove();
+  };
+
   scriptPromise = new Promise<TurnstileGlobal>((resolve, reject) => {
     if (window.turnstile) {
       resolve(window.turnstile);
@@ -60,6 +74,7 @@ function loadTurnstileScript(): Promise<TurnstileGlobal> {
       if (window.turnstile) {
         resolve(window.turnstile);
       } else {
+        resetForRetry();
         reject(new Error('Turnstile script loaded but window.turnstile is missing'));
       }
     };
@@ -71,7 +86,10 @@ function loadTurnstileScript(): Promise<TurnstileGlobal> {
       script.src = SCRIPT_SRC;
       script.async = true;
       script.defer = true;
-      script.onerror = () => reject(new Error('Failed to load Turnstile script'));
+      script.onerror = () => {
+        resetForRetry();
+        reject(new Error('Failed to load Turnstile script'));
+      };
       document.head.appendChild(script);
     }
   });
@@ -142,7 +160,7 @@ export function useTurnstile() {
       throw new Error('Turnstile widget failed to render');
     }
 
-    return new Promise<string>((resolve, reject) => {
+    const tokenPromise = new Promise<string>((resolve, reject) => {
       pendingResolve = resolve;
       pendingReject = reject;
       // The widget retains its previous token until reset(); explicit reset
@@ -150,6 +168,16 @@ export function useTurnstile() {
       if (widgetId.value) turnstile.reset(widgetId.value);
       if (widgetId.value) turnstile.execute(widgetId.value);
     });
+    // Bounded race against a hung widget. Clearing the pending handlers on
+    // timeout prevents a stale token from later resolving a long-gone caller.
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => {
+        pendingResolve = null;
+        pendingReject = null;
+        reject(new Error('Turnstile challenge timed out'));
+      }, GET_TOKEN_TIMEOUT_MS);
+    });
+    return Promise.race([tokenPromise, timeoutPromise]);
   }
 
   function setContainer(el: HTMLElement | null) {
@@ -157,6 +185,14 @@ export function useTurnstile() {
   }
 
   onBeforeUnmount(() => {
+    // Reject any in-flight getToken() promise so the awaiting caller doesn't
+    // hang forever after the form unmounts (e.g. user navigates away mid-
+    // challenge).
+    if (pendingReject) {
+      pendingReject(new Error('Turnstile widget unmounted'));
+      pendingResolve = null;
+      pendingReject = null;
+    }
     if (widgetId.value && window.turnstile) {
       window.turnstile.remove(widgetId.value);
       widgetId.value = null;

--- a/website/client/composables/useTurnstile.ts
+++ b/website/client/composables/useTurnstile.ts
@@ -63,9 +63,15 @@ function loadTurnstileScript(): Promise<TurnstileGlobal> {
   // blip) doesn't permanently lock the page out of Turnstile. Without this,
   // the rejected promise would be cached forever and every subsequent
   // getToken() call would inherit the same stale rejection.
+  //
+  // Belt-and-suspenders: also drop the global onload callback so a late-
+  // arriving script load (e.g. extension interference resolving after
+  // onerror) can't reach into a stale closure and resolve a long-gone
+  // promise.
   const resetForRetry = () => {
     scriptPromise = null;
     document.getElementById(SCRIPT_ID)?.remove();
+    delete window[READY_CALLBACK];
   };
 
   scriptPromise = new Promise<TurnstileGlobal>((resolve, reject) => {
@@ -174,8 +180,17 @@ export function useTurnstile() {
 
   // Ask the (invisible) widget for a fresh verification token. Each call
   // resets the widget first because Turnstile tokens are 1-shot.
-  async function getToken(): Promise<string> {
+  //
+  // The optional `signal` lets the caller (usePackRequest's submit flow)
+  // abort the challenge mid-flight when the user cancels — without it, a
+  // hung Turnstile iframe would block the cancel response for up to
+  // GET_TOKEN_TIMEOUT_MS even though the surrounding pack request was
+  // already aborted.
+  async function getToken(signal?: AbortSignal): Promise<string> {
     error.value = null;
+    if (signal?.aborted) {
+      throw new Error('Turnstile challenge aborted');
+    }
     if (!containerEl.value) {
       throw new Error('Turnstile container element not registered');
     }
@@ -194,6 +209,7 @@ export function useTurnstile() {
 
     const myGen = ++currentGen;
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let onAbort: (() => void) | undefined;
 
     const tokenPromise = new Promise<string>((resolve, reject) => {
       // Wrap in gen-checked closures so a delayed widget callback can't
@@ -202,6 +218,7 @@ export function useTurnstile() {
       pendingResolve = (token) => {
         if (myGen !== currentGen) return;
         if (timeoutId !== undefined) clearTimeout(timeoutId);
+        if (onAbort && signal) signal.removeEventListener('abort', onAbort);
         pendingResolve = null;
         pendingReject = null;
         resolve(token);
@@ -209,6 +226,7 @@ export function useTurnstile() {
       pendingReject = (err) => {
         if (myGen !== currentGen) return;
         if (timeoutId !== undefined) clearTimeout(timeoutId);
+        if (onAbort && signal) signal.removeEventListener('abort', onAbort);
         pendingResolve = null;
         pendingReject = null;
         reject(err);
@@ -218,12 +236,21 @@ export function useTurnstile() {
       if (widgetId.value) turnstile.reset(widgetId.value);
       if (widgetId.value) turnstile.execute(widgetId.value);
     });
+
+    if (signal) {
+      onAbort = () => {
+        if (pendingReject) pendingReject(new Error('Turnstile challenge aborted'));
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+
     // Bounded race against a hung widget. The gen check ensures a stale timer
     // from a previous call (whose tokenPromise already resolved) cannot clear
     // the current request's handlers.
     const timeoutPromise = new Promise<never>((_, reject) => {
       timeoutId = setTimeout(() => {
         if (myGen !== currentGen) return;
+        if (onAbort && signal) signal.removeEventListener('abort', onAbort);
         pendingResolve = null;
         pendingReject = null;
         reject(new Error('Turnstile challenge timed out'));

--- a/website/client/composables/useTurnstile.ts
+++ b/website/client/composables/useTurnstile.ts
@@ -35,6 +35,10 @@ interface TurnstileGlobal {
 interface TurnstileRenderOptions {
   sitekey: string;
   size?: 'normal' | 'compact' | 'invisible';
+  // `action` is bound into the issued token and verified server-side, so a
+  // token minted for /api/pack can't be replayed at a future endpoint that
+  // expects a different action.
+  action?: string;
   callback?: (token: string) => void;
   'error-callback'?: (errorCode: string) => void;
   'expired-callback'?: () => void;
@@ -106,8 +110,27 @@ export function useTurnstile() {
   // on each `getToken()` call so back-to-back submits don't share state.
   let pendingResolve: ((token: string) => void) | null = null;
   let pendingReject: ((error: Error) => void) | null = null;
+  // Monotonic generation counter. Each getToken() call captures a local copy
+  // and the timeout/callback closures verify it before mutating shared state.
+  // This neutralises three otherwise-leaky scenarios:
+  //  - a stale timeout from a previous call clearing the next call's pending
+  //    handlers,
+  //  - a delayed widget callback resolving the next call with a stale token,
+  //  - a back-to-back submit reusing handlers before the previous timeout
+  //    has fired.
+  let currentGen = 0;
 
   const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY ?? FALLBACK_TEST_SITE_KEY;
+  if (import.meta.env.PROD && !import.meta.env.VITE_TURNSTILE_SITE_KEY) {
+    // Production builds must inject a real site key. Falling through to the
+    // test key (always-passes) silently neutralises Turnstile if the server
+    // also uses a test secret, or causes universal 403s if it uses a real
+    // secret. A loud console.error makes the misconfiguration obvious during
+    // smoke tests.
+    console.error(
+      'VITE_TURNSTILE_SITE_KEY is not set; falling back to the Cloudflare test site key. Turnstile will not protect /api/pack.',
+    );
+  }
 
   async function ensureWidget(el: HTMLElement): Promise<TurnstileGlobal> {
     const turnstile = await loadTurnstileScript();
@@ -115,6 +138,7 @@ export function useTurnstile() {
       widgetId.value = turnstile.render(el, {
         sitekey: siteKey,
         size: 'invisible',
+        action: 'pack',
         callback: (token: string) => {
           if (pendingResolve) {
             pendingResolve(token);
@@ -160,18 +184,46 @@ export function useTurnstile() {
       throw new Error('Turnstile widget failed to render');
     }
 
+    // Supersede any in-flight request: reject the previous caller before we
+    // overwrite pendingResolve/pendingReject below.
+    if (pendingReject) {
+      pendingReject(new Error('Superseded by new Turnstile request'));
+      pendingResolve = null;
+      pendingReject = null;
+    }
+
+    const myGen = ++currentGen;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
     const tokenPromise = new Promise<string>((resolve, reject) => {
-      pendingResolve = resolve;
-      pendingReject = reject;
+      // Wrap in gen-checked closures so a delayed widget callback can't
+      // resolve a later request with a stale token, and the timeout below
+      // clears handlers only if no fresher request has taken over.
+      pendingResolve = (token) => {
+        if (myGen !== currentGen) return;
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
+        pendingResolve = null;
+        pendingReject = null;
+        resolve(token);
+      };
+      pendingReject = (err) => {
+        if (myGen !== currentGen) return;
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
+        pendingResolve = null;
+        pendingReject = null;
+        reject(err);
+      };
       // The widget retains its previous token until reset(); explicit reset
       // forces a new challenge on every getToken() call.
       if (widgetId.value) turnstile.reset(widgetId.value);
       if (widgetId.value) turnstile.execute(widgetId.value);
     });
-    // Bounded race against a hung widget. Clearing the pending handlers on
-    // timeout prevents a stale token from later resolving a long-gone caller.
+    // Bounded race against a hung widget. The gen check ensures a stale timer
+    // from a previous call (whose tokenPromise already resolved) cannot clear
+    // the current request's handlers.
     const timeoutPromise = new Promise<never>((_, reject) => {
-      setTimeout(() => {
+      timeoutId = setTimeout(() => {
+        if (myGen !== currentGen) return;
         pendingResolve = null;
         pendingReject = null;
         reject(new Error('Turnstile challenge timed out'));

--- a/website/client/composables/useTurnstile.ts
+++ b/website/client/composables/useTurnstile.ts
@@ -145,6 +145,13 @@ export function useTurnstile() {
 
   async function ensureWidget(el: HTMLElement): Promise<TurnstileGlobal> {
     const turnstile = await loadTurnstileScript();
+    // The component may have unmounted (or the user may have switched away
+    // from the form) while the script was loading. Detached DOM elements
+    // accept render() but the corresponding remove() in onBeforeUnmount has
+    // already run, so the widget would leak. Bail out instead.
+    if (containerEl.value !== el) {
+      throw new Error('Turnstile container detached during script load');
+    }
     if (!widgetId.value) {
       widgetId.value = turnstile.render(el, {
         sitekey: siteKey,

--- a/website/client/composables/useTurnstile.ts
+++ b/website/client/composables/useTurnstile.ts
@@ -1,0 +1,171 @@
+import { onBeforeUnmount, ref } from 'vue';
+
+// Cloudflare Turnstile integration. Used by usePackRequest to obtain a 1-shot
+// verification token that the server-side turnstileMiddleware verifies before
+// running /api/pack.
+//
+// Site key resolution:
+// - Build-time env var `VITE_TURNSTILE_SITE_KEY` overrides the default
+//   (used for production / staging deploys via VitePress build env).
+// - The fall-through is Cloudflare's "always-passes" test key
+//   (`1x00000000000000000000AA`) so local dev and contributor builds work
+//   without any setup. Using the test key in production would silently let all
+//   tokens through — pair the deploy with the matching test secret on the
+//   server, or set both to real values together.
+const FALLBACK_TEST_SITE_KEY = '1x00000000000000000000AA';
+
+const SCRIPT_SRC =
+  'https://challenges.cloudflare.com/turnstile/v0/api.js?onload=__repomixTurnstileOnload&render=explicit';
+const SCRIPT_ID = 'repomix-turnstile-script';
+const READY_CALLBACK = '__repomixTurnstileOnload';
+
+interface TurnstileGlobal {
+  render: (el: HTMLElement, options: TurnstileRenderOptions) => string;
+  execute: (widgetId: string) => void;
+  reset: (widgetId: string) => void;
+  remove: (widgetId: string) => void;
+  getResponse: (widgetId: string) => string | undefined;
+}
+
+interface TurnstileRenderOptions {
+  sitekey: string;
+  size?: 'normal' | 'compact' | 'invisible';
+  callback?: (token: string) => void;
+  'error-callback'?: (errorCode: string) => void;
+  'expired-callback'?: () => void;
+  'timeout-callback'?: () => void;
+}
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileGlobal;
+    __repomixTurnstileOnload?: () => void;
+  }
+}
+
+let scriptPromise: Promise<TurnstileGlobal> | null = null;
+
+// Load the Turnstile script exactly once per page. Multiple components can
+// share the same script tag and the same `window.turnstile` instance.
+function loadTurnstileScript(): Promise<TurnstileGlobal> {
+  if (scriptPromise) return scriptPromise;
+
+  scriptPromise = new Promise<TurnstileGlobal>((resolve, reject) => {
+    if (window.turnstile) {
+      resolve(window.turnstile);
+      return;
+    }
+
+    window[READY_CALLBACK] = () => {
+      if (window.turnstile) {
+        resolve(window.turnstile);
+      } else {
+        reject(new Error('Turnstile script loaded but window.turnstile is missing'));
+      }
+    };
+
+    let script = document.getElementById(SCRIPT_ID) as HTMLScriptElement | null;
+    if (!script) {
+      script = document.createElement('script');
+      script.id = SCRIPT_ID;
+      script.src = SCRIPT_SRC;
+      script.async = true;
+      script.defer = true;
+      script.onerror = () => reject(new Error('Failed to load Turnstile script'));
+      document.head.appendChild(script);
+    }
+  });
+
+  return scriptPromise;
+}
+
+export function useTurnstile() {
+  const widgetId = ref<string | null>(null);
+  const containerEl = ref<HTMLElement | null>(null);
+  const error = ref<string | null>(null);
+
+  // Resolved when the next render of the widget produces a token. Reassigned
+  // on each `getToken()` call so back-to-back submits don't share state.
+  let pendingResolve: ((token: string) => void) | null = null;
+  let pendingReject: ((error: Error) => void) | null = null;
+
+  const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY ?? FALLBACK_TEST_SITE_KEY;
+
+  async function ensureWidget(el: HTMLElement): Promise<TurnstileGlobal> {
+    const turnstile = await loadTurnstileScript();
+    if (!widgetId.value) {
+      widgetId.value = turnstile.render(el, {
+        sitekey: siteKey,
+        size: 'invisible',
+        callback: (token: string) => {
+          if (pendingResolve) {
+            pendingResolve(token);
+            pendingResolve = null;
+            pendingReject = null;
+          }
+        },
+        'error-callback': (errorCode: string) => {
+          const message = `Turnstile error: ${errorCode}`;
+          error.value = message;
+          if (pendingReject) {
+            pendingReject(new Error(message));
+            pendingResolve = null;
+            pendingReject = null;
+          }
+        },
+        'expired-callback': () => {
+          // Token expired before being used. The widget will issue a fresh
+          // one on the next execute() call.
+          if (widgetId.value) turnstile.reset(widgetId.value);
+        },
+        'timeout-callback': () => {
+          if (pendingReject) {
+            pendingReject(new Error('Turnstile challenge timed out'));
+            pendingResolve = null;
+            pendingReject = null;
+          }
+        },
+      });
+    }
+    return turnstile;
+  }
+
+  // Ask the (invisible) widget for a fresh verification token. Each call
+  // resets the widget first because Turnstile tokens are 1-shot.
+  async function getToken(): Promise<string> {
+    error.value = null;
+    if (!containerEl.value) {
+      throw new Error('Turnstile container element not registered');
+    }
+    const turnstile = await ensureWidget(containerEl.value);
+    if (!widgetId.value) {
+      throw new Error('Turnstile widget failed to render');
+    }
+
+    return new Promise<string>((resolve, reject) => {
+      pendingResolve = resolve;
+      pendingReject = reject;
+      // The widget retains its previous token until reset(); explicit reset
+      // forces a new challenge on every getToken() call.
+      if (widgetId.value) turnstile.reset(widgetId.value);
+      if (widgetId.value) turnstile.execute(widgetId.value);
+    });
+  }
+
+  function setContainer(el: HTMLElement | null) {
+    containerEl.value = el;
+  }
+
+  onBeforeUnmount(() => {
+    if (widgetId.value && window.turnstile) {
+      window.turnstile.remove(widgetId.value);
+      widgetId.value = null;
+    }
+  });
+
+  return {
+    setContainer,
+    getToken,
+    error,
+  };
+}

--- a/website/client/composables/useTurnstileScript.ts
+++ b/website/client/composables/useTurnstileScript.ts
@@ -1,0 +1,98 @@
+// Cloudflare Turnstile script loader. Split from useTurnstile.ts to keep
+// each file under the 250-line guideline (CLAUDE.md). The composable
+// concerns itself with widget lifecycle, token requests, and abort
+// propagation; this module only ensures the global script tag exists and
+// resolves to `window.turnstile`.
+
+const SCRIPT_SRC =
+  'https://challenges.cloudflare.com/turnstile/v0/api.js?onload=__repomixTurnstileOnload&render=explicit';
+const SCRIPT_ID = 'repomix-turnstile-script';
+const READY_CALLBACK = '__repomixTurnstileOnload';
+
+export interface TurnstileGlobal {
+  render: (el: HTMLElement, options: TurnstileRenderOptions) => string;
+  execute: (widgetId: string) => void;
+  reset: (widgetId: string) => void;
+  remove: (widgetId: string) => void;
+  getResponse: (widgetId: string) => string | undefined;
+}
+
+export interface TurnstileRenderOptions {
+  sitekey: string;
+  size?: 'normal' | 'compact' | 'invisible';
+  // `action` is bound into the issued token and verified server-side, so a
+  // token minted for /api/pack can't be replayed at a future endpoint that
+  // expects a different action.
+  action?: string;
+  callback?: (token: string) => void;
+  'error-callback'?: (errorCode: string) => void;
+  'expired-callback'?: () => void;
+  'timeout-callback'?: () => void;
+}
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileGlobal;
+    __repomixTurnstileOnload?: () => void;
+  }
+}
+
+let scriptPromise: Promise<TurnstileGlobal> | null = null;
+
+// Load the Turnstile script exactly once per page. Multiple components can
+// share the same script tag and the same `window.turnstile` instance.
+export function loadTurnstileScript(): Promise<TurnstileGlobal> {
+  if (scriptPromise) return scriptPromise;
+
+  // Reset state on rejection so a transient CDN failure (ad blocker, network
+  // blip) doesn't permanently lock the page out of Turnstile. Without this,
+  // the rejected promise would be cached forever and every subsequent
+  // getToken() call would inherit the same stale rejection.
+  //
+  // Belt-and-suspenders: also drop the global onload callback so a late-
+  // arriving script load (e.g. extension interference resolving after
+  // onerror) can't reach into a stale closure and resolve a long-gone
+  // promise.
+  const resetForRetry = () => {
+    scriptPromise = null;
+    document.getElementById(SCRIPT_ID)?.remove();
+    delete window[READY_CALLBACK];
+  };
+
+  scriptPromise = new Promise<TurnstileGlobal>((resolve, reject) => {
+    if (window.turnstile) {
+      resolve(window.turnstile);
+      return;
+    }
+
+    window[READY_CALLBACK] = () => {
+      // Drop the global once it has fired. Keeps the success path symmetric
+      // with the retry path (which also deletes via resetForRetry) and avoids
+      // leaving a stale function on `window` that could be invoked again if
+      // the script tag is re-injected by some other code on the page.
+      delete window[READY_CALLBACK];
+      if (window.turnstile) {
+        resolve(window.turnstile);
+      } else {
+        resetForRetry();
+        reject(new Error('Turnstile script loaded but window.turnstile is missing'));
+      }
+    };
+
+    let script = document.getElementById(SCRIPT_ID) as HTMLScriptElement | null;
+    if (!script) {
+      script = document.createElement('script');
+      script.id = SCRIPT_ID;
+      script.src = SCRIPT_SRC;
+      script.async = true;
+      script.defer = true;
+      script.onerror = () => {
+        resetForRetry();
+        reject(new Error('Failed to load Turnstile script'));
+      };
+      document.head.appendChild(script);
+    }
+  });
+
+  return scriptPromise;
+}

--- a/website/server/cloudbuild.yaml
+++ b/website/server/cloudbuild.yaml
@@ -53,7 +53,7 @@ steps:
       - '--set-env-vars'
       - 'NODE_ENV=production'
       - '--set-secrets'
-      - 'UPSTASH_REDIS_REST_URL=upstash-redis-rest-url:latest,UPSTASH_REDIS_REST_TOKEN=upstash-redis-rest-token:latest,CLOUDFLARE_ORIGIN_SECRET=cloudflare-origin-secret:latest'
+      - 'UPSTASH_REDIS_REST_URL=upstash-redis-rest-url:latest,UPSTASH_REDIS_REST_TOKEN=upstash-redis-rest-token:latest,CLOUDFLARE_ORIGIN_SECRET=cloudflare-origin-secret:latest,TURNSTILE_SECRET_KEY=turnstile-secret-key:latest'
 
   # Tag the image as latest
   - name: 'gcr.io/cloud-builders/docker'

--- a/website/server/src/actions/packEventSchema.ts
+++ b/website/server/src/actions/packEventSchema.ts
@@ -8,12 +8,13 @@ import { MESSAGES } from './packRequestMessages.js';
 // `pack_requests` metric will silently mislabel rows.
 //
 // Named `pack_completed` as a lifecycle event — it covers all pack-request
-// terminal outcomes (success / validation_error / pack_error / rate_limited),
-// not just successful packs. The alternative of per-outcome event names would
-// require N metric filters instead of one filter + outcome label.
+// terminal outcomes (success / validation_error / pack_error / rate_limited /
+// turnstile_failed), not just successful packs. The alternative of per-outcome
+// event names would require N metric filters instead of one filter + outcome
+// label.
 export const PACK_EVENT = 'pack_completed';
 
-export type PackOutcome = 'success' | 'validation_error' | 'pack_error' | 'rate_limited';
+export type PackOutcome = 'success' | 'validation_error' | 'pack_error' | 'rate_limited' | 'turnstile_failed';
 
 // Extract a stable `repoHost` label for log-based metrics (e.g. 'github.com',
 // 'gitlab.com', 'upload'). Repomix accepts shorthand like 'owner/repo' which

--- a/website/server/src/actions/packRequestMessages.ts
+++ b/website/server/src/actions/packRequestMessages.ts
@@ -19,4 +19,5 @@ export const MESSAGES = {
   IGNORE_TOO_LONG: 'Ignore patterns too long',
   MISSING_INPUT: 'Either URL or file must be provided',
   BOTH_PROVIDED: 'Cannot provide both URL and file',
+  TURNSTILE_FAILED: 'Verification failed. Please try again.',
 } as const;

--- a/website/server/src/index.ts
+++ b/website/server/src/index.ts
@@ -10,6 +10,7 @@ import { cloudflareGuardMiddleware } from './middlewares/cloudflareGuard.js';
 import { cloudLoggerMiddleware } from './middlewares/cloudLogger.js';
 import { corsMiddleware } from './middlewares/cors.js';
 import { rateLimitMiddleware } from './middlewares/rateLimit.js';
+import { turnstileMiddleware } from './middlewares/turnstile.js';
 import { logInfo, logMemoryUsage } from './utils/logger.js';
 import { getProcessConcurrency } from './utils/processConcurrency.js';
 
@@ -61,8 +62,9 @@ if (!isWarmupMode()) {
   // Health check endpoint
   app.get('/health', (c) => c.text('OK'));
 
-  // Main packing endpoint
-  app.post('/api/pack', bodyLimitMiddleware, packAction);
+  // Main packing endpoint — Turnstile is scoped to /api/pack only so docs and
+  // health endpoints remain challenge-free for SEO/LLMO crawlers.
+  app.post('/api/pack', turnstileMiddleware(), bodyLimitMiddleware, packAction);
 
   // Start server
   const port = process.env.PORT ? Number.parseInt(process.env.PORT, 10) : 3000;

--- a/website/server/src/middlewares/cors.ts
+++ b/website/server/src/middlewares/cors.ts
@@ -15,7 +15,7 @@ export const corsMiddleware = cors({
     return null;
   },
   allowMethods: ['GET', 'POST', 'OPTIONS'],
-  allowHeaders: ['Content-Type'],
+  allowHeaders: ['Content-Type', 'X-Turnstile-Token'],
   maxAge: 86400,
   credentials: true,
 });

--- a/website/server/src/middlewares/turnstile.ts
+++ b/website/server/src/middlewares/turnstile.ts
@@ -1,0 +1,122 @@
+import type { Context, Next } from 'hono';
+import { PACK_EVENT, type PackOutcome } from '../actions/packEventSchema.js';
+import { MESSAGES } from '../actions/packRequestMessages.js';
+import { getClientInfo } from '../utils/clientInfo.js';
+import { createErrorResponse } from '../utils/http.js';
+import { buildCfLogField, logInfo, logWarning } from '../utils/logger.js';
+
+const SITEVERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+const TOKEN_HEADER = 'X-Turnstile-Token';
+// Cloudflare-recommended timeout: siteverify normally returns in <100ms; a
+// hung verify call must not stall the pack flow. Returning 403 on timeout is
+// safer than failing open per request.
+const SITEVERIFY_TIMEOUT_MS = 5_000;
+
+interface SiteverifyResponse {
+  success: boolean;
+  'error-codes'?: string[];
+  hostname?: string;
+  challenge_ts?: string;
+  action?: string;
+}
+
+interface TurnstileDeps {
+  fetch: typeof fetch;
+  getSecret: () => string | undefined;
+}
+
+const defaultDeps: TurnstileDeps = {
+  fetch: globalThis.fetch,
+  getSecret: () => process.env.TURNSTILE_SECRET_KEY,
+};
+
+// Verify Cloudflare Turnstile tokens before /api/pack runs the actual pack.
+// Tokens are 1-shot (5min validity) and must be re-issued by the client widget
+// per request — the middleware doesn't cache verifications.
+//
+// Behaviour:
+// - TURNSTILE_SECRET_KEY unset → fail-open (skip verification, log once at
+//   warn level). This keeps local dev / preview environments unblocked while
+//   still surfacing missing config in production logs.
+// - Token missing or empty → 403 with `outcome: turnstile_failed`.
+// - siteverify success: false → 403 with `outcome: turnstile_failed`.
+// - siteverify network failure → 403 with `outcome: turnstile_failed` (fail-
+//   closed; if Cloudflare can't verify, treat as untrusted).
+//
+// Placement: applied to /api/pack only — docs pages, health checks, and any
+// future public read-only endpoints stay challenge-free so SEO/LLMO crawlers
+// (Googlebot, GPTBot, etc.) are unaffected.
+export function turnstileMiddleware(deps: TurnstileDeps = defaultDeps) {
+  let secretMissingLogged = false;
+
+  return async function turnstileMiddleware(c: Context, next: Next) {
+    const secret = deps.getSecret();
+    if (!secret) {
+      if (!secretMissingLogged) {
+        secretMissingLogged = true;
+        logWarning('TURNSTILE_SECRET_KEY not set — Turnstile verification skipped');
+      }
+      await next();
+      return;
+    }
+
+    const requestId = c.get('requestId');
+    const clientInfo = getClientInfo(c);
+    const cf = buildCfLogField(clientInfo);
+    const token = c.req.header(TOKEN_HEADER);
+
+    if (!token) {
+      logInfo('Turnstile token missing', {
+        event: PACK_EVENT,
+        outcome: 'turnstile_failed' satisfies PackOutcome,
+        reason: 'missing_token',
+        requestId,
+        source: clientInfo.source,
+        ...(cf && { cf }),
+      });
+      return c.json(createErrorResponse(MESSAGES.TURNSTILE_FAILED, requestId), 403);
+    }
+
+    let verifyResult: SiteverifyResponse | undefined;
+    try {
+      const body = new URLSearchParams({
+        secret,
+        response: token,
+        remoteip: clientInfo.ip,
+      });
+      const res = await deps.fetch(SITEVERIFY_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body,
+        signal: AbortSignal.timeout(SITEVERIFY_TIMEOUT_MS),
+      });
+      verifyResult = (await res.json()) as SiteverifyResponse;
+    } catch (error) {
+      logWarning('Turnstile siteverify network failure', {
+        event: PACK_EVENT,
+        outcome: 'turnstile_failed' satisfies PackOutcome,
+        reason: 'siteverify_unavailable',
+        requestId,
+        source: clientInfo.source,
+        error: error instanceof Error ? error.message : String(error),
+        ...(cf && { cf }),
+      });
+      return c.json(createErrorResponse(MESSAGES.TURNSTILE_FAILED, requestId), 403);
+    }
+
+    if (!verifyResult?.success) {
+      logInfo('Turnstile verification rejected', {
+        event: PACK_EVENT,
+        outcome: 'turnstile_failed' satisfies PackOutcome,
+        reason: 'siteverify_rejected',
+        errorCodes: verifyResult?.['error-codes'],
+        requestId,
+        source: clientInfo.source,
+        ...(cf && { cf }),
+      });
+      return c.json(createErrorResponse(MESSAGES.TURNSTILE_FAILED, requestId), 403);
+    }
+
+    await next();
+  };
+}

--- a/website/server/src/middlewares/turnstile.ts
+++ b/website/server/src/middlewares/turnstile.ts
@@ -79,11 +79,14 @@ export function turnstileMiddleware(deps: TurnstileDeps = defaultDeps) {
 
     let verifyResult: SiteverifyResponse | undefined;
     try {
-      const body = new URLSearchParams({
-        secret,
-        response: token,
-        remoteip: clientInfo.ip,
-      });
+      // remoteip is optional in Cloudflare's siteverify API. clientInfo.ip
+      // falls back to '0.0.0.0' when no IP header was present — sending that
+      // sentinel doesn't help Cloudflare's risk scoring and can confuse their
+      // validation, so omit the field entirely in that case.
+      const body = new URLSearchParams({ secret, response: token });
+      if (clientInfo.ip && clientInfo.ip !== '0.0.0.0') {
+        body.set('remoteip', clientInfo.ip);
+      }
       const res = await deps.fetch(SITEVERIFY_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/website/server/src/middlewares/turnstile.ts
+++ b/website/server/src/middlewares/turnstile.ts
@@ -1,7 +1,7 @@
 import type { Context, Next } from 'hono';
 import { PACK_EVENT, type PackOutcome } from '../actions/packEventSchema.js';
 import { MESSAGES } from '../actions/packRequestMessages.js';
-import { getClientInfo } from '../utils/clientInfo.js';
+import { type ClientInfo, getClientInfo } from '../utils/clientInfo.js';
 import { createErrorResponse } from '../utils/http.js';
 import { buildCfLogField, logInfo, logWarning } from '../utils/logger.js';
 
@@ -16,8 +16,10 @@ const SITEVERIFY_TIMEOUT_MS = 5_000;
 const MAX_TOKEN_LENGTH = 2048;
 // Action claim the client widget binds when calling turnstile.render — the
 // server requires this exact value so a token issued for some other endpoint
-// (or a future widget) can't be replayed at /api/pack.
-const EXPECTED_ACTION = 'pack';
+// (or a future widget) can't be replayed at /api/pack. The matching client-
+// side string is in `useTurnstile.ts` (`data-action='pack'` on the widget);
+// see `tests/turnstile.test.ts` for the cross-stack contract assertion.
+export const EXPECTED_TURNSTILE_ACTION = 'pack';
 // Hostnames we expect tokens to be minted from. Must match the site
 // configured in the Cloudflare Turnstile dashboard. Tokens minted on other
 // hostnames (e.g. a leaked sitekey reused on attacker's domain) will be
@@ -57,9 +59,11 @@ const defaultDeps: TurnstileDeps = {
 //     contributors and preview environments unblocked.
 // - Token missing / empty / oversized → 403 with `outcome: turnstile_failed`.
 // - siteverify success: false → 403 with `outcome: turnstile_failed`.
-// - siteverify network failure → 403 with `outcome: turnstile_failed` (fail-
-//   closed; if Cloudflare can't verify, treat as untrusted).
-// - Action claim mismatch → 403 (token wasn't minted for /api/pack).
+// - siteverify network failure / non-JSON → 403 with `outcome:
+//   turnstile_failed` (fail-closed; if Cloudflare can't verify, treat as
+//   untrusted).
+// - Action / hostname claim mismatch → 403 (token wasn't minted for /api/pack
+//   or was minted on a different domain).
 //
 // Placement: applied to /api/pack only — docs pages, health checks, and any
 // future public read-only endpoints stay challenge-free so SEO/LLMO crawlers
@@ -72,18 +76,33 @@ export function turnstileMiddleware(deps: TurnstileDeps = defaultDeps) {
     const clientInfo = getClientInfo(c);
     const cf = buildCfLogField(clientInfo);
 
+    // Single failure-logging shape used by every reject branch — keeps the
+    // event/outcome/source/cf envelope consistent and makes it harder to
+    // forget a field when adding the next reason.
+    const rejectAndLog = (
+      reason: string,
+      logMessage: string,
+      level: 'info' | 'warn' = 'info',
+      extra?: Record<string, unknown>,
+    ) => {
+      const payload = {
+        event: PACK_EVENT,
+        outcome: 'turnstile_failed' satisfies PackOutcome,
+        reason,
+        requestId,
+        source: clientInfo.source,
+        ...(cf && { cf }),
+        ...extra,
+      };
+      if (level === 'warn') logWarning(logMessage, payload);
+      else logInfo(logMessage, payload);
+      return c.json(createErrorResponse(MESSAGES.TURNSTILE_FAILED, requestId), 403);
+    };
+
     const secret = deps.getSecret();
     if (!secret) {
       if (deps.isProduction()) {
-        logWarning('TURNSTILE_SECRET_KEY not set in production', {
-          event: PACK_EVENT,
-          outcome: 'turnstile_failed' satisfies PackOutcome,
-          reason: 'secret_missing',
-          requestId,
-          source: clientInfo.source,
-          ...(cf && { cf }),
-        });
-        return c.json(createErrorResponse(MESSAGES.TURNSTILE_FAILED, requestId), 403);
+        return rejectAndLog('secret_missing', 'TURNSTILE_SECRET_KEY not set in production', 'warn');
       }
       if (!secretMissingLogged) {
         secretMissingLogged = true;
@@ -93,77 +112,31 @@ export function turnstileMiddleware(deps: TurnstileDeps = defaultDeps) {
       return;
     }
 
-    const rawToken = c.req.header(TOKEN_HEADER);
-    const token = rawToken?.trim();
+    const token = c.req.header(TOKEN_HEADER)?.trim();
 
     if (!token) {
-      logInfo('Turnstile token missing', {
-        event: PACK_EVENT,
-        outcome: 'turnstile_failed' satisfies PackOutcome,
-        reason: 'missing_token',
-        requestId,
-        source: clientInfo.source,
-        ...(cf && { cf }),
-      });
-      return c.json(createErrorResponse(MESSAGES.TURNSTILE_FAILED, requestId), 403);
+      return rejectAndLog('missing_token', 'Turnstile token missing');
     }
 
     if (token.length > MAX_TOKEN_LENGTH) {
       // Defensive: oversized tokens are guaranteed-invalid per Cloudflare's
       // spec. Reject without spending a siteverify call.
-      logInfo('Turnstile token rejected: oversized', {
-        event: PACK_EVENT,
-        outcome: 'turnstile_failed' satisfies PackOutcome,
-        reason: 'token_too_long',
+      return rejectAndLog('token_too_long', 'Turnstile token rejected: oversized', 'info', {
         tokenLength: token.length,
-        requestId,
-        source: clientInfo.source,
-        ...(cf && { cf }),
       });
-      return c.json(createErrorResponse(MESSAGES.TURNSTILE_FAILED, requestId), 403);
     }
 
-    let verifyResult: SiteverifyResponse | undefined;
-    try {
-      // remoteip is optional in Cloudflare's siteverify API. clientInfo.ip
-      // falls back to '0.0.0.0' when no IP header was present — sending that
-      // sentinel doesn't help Cloudflare's risk scoring and can confuse their
-      // validation, so omit the field entirely in that case.
-      const body = new URLSearchParams({ secret, response: token });
-      if (clientInfo.ip && clientInfo.ip !== '0.0.0.0') {
-        body.set('remoteip', clientInfo.ip);
-      }
-      const res = await deps.fetch(SITEVERIFY_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body,
-        signal: AbortSignal.timeout(SITEVERIFY_TIMEOUT_MS),
+    const verifyResult = await runSiteverify(deps, secret, token, clientInfo);
+    if (verifyResult instanceof Error) {
+      return rejectAndLog('siteverify_unavailable', 'Turnstile siteverify network failure', 'warn', {
+        error: verifyResult.message,
       });
-      verifyResult = (await res.json()) as SiteverifyResponse;
-    } catch (error) {
-      logWarning('Turnstile siteverify network failure', {
-        event: PACK_EVENT,
-        outcome: 'turnstile_failed' satisfies PackOutcome,
-        reason: 'siteverify_unavailable',
-        requestId,
-        source: clientInfo.source,
-        error: error instanceof Error ? error.message : String(error),
-        ...(cf && { cf }),
-      });
-      return c.json(createErrorResponse(MESSAGES.TURNSTILE_FAILED, requestId), 403);
     }
 
     if (!verifyResult?.success) {
-      logInfo('Turnstile verification rejected', {
-        event: PACK_EVENT,
-        outcome: 'turnstile_failed' satisfies PackOutcome,
-        reason: 'siteverify_rejected',
+      return rejectAndLog('siteverify_rejected', 'Turnstile verification rejected', 'info', {
         errorCodes: verifyResult?.['error-codes'],
-        requestId,
-        source: clientInfo.source,
-        ...(cf && { cf }),
       });
-      return c.json(createErrorResponse(MESSAGES.TURNSTILE_FAILED, requestId), 403);
     }
 
     // Action claim binding: only present on tokens minted with `data-action`
@@ -171,35 +144,52 @@ export function turnstileMiddleware(deps: TurnstileDeps = defaultDeps) {
     // client supplied (or undefined if none), so we accept undefined as a
     // backward-compat fallback for older client builds. The strict check kicks
     // in once the client started sending an action.
-    if (verifyResult.action !== undefined && verifyResult.action !== EXPECTED_ACTION) {
-      logInfo('Turnstile verification rejected: action mismatch', {
-        event: PACK_EVENT,
-        outcome: 'turnstile_failed' satisfies PackOutcome,
-        reason: 'action_mismatch',
+    if (verifyResult.action !== undefined && verifyResult.action !== EXPECTED_TURNSTILE_ACTION) {
+      return rejectAndLog('action_mismatch', 'Turnstile verification rejected: action mismatch', 'info', {
         action: verifyResult.action,
-        requestId,
-        source: clientInfo.source,
-        ...(cf && { cf }),
       });
-      return c.json(createErrorResponse(MESSAGES.TURNSTILE_FAILED, requestId), 403);
     }
 
     // Hostname claim binding: defends against a leaked sitekey being used on
     // an attacker-controlled origin. Test sitekeys omit hostname, so allow
     // undefined for backward-compat (same pattern as the action check).
     if (verifyResult.hostname !== undefined && !ALLOWED_HOSTNAMES.includes(verifyResult.hostname)) {
-      logInfo('Turnstile verification rejected: hostname mismatch', {
-        event: PACK_EVENT,
-        outcome: 'turnstile_failed' satisfies PackOutcome,
-        reason: 'hostname_mismatch',
+      return rejectAndLog('hostname_mismatch', 'Turnstile verification rejected: hostname mismatch', 'info', {
         hostname: verifyResult.hostname,
-        requestId,
-        source: clientInfo.source,
-        ...(cf && { cf }),
       });
-      return c.json(createErrorResponse(MESSAGES.TURNSTILE_FAILED, requestId), 403);
     }
 
     await next();
   };
+}
+
+// Wrap the siteverify call so the middleware body stays focused on policy.
+// Returns the parsed body on success or an Error sentinel on any failure
+// (network error, non-JSON response, abort) so the caller can fail-closed
+// uniformly without distinguishing failure modes — they all map to 403.
+async function runSiteverify(
+  deps: TurnstileDeps,
+  secret: string,
+  token: string,
+  clientInfo: ClientInfo,
+): Promise<SiteverifyResponse | Error> {
+  // remoteip is optional in Cloudflare's siteverify API. clientInfo.ip falls
+  // back to '0.0.0.0' when no IP header was present — sending that sentinel
+  // doesn't help Cloudflare's risk scoring and can confuse their validation,
+  // so omit the field entirely in that case.
+  const body = new URLSearchParams({ secret, response: token });
+  if (clientInfo.ip && clientInfo.ip !== '0.0.0.0') {
+    body.set('remoteip', clientInfo.ip);
+  }
+  try {
+    const res = await deps.fetch(SITEVERIFY_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+      signal: AbortSignal.timeout(SITEVERIFY_TIMEOUT_MS),
+    });
+    return (await res.json()) as SiteverifyResponse;
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
 }

--- a/website/server/src/middlewares/turnstile.ts
+++ b/website/server/src/middlewares/turnstile.ts
@@ -18,6 +18,12 @@ const MAX_TOKEN_LENGTH = 2048;
 // server requires this exact value so a token issued for some other endpoint
 // (or a future widget) can't be replayed at /api/pack.
 const EXPECTED_ACTION = 'pack';
+// Hostnames we expect tokens to be minted from. Must match the site
+// configured in the Cloudflare Turnstile dashboard. Tokens minted on other
+// hostnames (e.g. a leaked sitekey reused on attacker's domain) will be
+// rejected. The test sitekey returns no hostname, so undefined is allowed
+// for backward-compat.
+const ALLOWED_HOSTNAMES: readonly string[] = ['repomix.com'];
 
 interface SiteverifyResponse {
   success: boolean;
@@ -171,6 +177,22 @@ export function turnstileMiddleware(deps: TurnstileDeps = defaultDeps) {
         outcome: 'turnstile_failed' satisfies PackOutcome,
         reason: 'action_mismatch',
         action: verifyResult.action,
+        requestId,
+        source: clientInfo.source,
+        ...(cf && { cf }),
+      });
+      return c.json(createErrorResponse(MESSAGES.TURNSTILE_FAILED, requestId), 403);
+    }
+
+    // Hostname claim binding: defends against a leaked sitekey being used on
+    // an attacker-controlled origin. Test sitekeys omit hostname, so allow
+    // undefined for backward-compat (same pattern as the action check).
+    if (verifyResult.hostname !== undefined && !ALLOWED_HOSTNAMES.includes(verifyResult.hostname)) {
+      logInfo('Turnstile verification rejected: hostname mismatch', {
+        event: PACK_EVENT,
+        outcome: 'turnstile_failed' satisfies PackOutcome,
+        reason: 'hostname_mismatch',
+        hostname: verifyResult.hostname,
         requestId,
         source: clientInfo.source,
         ...(cf && { cf }),

--- a/website/server/src/middlewares/turnstile.ts
+++ b/website/server/src/middlewares/turnstile.ts
@@ -11,6 +11,13 @@ const TOKEN_HEADER = 'X-Turnstile-Token';
 // hung verify call must not stall the pack flow. Returning 403 on timeout is
 // safer than failing open per request.
 const SITEVERIFY_TIMEOUT_MS = 5_000;
+// Cloudflare's documented upper bound for Turnstile tokens. Anything longer is
+// guaranteed-invalid and should be rejected before we call siteverify.
+const MAX_TOKEN_LENGTH = 2048;
+// Action claim the client widget binds when calling turnstile.render — the
+// server requires this exact value so a token issued for some other endpoint
+// (or a future widget) can't be replayed at /api/pack.
+const EXPECTED_ACTION = 'pack';
 
 interface SiteverifyResponse {
   success: boolean;
@@ -23,11 +30,13 @@ interface SiteverifyResponse {
 interface TurnstileDeps {
   fetch: typeof fetch;
   getSecret: () => string | undefined;
+  isProduction: () => boolean;
 }
 
 const defaultDeps: TurnstileDeps = {
   fetch: globalThis.fetch,
   getSecret: () => process.env.TURNSTILE_SECRET_KEY,
+  isProduction: () => process.env.NODE_ENV === 'production',
 };
 
 // Verify Cloudflare Turnstile tokens before /api/pack runs the actual pack.
@@ -35,13 +44,16 @@ const defaultDeps: TurnstileDeps = {
 // per request — the middleware doesn't cache verifications.
 //
 // Behaviour:
-// - TURNSTILE_SECRET_KEY unset → fail-open (skip verification, log once at
-//   warn level). This keeps local dev / preview environments unblocked while
-//   still surfacing missing config in production logs.
-// - Token missing or empty → 403 with `outcome: turnstile_failed`.
+// - TURNSTILE_SECRET_KEY unset:
+//   - In production → fail-closed (403 with `reason: secret_missing`). Missing
+//     config in production is a deployment bug, not a normal state.
+//   - In dev/test → fail-open (skip verification, warn once). Keeps local
+//     contributors and preview environments unblocked.
+// - Token missing / empty / oversized → 403 with `outcome: turnstile_failed`.
 // - siteverify success: false → 403 with `outcome: turnstile_failed`.
 // - siteverify network failure → 403 with `outcome: turnstile_failed` (fail-
 //   closed; if Cloudflare can't verify, treat as untrusted).
+// - Action claim mismatch → 403 (token wasn't minted for /api/pack).
 //
 // Placement: applied to /api/pack only — docs pages, health checks, and any
 // future public read-only endpoints stay challenge-free so SEO/LLMO crawlers
@@ -50,26 +62,54 @@ export function turnstileMiddleware(deps: TurnstileDeps = defaultDeps) {
   let secretMissingLogged = false;
 
   return async function turnstileMiddleware(c: Context, next: Next) {
+    const requestId = c.get('requestId');
+    const clientInfo = getClientInfo(c);
+    const cf = buildCfLogField(clientInfo);
+
     const secret = deps.getSecret();
     if (!secret) {
+      if (deps.isProduction()) {
+        logWarning('TURNSTILE_SECRET_KEY not set in production', {
+          event: PACK_EVENT,
+          outcome: 'turnstile_failed' satisfies PackOutcome,
+          reason: 'secret_missing',
+          requestId,
+          source: clientInfo.source,
+          ...(cf && { cf }),
+        });
+        return c.json(createErrorResponse(MESSAGES.TURNSTILE_FAILED, requestId), 403);
+      }
       if (!secretMissingLogged) {
         secretMissingLogged = true;
-        logWarning('TURNSTILE_SECRET_KEY not set — Turnstile verification skipped');
+        logWarning('TURNSTILE_SECRET_KEY not set — Turnstile verification skipped (non-production)');
       }
       await next();
       return;
     }
 
-    const requestId = c.get('requestId');
-    const clientInfo = getClientInfo(c);
-    const cf = buildCfLogField(clientInfo);
-    const token = c.req.header(TOKEN_HEADER);
+    const rawToken = c.req.header(TOKEN_HEADER);
+    const token = rawToken?.trim();
 
     if (!token) {
       logInfo('Turnstile token missing', {
         event: PACK_EVENT,
         outcome: 'turnstile_failed' satisfies PackOutcome,
         reason: 'missing_token',
+        requestId,
+        source: clientInfo.source,
+        ...(cf && { cf }),
+      });
+      return c.json(createErrorResponse(MESSAGES.TURNSTILE_FAILED, requestId), 403);
+    }
+
+    if (token.length > MAX_TOKEN_LENGTH) {
+      // Defensive: oversized tokens are guaranteed-invalid per Cloudflare's
+      // spec. Reject without spending a siteverify call.
+      logInfo('Turnstile token rejected: oversized', {
+        event: PACK_EVENT,
+        outcome: 'turnstile_failed' satisfies PackOutcome,
+        reason: 'token_too_long',
+        tokenLength: token.length,
         requestId,
         source: clientInfo.source,
         ...(cf && { cf }),
@@ -113,6 +153,24 @@ export function turnstileMiddleware(deps: TurnstileDeps = defaultDeps) {
         outcome: 'turnstile_failed' satisfies PackOutcome,
         reason: 'siteverify_rejected',
         errorCodes: verifyResult?.['error-codes'],
+        requestId,
+        source: clientInfo.source,
+        ...(cf && { cf }),
+      });
+      return c.json(createErrorResponse(MESSAGES.TURNSTILE_FAILED, requestId), 403);
+    }
+
+    // Action claim binding: only present on tokens minted with `data-action`
+    // on the widget. Cloudflare's test sitekey echoes whatever action the
+    // client supplied (or undefined if none), so we accept undefined as a
+    // backward-compat fallback for older client builds. The strict check kicks
+    // in once the client started sending an action.
+    if (verifyResult.action !== undefined && verifyResult.action !== EXPECTED_ACTION) {
+      logInfo('Turnstile verification rejected: action mismatch', {
+        event: PACK_EVENT,
+        outcome: 'turnstile_failed' satisfies PackOutcome,
+        reason: 'action_mismatch',
+        action: verifyResult.action,
         requestId,
         source: clientInfo.source,
         ...(cf && { cf }),

--- a/website/server/tests/turnstile.test.ts
+++ b/website/server/tests/turnstile.test.ts
@@ -6,10 +6,7 @@ import { turnstileMiddleware } from '../src/middlewares/turnstile.js';
 // (set by upstream middleware in production). For unit tests we shim these
 // via a tiny middleware so each test gets the values it needs without
 // importing the full middleware chain.
-function buildApp(opts: {
-  middleware: ReturnType<typeof turnstileMiddleware>;
-  requestId?: string;
-}) {
+function buildApp(opts: { middleware: ReturnType<typeof turnstileMiddleware>; requestId?: string }) {
   const app = new Hono();
   app.use('*', async (c, next) => {
     c.set('requestId', opts.requestId ?? 'req-test');
@@ -169,9 +166,9 @@ describe('turnstileMiddleware', () => {
   });
 
   test('returns 403 when siteverify reports failure', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      okResponse({ success: false, 'error-codes': ['invalid-input-response'] }),
-    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(okResponse({ success: false, 'error-codes': ['invalid-input-response'] }));
     const middleware = turnstileMiddleware({
       fetch: fetchMock,
       getSecret: () => SECRET,

--- a/website/server/tests/turnstile.test.ts
+++ b/website/server/tests/turnstile.test.ts
@@ -411,9 +411,7 @@ describe('EXPECTED_TURNSTILE_ACTION contract', () => {
   test('matches the action literal embedded in the client useTurnstile composable', async () => {
     expect(EXPECTED_TURNSTILE_ACTION).toBe('pack');
 
-    const useTurnstilePath = fileURLToPath(
-      new URL('../../client/composables/useTurnstile.ts', import.meta.url),
-    );
+    const useTurnstilePath = fileURLToPath(new URL('../../client/composables/useTurnstile.ts', import.meta.url));
     const source = await readFile(useTurnstilePath, 'utf8');
     expect(source).toMatch(/action:\s*['"]pack['"]/);
   });

--- a/website/server/tests/turnstile.test.ts
+++ b/website/server/tests/turnstile.test.ts
@@ -6,7 +6,10 @@ import { turnstileMiddleware } from '../src/middlewares/turnstile.js';
 // (set by upstream middleware in production). For unit tests we shim these
 // via a tiny middleware so each test gets the values it needs without
 // importing the full middleware chain.
-function buildApp(opts: { middleware: ReturnType<typeof turnstileMiddleware>; requestId?: string }) {
+function buildApp(opts: {
+  middleware: ReturnType<typeof turnstileMiddleware>;
+  requestId?: string;
+}) {
   const app = new Hono();
   app.use('*', async (c, next) => {
     c.set('requestId', opts.requestId ?? 'req-test');
@@ -18,12 +21,18 @@ function buildApp(opts: { middleware: ReturnType<typeof turnstileMiddleware>; re
 
 const SECRET = 'test-secret';
 
+const okResponse = (body: object) =>
+  new Response(JSON.stringify(body), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+
 describe('turnstileMiddleware', () => {
-  test('skips verification when secret is unset (fail-open)', async () => {
+  test('skips verification when secret is unset (fail-open in dev/test)', async () => {
     const fetchMock = vi.fn();
     const middleware = turnstileMiddleware({
       fetch: fetchMock,
       getSecret: () => undefined,
+      isProduction: () => false,
     });
     const app = buildApp({ middleware });
 
@@ -33,11 +42,27 @@ describe('turnstileMiddleware', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  test('returns 403 when secret is unset in production (fail-closed)', async () => {
+    const fetchMock = vi.fn();
+    const middleware = turnstileMiddleware({
+      fetch: fetchMock,
+      getSecret: () => undefined,
+      isProduction: () => true,
+    });
+    const app = buildApp({ middleware });
+
+    const res = await app.request('/api/pack', { method: 'POST' });
+
+    expect(res.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   test('returns 403 when token header is missing', async () => {
     const fetchMock = vi.fn();
     const middleware = turnstileMiddleware({
       fetch: fetchMock,
       getSecret: () => SECRET,
+      isProduction: () => false,
     });
     const app = buildApp({ middleware });
 
@@ -49,15 +74,49 @@ describe('turnstileMiddleware', () => {
     expect(body.error).toMatch(/Verification failed/);
   });
 
-  test('passes through when siteverify reports success', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ success: true }), {
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    );
+  test('returns 403 when token is whitespace-only (treated as missing)', async () => {
+    const fetchMock = vi.fn();
     const middleware = turnstileMiddleware({
       fetch: fetchMock,
       getSecret: () => SECRET,
+      isProduction: () => false,
+    });
+    const app = buildApp({ middleware });
+
+    const res = await app.request('/api/pack', {
+      method: 'POST',
+      headers: { 'X-Turnstile-Token': '   ' },
+    });
+
+    expect(res.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('returns 403 when token exceeds max length (no siteverify call)', async () => {
+    const fetchMock = vi.fn();
+    const middleware = turnstileMiddleware({
+      fetch: fetchMock,
+      getSecret: () => SECRET,
+      isProduction: () => false,
+    });
+    const app = buildApp({ middleware });
+
+    const oversized = 'x'.repeat(2049);
+    const res = await app.request('/api/pack', {
+      method: 'POST',
+      headers: { 'X-Turnstile-Token': oversized },
+    });
+
+    expect(res.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('passes through when siteverify reports success', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({ success: true, action: 'pack' }));
+    const middleware = turnstileMiddleware({
+      fetch: fetchMock,
+      getSecret: () => SECRET,
+      isProduction: () => false,
     });
     const app = buildApp({ middleware });
 
@@ -75,19 +134,48 @@ describe('turnstileMiddleware', () => {
     expect(body.get('response')).toBe('good-token');
   });
 
+  test('passes through when siteverify omits action (backward-compat)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({ success: true }));
+    const middleware = turnstileMiddleware({
+      fetch: fetchMock,
+      getSecret: () => SECRET,
+      isProduction: () => false,
+    });
+    const app = buildApp({ middleware });
+
+    const res = await app.request('/api/pack', {
+      method: 'POST',
+      headers: { 'X-Turnstile-Token': 'good-token' },
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  test('returns 403 when siteverify reports an action other than "pack"', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({ success: true, action: 'login' }));
+    const middleware = turnstileMiddleware({
+      fetch: fetchMock,
+      getSecret: () => SECRET,
+      isProduction: () => false,
+    });
+    const app = buildApp({ middleware });
+
+    const res = await app.request('/api/pack', {
+      method: 'POST',
+      headers: { 'X-Turnstile-Token': 'wrong-action-token' },
+    });
+
+    expect(res.status).toBe(403);
+  });
+
   test('returns 403 when siteverify reports failure', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          success: false,
-          'error-codes': ['invalid-input-response'],
-        }),
-        { headers: { 'Content-Type': 'application/json' } },
-      ),
+      okResponse({ success: false, 'error-codes': ['invalid-input-response'] }),
     );
     const middleware = turnstileMiddleware({
       fetch: fetchMock,
       getSecret: () => SECRET,
+      isProduction: () => false,
     });
     const app = buildApp({ middleware });
 
@@ -104,6 +192,7 @@ describe('turnstileMiddleware', () => {
     const middleware = turnstileMiddleware({
       fetch: fetchMock,
       getSecret: () => SECRET,
+      isProduction: () => false,
     });
     const app = buildApp({ middleware });
 

--- a/website/server/tests/turnstile.test.ts
+++ b/website/server/tests/turnstile.test.ts
@@ -1,0 +1,117 @@
+import { Hono } from 'hono';
+import { describe, expect, test, vi } from 'vitest';
+import { turnstileMiddleware } from '../src/middlewares/turnstile.js';
+
+// The middleware reads `requestId` and `clientInfo` from the Hono context
+// (set by upstream middleware in production). For unit tests we shim these
+// via a tiny middleware so each test gets the values it needs without
+// importing the full middleware chain.
+function buildApp(opts: { middleware: ReturnType<typeof turnstileMiddleware>; requestId?: string }) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('requestId', opts.requestId ?? 'req-test');
+    await next();
+  });
+  app.post('/api/pack', opts.middleware, (c) => c.json({ ok: true }));
+  return app;
+}
+
+const SECRET = 'test-secret';
+
+describe('turnstileMiddleware', () => {
+  test('skips verification when secret is unset (fail-open)', async () => {
+    const fetchMock = vi.fn();
+    const middleware = turnstileMiddleware({
+      fetch: fetchMock,
+      getSecret: () => undefined,
+    });
+    const app = buildApp({ middleware });
+
+    const res = await app.request('/api/pack', { method: 'POST' });
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('returns 403 when token header is missing', async () => {
+    const fetchMock = vi.fn();
+    const middleware = turnstileMiddleware({
+      fetch: fetchMock,
+      getSecret: () => SECRET,
+    });
+    const app = buildApp({ middleware });
+
+    const res = await app.request('/api/pack', { method: 'POST' });
+
+    expect(res.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/Verification failed/);
+  });
+
+  test('passes through when siteverify reports success', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const middleware = turnstileMiddleware({
+      fetch: fetchMock,
+      getSecret: () => SECRET,
+    });
+    const app = buildApp({ middleware });
+
+    const res = await app.request('/api/pack', {
+      method: 'POST',
+      headers: { 'X-Turnstile-Token': 'good-token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://challenges.cloudflare.com/turnstile/v0/siteverify');
+    const body = (init as RequestInit).body as URLSearchParams;
+    expect(body.get('secret')).toBe(SECRET);
+    expect(body.get('response')).toBe('good-token');
+  });
+
+  test('returns 403 when siteverify reports failure', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: false,
+          'error-codes': ['invalid-input-response'],
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const middleware = turnstileMiddleware({
+      fetch: fetchMock,
+      getSecret: () => SECRET,
+    });
+    const app = buildApp({ middleware });
+
+    const res = await app.request('/api/pack', {
+      method: 'POST',
+      headers: { 'X-Turnstile-Token': 'bad-token' },
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  test('returns 403 (fail-closed) when siteverify network call rejects', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network down'));
+    const middleware = turnstileMiddleware({
+      fetch: fetchMock,
+      getSecret: () => SECRET,
+    });
+    const app = buildApp({ middleware });
+
+    const res = await app.request('/api/pack', {
+      method: 'POST',
+      headers: { 'X-Turnstile-Token': 'any-token' },
+    });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/website/server/tests/turnstile.test.ts
+++ b/website/server/tests/turnstile.test.ts
@@ -1,6 +1,8 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import { Hono } from 'hono';
 import { describe, expect, test, vi } from 'vitest';
-import { turnstileMiddleware } from '../src/middlewares/turnstile.js';
+import { EXPECTED_TURNSTILE_ACTION, turnstileMiddleware } from '../src/middlewares/turnstile.js';
 import * as logger from '../src/utils/logger.js';
 
 // The middleware reads `requestId` and `clientInfo` from the Hono context
@@ -372,5 +374,47 @@ describe('turnstileMiddleware', () => {
     // (loggers) see the codes via the verifyResult object — verified
     // implicitly by middleware not throwing on the array shape.
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns 403 when siteverify response is not valid JSON', async () => {
+    // Simulate a non-JSON response (e.g. Cloudflare returning a 5xx HTML
+    // error page or an upstream proxy mangling the body). The runSiteverify
+    // wrapper should map the JSON parse error to the same fail-closed 403
+    // path as a network failure — no uncaught exception should escape.
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('<!doctype html><h1>Bad Gateway</h1>', {
+        headers: { 'Content-Type': 'text/html' },
+      }),
+    );
+    const middleware = turnstileMiddleware({
+      fetch: fetchMock,
+      getSecret: () => SECRET,
+      isProduction: () => false,
+    });
+    const app = buildApp({ middleware });
+
+    const res = await app.request('/api/pack', {
+      method: 'POST',
+      headers: { 'X-Turnstile-Token': 'token' },
+    });
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// Cross-stack contract: the EXPECTED_TURNSTILE_ACTION on the server must
+// match the literal `action` value the client widget binds in
+// `useTurnstile.ts`. They live in different bundles with no shared module,
+// so this test is the only thing keeping a rename on one side from silently
+// breaking Turnstile in production.
+describe('EXPECTED_TURNSTILE_ACTION contract', () => {
+  test('matches the action literal embedded in the client useTurnstile composable', async () => {
+    expect(EXPECTED_TURNSTILE_ACTION).toBe('pack');
+
+    const useTurnstilePath = fileURLToPath(
+      new URL('../../client/composables/useTurnstile.ts', import.meta.url),
+    );
+    const source = await readFile(useTurnstilePath, 'utf8');
+    expect(source).toMatch(/action:\s*['"]pack['"]/);
   });
 });

--- a/website/server/tests/turnstile.test.ts
+++ b/website/server/tests/turnstile.test.ts
@@ -200,4 +200,109 @@ describe('turnstileMiddleware', () => {
 
     expect(res.status).toBe(403);
   });
+
+  test('omits remoteip when clientInfo.ip falls back to 0.0.0.0', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({ success: true }));
+    const middleware = turnstileMiddleware({
+      fetch: fetchMock,
+      getSecret: () => SECRET,
+      isProduction: () => false,
+    });
+    // Build a minimal app without IP-providing headers so getClientInfo()
+    // returns the '0.0.0.0' sentinel.
+    const app = buildApp({ middleware });
+
+    const res = await app.request('/api/pack', {
+      method: 'POST',
+      headers: { 'X-Turnstile-Token': 'good-token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (fetchMock.mock.calls[0][1] as RequestInit).body as URLSearchParams;
+    expect(body.has('remoteip')).toBe(false);
+  });
+
+  test('includes remoteip when a real client IP header is present', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({ success: true }));
+    const middleware = turnstileMiddleware({
+      fetch: fetchMock,
+      getSecret: () => SECRET,
+      isProduction: () => false,
+    });
+    const app = buildApp({ middleware });
+
+    const res = await app.request('/api/pack', {
+      method: 'POST',
+      headers: {
+        'X-Turnstile-Token': 'good-token',
+        'cf-connecting-ip': '203.0.113.42',
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (fetchMock.mock.calls[0][1] as RequestInit).body as URLSearchParams;
+    expect(body.get('remoteip')).toBe('203.0.113.42');
+  });
+
+  test('logs the secret-missing warning at most once across requests', async () => {
+    // Reuse a single middleware instance across calls so the closure-state
+    // `secretMissingLogged` flag is shared (mirrors the production setup).
+    const middleware = turnstileMiddleware({
+      fetch: vi.fn(),
+      getSecret: () => undefined,
+      isProduction: () => false,
+    });
+    const app = buildApp({ middleware });
+
+    const consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    try {
+      await app.request('/api/pack', { method: 'POST' });
+      await app.request('/api/pack', { method: 'POST' });
+      await app.request('/api/pack', { method: 'POST' });
+
+      // logWarning eventually goes through Winston which writes to the same
+      // stdout stream we don't intercept here, so the cleanest assertion is
+      // that the function-level flag is honoured by the next request also
+      // returning 200 without further side effects.
+      // (A direct logger spy would be tighter, but the only-once contract is
+      // observable through behaviour: the middleware doesn't re-throw or
+      // mutate state on subsequent calls.)
+    } finally {
+      consoleInfoSpy.mockRestore();
+    }
+    // No assertion failure means the closure state didn't blow up; if the
+    // only-once guard ever regresses, the warning would still be emitted on
+    // every call but tests would still pass — so we add a guard against the
+    // function changing shape such that getSecret is called more than 3 times
+    // (which would indicate a recreated middleware per request).
+    expect(true).toBe(true);
+  });
+
+  test('passes through siteverify error-codes in the rejection log payload', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      okResponse({
+        success: false,
+        'error-codes': ['timeout-or-duplicate', 'invalid-input-response'],
+      }),
+    );
+    const middleware = turnstileMiddleware({
+      fetch: fetchMock,
+      getSecret: () => SECRET,
+      isProduction: () => false,
+    });
+    const app = buildApp({ middleware });
+
+    const res = await app.request('/api/pack', {
+      method: 'POST',
+      headers: { 'X-Turnstile-Token': 'duplicate-token' },
+    });
+
+    expect(res.status).toBe(403);
+    // The middleware doesn't expose the error codes in the response body
+    // (they're internal triage info). Behavioural assertion: the rejection
+    // fires with the failure response shape, and downstream callers
+    // (loggers) see the codes via the verifyResult object — verified
+    // implicitly by middleware not throwing on the array shape.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/website/server/tests/turnstile.test.ts
+++ b/website/server/tests/turnstile.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { describe, expect, test, vi } from 'vitest';
 import { turnstileMiddleware } from '../src/middlewares/turnstile.js';
+import * as logger from '../src/utils/logger.js';
 
 // The middleware reads `requestId` and `clientInfo` from the Hono context
 // (set by upstream middleware in production). For unit tests we shim these
@@ -244,38 +245,109 @@ describe('turnstileMiddleware', () => {
     expect(body.get('remoteip')).toBe('203.0.113.42');
   });
 
-  test('logs the secret-missing warning at most once across requests', async () => {
-    // Reuse a single middleware instance across calls so the closure-state
-    // `secretMissingLogged` flag is shared (mirrors the production setup).
+  test('logs the secret-missing warning at most once across requests (dev/test)', async () => {
+    const logWarningSpy = vi.spyOn(logger, 'logWarning').mockImplementation(() => {});
+    try {
+      // Reuse a single middleware instance across calls so the closure-state
+      // `secretMissingLogged` flag is shared (mirrors the production setup
+      // where one instance is registered for the whole server lifetime).
+      const middleware = turnstileMiddleware({
+        fetch: vi.fn(),
+        getSecret: () => undefined,
+        isProduction: () => false,
+      });
+      const app = buildApp({ middleware });
+
+      await app.request('/api/pack', { method: 'POST' });
+      await app.request('/api/pack', { method: 'POST' });
+      await app.request('/api/pack', { method: 'POST' });
+
+      const skipLogs = logWarningSpy.mock.calls.filter((call) =>
+        String(call[0]).includes('Turnstile verification skipped'),
+      );
+      expect(skipLogs).toHaveLength(1);
+    } finally {
+      logWarningSpy.mockRestore();
+    }
+  });
+
+  test('logs the secret-missing warning every request in production (no closure cache)', async () => {
+    const logWarningSpy = vi.spyOn(logger, 'logWarning').mockImplementation(() => {});
+    try {
+      const middleware = turnstileMiddleware({
+        fetch: vi.fn(),
+        getSecret: () => undefined,
+        isProduction: () => true,
+      });
+      const app = buildApp({ middleware });
+
+      await app.request('/api/pack', { method: 'POST' });
+      await app.request('/api/pack', { method: 'POST' });
+
+      // Production fail-closed path logs every time so a chronic misconfig
+      // shows up on the dashboard, not just once at boot.
+      const prodLogs = logWarningSpy.mock.calls.filter((call) =>
+        String(call[0]).includes('TURNSTILE_SECRET_KEY not set in production'),
+      );
+      expect(prodLogs).toHaveLength(2);
+    } finally {
+      logWarningSpy.mockRestore();
+    }
+  });
+
+  test('passes through when siteverify hostname is allowed', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(okResponse({ success: true, hostname: 'repomix.com' }));
     const middleware = turnstileMiddleware({
-      fetch: vi.fn(),
-      getSecret: () => undefined,
+      fetch: fetchMock,
+      getSecret: () => SECRET,
       isProduction: () => false,
     });
     const app = buildApp({ middleware });
 
-    const consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
-    try {
-      await app.request('/api/pack', { method: 'POST' });
-      await app.request('/api/pack', { method: 'POST' });
-      await app.request('/api/pack', { method: 'POST' });
+    const res = await app.request('/api/pack', {
+      method: 'POST',
+      headers: { 'X-Turnstile-Token': 'good-token' },
+    });
 
-      // logWarning eventually goes through Winston which writes to the same
-      // stdout stream we don't intercept here, so the cleanest assertion is
-      // that the function-level flag is honoured by the next request also
-      // returning 200 without further side effects.
-      // (A direct logger spy would be tighter, but the only-once contract is
-      // observable through behaviour: the middleware doesn't re-throw or
-      // mutate state on subsequent calls.)
-    } finally {
-      consoleInfoSpy.mockRestore();
-    }
-    // No assertion failure means the closure state didn't blow up; if the
-    // only-once guard ever regresses, the warning would still be emitted on
-    // every call but tests would still pass — so we add a guard against the
-    // function changing shape such that getSecret is called more than 3 times
-    // (which would indicate a recreated middleware per request).
-    expect(true).toBe(true);
+    expect(res.status).toBe(200);
+  });
+
+  test('returns 403 when siteverify reports an unexpected hostname', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(okResponse({ success: true, hostname: 'attacker.example' }));
+    const middleware = turnstileMiddleware({
+      fetch: fetchMock,
+      getSecret: () => SECRET,
+      isProduction: () => false,
+    });
+    const app = buildApp({ middleware });
+
+    const res = await app.request('/api/pack', {
+      method: 'POST',
+      headers: { 'X-Turnstile-Token': 'token' },
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  test('passes through when siteverify omits hostname (test sitekey backward-compat)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({ success: true }));
+    const middleware = turnstileMiddleware({
+      fetch: fetchMock,
+      getSecret: () => SECRET,
+      isProduction: () => false,
+    });
+    const app = buildApp({ middleware });
+
+    const res = await app.request('/api/pack', {
+      method: 'POST',
+      headers: { 'X-Turnstile-Token': 'good-token' },
+    });
+
+    expect(res.status).toBe(200);
   });
 
   test('passes through siteverify error-codes in the rejection log payload', async () => {

--- a/website/server/tests/turnstile.test.ts
+++ b/website/server/tests/turnstile.test.ts
@@ -296,9 +296,7 @@ describe('turnstileMiddleware', () => {
   });
 
   test('passes through when siteverify hostname is allowed', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(okResponse({ success: true, hostname: 'repomix.com' }));
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({ success: true, hostname: 'repomix.com' }));
     const middleware = turnstileMiddleware({
       fetch: fetchMock,
       getSecret: () => SECRET,
@@ -315,9 +313,7 @@ describe('turnstileMiddleware', () => {
   });
 
   test('returns 403 when siteverify reports an unexpected hostname', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(okResponse({ success: true, hostname: 'attacker.example' }));
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({ success: true, hostname: 'attacker.example' }));
     const middleware = turnstileMiddleware({
       fetch: fetchMock,
       getSecret: () => SECRET,


### PR DESCRIPTION
## Summary

Adds Cloudflare Turnstile verification to `/api/pack` to mitigate the residential-proxy crawler abuse identified in the recent SG incident investigation. IP-based rate limiting (3/min, 30/day) was demonstrated to be ineffective against the attacker (2,256+ unique IPs in a single day from a Tencent Cloud SG + residential proxy mix), so a JS-challenge layer is added at the application boundary.

### Scope

- `/api/pack` only — docs, health, homepage browsing remain challenge-free, so SEO/LLMO crawlers (Googlebot, GPTBot, ClaudeBot etc. that only `GET` HTML) are unaffected.
- Invisible widget on the pack form — most users will never see a challenge.

### Behaviour

| Condition | Outcome |
|---|---|
| `TURNSTILE_SECRET_KEY` unset | fail-open (skip verification, log warn once) — keeps local dev / preview environments unblocked |
| Token missing / siteverify rejects / network failure | fail-closed (403, `outcome: turnstile_failed` log) |
| siteverify success | passes through to `packAction` |

### Files

- **Server** (3 new, 4 modified)
  - `middlewares/turnstile.ts` — siteverify wrapper with DI
  - `tests/turnstile.test.ts` — 5 tests (skip / missing token / success / siteverify reject / network failure)
  - `actions/packRequestMessages.ts` — `TURNSTILE_FAILED` constant
  - `actions/packEventSchema.ts` — `'turnstile_failed'` outcome
  - `middlewares/cors.ts` — allow `X-Turnstile-Token` in preflight (required for the custom header)
  - `index.ts` — apply middleware to `/api/pack`
  - `cloudbuild.yaml` — wire `TURNSTILE_SECRET_KEY` from Secret Manager
- **Client** (1 new, 4 modified)
  - `composables/useTurnstile.ts` — invisible widget with 1-shot token API
  - `composables/usePackRequest.ts` — call `getToken()` before submitting
  - `components/api/client.ts` — pass token via `X-Turnstile-Token` header
  - `components/utils/requestHandlers.ts` — plumb token through
  - `components/Home/TryIt.vue` — mount widget container

### Deployment prerequisites (already done)

- [x] Cloudflare Turnstile site created (hostname `repomix.com`, mode Managed)
- [x] `VITE_TURNSTILE_SITE_KEY` set in Cloudflare Pages env vars (Production)
- [x] `turnstile-secret-key` created in GCP Secret Manager (project `repomix`)
- [x] Cloud Run SA granted `roles/secretmanager.secretAccessor` on the secret

### Deployment order risk

After merge, Cloudflare Pages and Cloud Build run in parallel. Pages typically finishes first (1-2 min vs 3-5 min for Cloud Build), so the natural order is favorable. If Cloud Run completes first, browsers on the old (cached) JS would 403. Mitigations:

- VitePress uses content-hashed JS chunks → fresh page loads pull new JS
- Rollback path: `gcloud run services update repomix-server-us --remove-secrets=TURNSTILE_SECRET_KEY` reverts server to fail-open

Recommend merging during low-traffic JST hours.

## Checklist

- [x] Run `npm run test` (server: 33 passed)
- [x] Run `npm run lint` (server / client / root biome: all green)

## Background

Incident investigation summary: GA4 + Cloud Run logs confirmed 21,477 unique GitHub repos enumerated alphabetically over 2026-04-17–23, primarily from Tencent Cloud SG (AS132203) + residential proxies (Vodafone DE, Hutchison HK, Telefônica BR, etc. — BrightData/Oxylabs-style IP pool). Server-side rate limit caught the requests (only 32 of 21,501 attempts succeeded = 0.15%) but the inbound request volume still loaded Cloud Run. Turnstile shifts cost asymmetrically — invisible to humans, expensive for stealth-naive automation regardless of IP diversity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yamadashy/repomix/pull/1538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->