### PR TITLE
fix(website): Defer Turnstile render() until pack click

### DIFF
--- a/website/client/.vitepress/config/configShard.ts
+++ b/website/client/.vitepress/config/configShard.ts
@@ -207,6 +207,13 @@ export const configShard = defineConfig({
     // Favicon
     ['link', { rel: 'icon', href: '/images/repomix-logo.svg' }],
 
+    // Warm up the connection to Cloudflare Turnstile before the user clicks
+    // pack so the script load + challenge round-trip don't add a cold-start
+    // DNS/TLS handshake to the perceived latency. Resource hint only, no
+    // request body — does not interact with Turnstile's challenge counter.
+    ['link', { rel: 'preconnect', href: 'https://challenges.cloudflare.com' }],
+    ['link', { rel: 'dns-prefetch', href: 'https://challenges.cloudflare.com' }],
+
     // OGP
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:site_name', content: siteName }],

--- a/website/client/.vitepress/config/configShard.ts
+++ b/website/client/.vitepress/config/configShard.ts
@@ -211,7 +211,14 @@ export const configShard = defineConfig({
     // pack so the script load + challenge round-trip don't add a cold-start
     // DNS/TLS handshake to the perceived latency. Resource hint only, no
     // request body — does not interact with Turnstile's challenge counter.
+    //
+    // Two `preconnect` hints: the bare one warms the connection pool used
+    // for the anonymous `api.js` script fetch, and the `crossorigin`
+    // variant warms the separate pool the Turnstile iframe uses for its
+    // CORS sub-resources. Browsers treat these as distinct pools, so a
+    // single hint only warms one of them.
     ['link', { rel: 'preconnect', href: 'https://challenges.cloudflare.com' }],
+    ['link', { rel: 'preconnect', href: 'https://challenges.cloudflare.com', crossorigin: '' }],
     ['link', { rel: 'dns-prefetch', href: 'https://challenges.cloudflare.com' }],
 
     // OGP

--- a/website/client/composables/useTurnstile.ts
+++ b/website/client/composables/useTurnstile.ts
@@ -59,11 +59,12 @@ export function useTurnstile() {
   // somehow shipped the test sitekey would still 403 every pack.
   const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY ?? FALLBACK_TEST_SITE_KEY;
 
-  // Single-flight cache for the in-flight ensureWidget promise. Without it,
-  // pre-warm and getToken() can both race past the `widgetId.value` null
-  // check after `await loadTurnstileScript()` resolves, calling
-  // `turnstile.render()` twice — the first widget id gets overwritten and
-  // leaks (onBeforeUnmount can only remove the surviving id).
+  // Single-flight cache for the in-flight ensureWidget promise. With pack
+  // pre-warm now restricted to `loadTurnstileScript()`, only back-to-back
+  // `getToken()` calls can race here — but two concurrent submits would
+  // still both pass the `widgetId.value` null check after the awaited
+  // script load resolves and call `turnstile.render()` twice, leaking the
+  // first widget id (onBeforeUnmount can only remove the surviving one).
   let ensureWidgetPromise: Promise<TurnstileGlobal> | null = null;
 
   async function ensureWidget(el: HTMLElement): Promise<TurnstileGlobal> {
@@ -82,10 +83,12 @@ export function useTurnstile() {
           sitekey: siteKey,
           size: 'invisible',
           action: 'pack',
-          // Defer the actual challenge until getToken() calls execute(). This
-          // is what makes the pre-warm in setContainer() free of side-effects
-          // (no token waste, no inflated "unresolved challenge" counter for
-          // visitors who never click pack).
+          // Defer the actual challenge until execute() is called below.
+          // Caveat per PR #1541: render() itself still inflates the
+          // Cloudflare dashboard's challenge counters even with this
+          // option, which is why `setContainer()` no longer pre-warms by
+          // calling render(). We still pass `execute` here so render() at
+          // least doesn't auto-mint a token before getToken() is ready.
           execution: 'execute',
           callback: (token: string) => {
             if (pendingResolve) {

--- a/website/client/composables/useTurnstile.ts
+++ b/website/client/composables/useTurnstile.ts
@@ -233,20 +233,22 @@ export function useTurnstile() {
 
   function setContainer(el: HTMLElement | null) {
     containerEl.value = el;
-    // Pre-warm: load the Turnstile script and render the (invisible) widget
-    // as soon as the container is registered, instead of waiting for the
-    // first `getToken()` call. This trades a small amount of page-idle work
-    // for a noticeably shorter "Processing repository..." gap when the user
-    // clicks pack — `execute()` on a ready widget typically returns in
-    // 100-200ms, vs 500-1000ms when script load + widget init happen
-    // serially with the click.
+    // Pre-warm scope: ONLY load the Turnstile script, do NOT render the
+    // widget here. Production telemetry showed that calling
+    // `turnstile.render()` at form-mount time inflated the Cloudflare
+    // dashboard's "challenge issued / solved" counters far beyond the GA
+    // pack_start volume — every visitor (humans, crawlers, ad-blocker
+    // failures) was being counted into Turnstile analytics even though the
+    // widget was configured with `execution: 'execute'`. The docs say
+    // render() shouldn't fire a challenge in that mode, but the analytics
+    // disagree, so we no longer trust render() to be side-effect free at
+    // mount time. Render is now deferred to the first `getToken()` call.
     //
     // Errors are intentionally swallowed: a failed pre-warm doesn't block
-    // page rendering, and the same `loadTurnstileScript` / `ensureWidget`
-    // path will retry (with full error propagation) when `getToken()` is
-    // eventually called.
+    // page rendering, and the same `loadTurnstileScript` path will retry
+    // (with full error propagation) when `getToken()` is eventually called.
     if (el) {
-      ensureWidget(el).catch(() => {
+      loadTurnstileScript().catch(() => {
         // pre-warm failures surface on the actual submit path
       });
     }

--- a/website/client/composables/useTurnstileScript.ts
+++ b/website/client/composables/useTurnstileScript.ts
@@ -26,12 +26,14 @@ export interface TurnstileRenderOptions {
   action?: string;
   // 'render' (Cloudflare default) auto-runs the challenge on render(),
   // 'execute' waits for an explicit turnstile.execute() call. Use 'execute'
-  // so the pre-warm path (render at form mount) only loads the script and
-  // widget shell — no challenge runs and no token is minted until the user
-  // clicks pack. Without this, render() fires a wasted challenge per page
-  // view, which (a) inflates the Turnstile dashboard's "unresolved
-  // challenges" counter for any non-human visitor, and (b) burns one token
-  // before the user actually submits.
+  // so the widget can be rendered without immediately minting a token.
+  //
+  // NOTE: production telemetry (PR #1539 → #1541) showed that even with
+  // `execution: 'execute'` the dashboard still counts every render() call
+  // toward "challenges issued / solved", contradicting the public docs. The
+  // useTurnstile composable now defers render() to the first getToken()
+  // call instead of pre-warming at form mount, which is the only reliable
+  // way to keep the dashboard counters aligned with real submissions.
   execution?: 'render' | 'execute';
   callback?: (token: string) => void;
   'error-callback'?: (errorCode: string) => void;


### PR DESCRIPTION
## Summary

12 hours after PR #1539 deployed, the Cloudflare Turnstile dashboard showed numbers that did not match user behaviour:

| Source | 12-hour value |
|---|---:|
| GA `pack_start` (real click count) | ~150–200 |
| Cloudflare Turnstile — **challenges solved** | 986 |
| Cloudflare Turnstile — **challenges issued** | 2,620 |

That is roughly **5×** more solved challenges than actual pack clicks, and **13×** more issued challenges. Every visitor of `repomix.com` (including crawlers, ad-blocked sessions, and abandoned tabs) was being counted into Turnstile analytics, even though the widget was configured with `execution: 'execute'`.

Cloudflare's docs say `turnstile.render()` is side-effect free in `execution: 'execute'` mode, but the dashboard tells a different story. Confirmed both via direct telemetry comparison and a follow-up review with codex.

## Fix

Pre-warm scope is now narrower:

```diff
- if (el) {
-   ensureWidget(el).catch(() => {});  // ran turnstile.render(), counted by analytics
- }
+ if (el) {
+   loadTurnstileScript().catch(() => {});  // script fetch only, no render()
+ }
```

`turnstile.render()` now happens lazily inside `getToken()`, i.e. only when the user actually clicks pack. To compensate for the lost render-time pre-warm, a `preconnect` (and a `dns-prefetch` fallback) hint to `challenges.cloudflare.com` is added to the global `<head>` so the DNS / TLS / HTTP-2 handshake is warm before the click.

## Expected impact

- `Challenges issued ≈ Challenges solved ≈ siteverify requests ≈ GA pack_start`
- "Likely bot" ratio in the dashboard reflects real submitters again, not casual visitors
- Click-to-API latency stays close to the previous PR (script is still warm; only `render()` runs on click, which is cheap on a warm connection)

## What I learned

When the dashboard and the docs disagree, trust the dashboard. The previous PR introduced the pre-warm based on the docs' promise that `render()` is inert in execute mode; the live analytics proved otherwise. Treat every new `render()` call site as a billable side effect until proved otherwise on real telemetry.

## Checklist

- [x] `npm run test` — 20 server cases pass
- [x] `npm run lint` — server / client / root biome green

🤖 Generated with [Claude Code](https://claude.com/claude-code)