### PR TITLE
chore(agents): Add codex-review-loop command

### DIFF
--- a/.agents/commands/code/codex-review-loop.md
+++ b/.agents/commands/code/codex-review-loop.md
@@ -1,0 +1,9 @@
+Repeat the following cycle on the current branch's changes against `main` (max 3 iterations):
+
+1. **Review** — Spawn codex reviewer agent
+2. **Triage** — Review agent findings and keep only what you also deem noteworthy. Classify each as **Fix** (clear defects, must fix) or **Skip** (style, nitpicks, scope creep). Show a brief table before changing anything.
+3. **Fix** only the "Fix" items. Keep changes minimal.
+4. **Verify** with `npm run lint` and `npm run test`. Fix any regressions and repeat this step until all checks pass before continuing.
+5. **Re-review** only the newly changed lines. Do not re-raise skipped items.
+
+Stop when no "Fix" items remain or 3 iterations are reached. Print a summary of what was fixed and what was skipped.

--- a/.agents/commands/code/codex-review-loop.md
+++ b/.agents/commands/code/codex-review-loop.md
@@ -1,3 +1,7 @@
+---
+description: Iterative review-and-fix loop using codex
+---
+
 Repeat the following cycle on the current branch's changes against `main` (max 3 iterations):
 
 1. **Review** — Spawn codex reviewer agent


### PR DESCRIPTION
## Summary

- Adds `.agents/commands/code/codex-review-loop.md`, a sibling to the existing `review-loop` command that explicitly delegates the review step to the codex reviewer agent.
- Same review/triage/fix/verify/re-review cycle (max 3 iterations) as `review-loop`.

Cherry-picked from `chore/drop-node-20` (e7ce123b).

## Checklist

- [ ] Run `npm run test`
- [ ] Run `npm run lint`