### PR TITLE
perf(website): Pre-warm Turnstile widget and stop wasting tokens

### DIFF
--- a/website/client/composables/useTurnstile.ts
+++ b/website/client/composables/useTurnstile.ts
@@ -231,6 +231,12 @@ export function useTurnstile() {
   }
 
   onBeforeUnmount(() => {
+    // Drop the container ref first so any in-flight pre-warm `ensureWidget()`
+    // call that resolves AFTER unmount sees `containerEl.value !== el` and
+    // skips render(). Without this, a slow script load could complete after
+    // the form was unmounted and bind a new widget to a detached DOM node
+    // with no remove() left to clean it up.
+    containerEl.value = null;
     // Reject any in-flight getToken() promise so the awaiting caller doesn't
     // hang forever after the form unmounts (e.g. user navigates away mid-
     // challenge).

--- a/website/client/composables/useTurnstile.ts
+++ b/website/client/composables/useTurnstile.ts
@@ -73,6 +73,11 @@ export function useTurnstile() {
         sitekey: siteKey,
         size: 'invisible',
         action: 'pack',
+        // Defer the actual challenge until getToken() calls execute(). This
+        // is what makes the pre-warm in setContainer() free of side-effects
+        // (no token waste, no inflated "unresolved challenge" counter for
+        // visitors who never click pack).
+        execution: 'execute',
         callback: (token: string) => {
           if (pendingResolve) {
             pendingResolve(token);

--- a/website/client/composables/useTurnstile.ts
+++ b/website/client/composables/useTurnstile.ts
@@ -206,6 +206,23 @@ export function useTurnstile() {
 
   function setContainer(el: HTMLElement | null) {
     containerEl.value = el;
+    // Pre-warm: load the Turnstile script and render the (invisible) widget
+    // as soon as the container is registered, instead of waiting for the
+    // first `getToken()` call. This trades a small amount of page-idle work
+    // for a noticeably shorter "Processing repository..." gap when the user
+    // clicks pack — `execute()` on a ready widget typically returns in
+    // 100-200ms, vs 500-1000ms when script load + widget init happen
+    // serially with the click.
+    //
+    // Errors are intentionally swallowed: a failed pre-warm doesn't block
+    // page rendering, and the same `loadTurnstileScript` / `ensureWidget`
+    // path will retry (with full error propagation) when `getToken()` is
+    // eventually called.
+    if (el) {
+      ensureWidget(el).catch(() => {
+        // pre-warm failures surface on the actual submit path
+      });
+    }
   }
 
   onBeforeUnmount(() => {

--- a/website/client/composables/useTurnstile.ts
+++ b/website/client/composables/useTurnstile.ts
@@ -59,56 +59,78 @@ export function useTurnstile() {
   // somehow shipped the test sitekey would still 403 every pack.
   const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY ?? FALLBACK_TEST_SITE_KEY;
 
+  // Single-flight cache for the in-flight ensureWidget promise. Without it,
+  // pre-warm and getToken() can both race past the `widgetId.value` null
+  // check after `await loadTurnstileScript()` resolves, calling
+  // `turnstile.render()` twice — the first widget id gets overwritten and
+  // leaks (onBeforeUnmount can only remove the surviving id).
+  let ensureWidgetPromise: Promise<TurnstileGlobal> | null = null;
+
   async function ensureWidget(el: HTMLElement): Promise<TurnstileGlobal> {
-    const turnstile = await loadTurnstileScript();
-    // The component may have unmounted (or the user may have switched away
-    // from the form) while the script was loading. Detached DOM elements
-    // accept render() but the corresponding remove() in onBeforeUnmount has
-    // already run, so the widget would leak. Bail out instead.
-    if (containerEl.value !== el) {
-      throw new Error('Turnstile container detached during script load');
+    if (ensureWidgetPromise) return ensureWidgetPromise;
+    ensureWidgetPromise = (async () => {
+      const turnstile = await loadTurnstileScript();
+      // The component may have unmounted (or the user may have switched away
+      // from the form) while the script was loading. Detached DOM elements
+      // accept render() but the corresponding remove() in onBeforeUnmount has
+      // already run, so the widget would leak. Bail out instead.
+      if (containerEl.value !== el) {
+        throw new Error('Turnstile container detached during script load');
+      }
+      if (!widgetId.value) {
+        widgetId.value = turnstile.render(el, {
+          sitekey: siteKey,
+          size: 'invisible',
+          action: 'pack',
+          // Defer the actual challenge until getToken() calls execute(). This
+          // is what makes the pre-warm in setContainer() free of side-effects
+          // (no token waste, no inflated "unresolved challenge" counter for
+          // visitors who never click pack).
+          execution: 'execute',
+          callback: (token: string) => {
+            if (pendingResolve) {
+              pendingResolve(token);
+              pendingResolve = null;
+              pendingReject = null;
+            }
+          },
+          'error-callback': (errorCode: string) => {
+            const message = `Turnstile error: ${errorCode}`;
+            error.value = message;
+            if (pendingReject) {
+              pendingReject(new Error(message));
+              pendingResolve = null;
+              pendingReject = null;
+            }
+          },
+          'expired-callback': () => {
+            // Token expired before being used. The widget will issue a fresh
+            // one on the next execute() call.
+            if (widgetId.value) turnstile.reset(widgetId.value);
+          },
+          'timeout-callback': () => {
+            if (pendingReject) {
+              pendingReject(new Error('Turnstile challenge timed out'));
+              pendingResolve = null;
+              pendingReject = null;
+            }
+          },
+        });
+      }
+      return turnstile;
+    })();
+    try {
+      return await ensureWidgetPromise;
+    } catch (err) {
+      // Drop the cached promise on rejection so a retry (e.g. after a CDN
+      // blip cleared by useTurnstileScript's resetForRetry) can re-enter the
+      // render path. On success we keep the resolved promise cached: the
+      // widgetId guard above turns subsequent calls into a no-op anyway, but
+      // returning the same promise avoids a duplicate `loadTurnstileScript()`
+      // round-trip in the cached-success case.
+      ensureWidgetPromise = null;
+      throw err;
     }
-    if (!widgetId.value) {
-      widgetId.value = turnstile.render(el, {
-        sitekey: siteKey,
-        size: 'invisible',
-        action: 'pack',
-        // Defer the actual challenge until getToken() calls execute(). This
-        // is what makes the pre-warm in setContainer() free of side-effects
-        // (no token waste, no inflated "unresolved challenge" counter for
-        // visitors who never click pack).
-        execution: 'execute',
-        callback: (token: string) => {
-          if (pendingResolve) {
-            pendingResolve(token);
-            pendingResolve = null;
-            pendingReject = null;
-          }
-        },
-        'error-callback': (errorCode: string) => {
-          const message = `Turnstile error: ${errorCode}`;
-          error.value = message;
-          if (pendingReject) {
-            pendingReject(new Error(message));
-            pendingResolve = null;
-            pendingReject = null;
-          }
-        },
-        'expired-callback': () => {
-          // Token expired before being used. The widget will issue a fresh
-          // one on the next execute() call.
-          if (widgetId.value) turnstile.reset(widgetId.value);
-        },
-        'timeout-callback': () => {
-          if (pendingReject) {
-            pendingReject(new Error('Turnstile challenge timed out'));
-            pendingResolve = null;
-            pendingReject = null;
-          }
-        },
-      });
-    }
-    return turnstile;
   }
 
   // Ask the (invisible) widget for a fresh verification token. Each call

--- a/website/client/composables/useTurnstileScript.ts
+++ b/website/client/composables/useTurnstileScript.ts
@@ -24,6 +24,15 @@ export interface TurnstileRenderOptions {
   // token minted for /api/pack can't be replayed at a future endpoint that
   // expects a different action.
   action?: string;
+  // 'render' (Cloudflare default) auto-runs the challenge on render(),
+  // 'execute' waits for an explicit turnstile.execute() call. Use 'execute'
+  // so the pre-warm path (render at form mount) only loads the script and
+  // widget shell — no challenge runs and no token is minted until the user
+  // clicks pack. Without this, render() fires a wasted challenge per page
+  // view, which (a) inflates the Turnstile dashboard's "unresolved
+  // challenges" counter for any non-human visitor, and (b) burns one token
+  // before the user actually submits.
+  execution?: 'render' | 'execute';
   callback?: (token: string) => void;
   'error-callback'?: (errorCode: string) => void;
   'expired-callback'?: () => void;


### PR DESCRIPTION
## Summary

After PR #1538 was deployed, pack-button latency was visibly worse than before Turnstile: a ~1s "Processing repository..." gap before the API call. Cloudflare's Turnstile dashboard then showed an even bigger problem — most of the tokens we issued were being thrown away:

| Metric (30 min sample) | Value |
|---|---:|
| Challenges issued | 217 |
| Challenges solved | 90 |
| **siteverify requests** | **22** |
| Unresolved challenges | 127 (58.5%) |
| "Likely bot" share | 58.53% |

68 solved tokens never reached the server. The dashboard's bot share was inflated too, because every page visitor (including legitimate crawlers running JS) was triggering an automatic challenge.

## Root cause

Cloudflare Turnstile's invisible widget defaults to `execution: 'render'`, which means `turnstile.render()` immediately fires a challenge and mints a token — whether the user ever clicks pack or not. Calling `render()` on form mount (the natural place to pre-warm the script + widget shell) therefore generates a token per page view that we never use, and pulls every JS-capable visitor through the bot-vs-human classifier.

## Fix

Two changes that work together:

1. **Pre-warm on container mount.** `setContainer(el)` now calls `ensureWidget()` fire-and-forget, so the script load and widget shell are ready by the time the user clicks pack. `execute()` on a primed widget typically returns in 100–200 ms vs 500–1000 ms when script load + widget init happen serially with the click.
2. **Defer the challenge with `execution: 'execute'`.** Render no longer auto-runs a challenge. We only mint a token when the user actually clicks pack (`turnstile.execute()`). This eliminates the token waste *and* removes random visitors from the dashboard's bot/human counters.

Defensive cleanups while we were here:

- `onBeforeUnmount` clears `containerEl` first, so a slow script load that finishes after unmount sees the detached state and skips `render()`.
- `ensureWidget()` is single-flight via a cached promise. Pre-warm and submit can race past the `widgetId` null check after `await loadTurnstileScript()` resolves; without the cache they would both call `render()` and the first widget id would leak (the surviving id is the only one `onBeforeUnmount` can `remove()`).

## Why this is safe

- `ensureWidget()` is idempotent (returns the cached widget once rendered).
- `execution: 'execute'` is documented Cloudflare behaviour; tokens are minted only when `execute()` is called.
- Pre-warm errors are swallowed on purpose. The same `loadTurnstileScript()` / `ensureWidget()` path is re-entered on submit, so any real failure surfaces with a user-facing error there.
- Server tests (20 cases) and lint stay green; `docs:build` passes with `VITE_TURNSTILE_SITE_KEY` set.

## Expected dashboard impact post-deploy

- Challenges issued ≈ challenges solved ≈ siteverify requests ≈ pack submissions
- Bot/human ratio reflects real submitters, not casual visitors

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)