### PR TITLE
perf(website): Show verifying step + emit siteverify duration metric

### DIFF
--- a/website/client/components/Home/TryItLoading.vue
+++ b/website/client/components/Home/TryItLoading.vue
@@ -10,6 +10,7 @@ interface Props {
 const props = defineProps<Props>();
 
 const stageMessages: Record<PackProgressStage, string> = {
+  verifying: 'Verifying request...',
   'cache-check': 'Checking cache...',
   cloning: 'Cloning repository...',
   'repository-fetch': 'Fetching repository...',

--- a/website/client/components/Home/TryItLoading.vue
+++ b/website/client/components/Home/TryItLoading.vue
@@ -1,15 +1,15 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import type { PackProgressStage } from '../api/client';
+import type { DisplayProgressStage } from '../api/client';
 
 interface Props {
-  stage?: PackProgressStage | null;
+  stage?: DisplayProgressStage | null;
   message?: string | null;
 }
 
 const props = defineProps<Props>();
 
-const stageMessages: Record<PackProgressStage, string> = {
+const stageMessages: Record<DisplayProgressStage, string> = {
   verifying: 'Verifying request...',
   'cache-check': 'Checking cache...',
   cloning: 'Cloning repository...',

--- a/website/client/components/Home/TryItResult.vue
+++ b/website/client/components/Home/TryItResult.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from 'vue';
 import type { PackOptions } from '../../composables/usePackOptions';
 import type { TabType } from '../../types/ui';
-import type { FileInfo, PackProgressStage, PackResult } from '../api/client';
+import type { DisplayProgressStage, FileInfo, PackResult } from '../api/client';
 import SupportMessage from './SupportMessage.vue';
 import TryItFileSelection from './TryItFileSelection.vue';
 import TryItLoading from './TryItLoading.vue';
@@ -16,7 +16,7 @@ interface Props {
   errorType?: 'error' | 'warning';
   repositoryUrl?: string;
   packOptions?: PackOptions;
-  progressStage?: PackProgressStage | null;
+  progressStage?: DisplayProgressStage | null;
   progressMessage?: string | null;
 }
 

--- a/website/client/components/api/client.ts
+++ b/website/client/components/api/client.ts
@@ -60,18 +60,20 @@ export class ApiError extends Error {
   }
 }
 
-// `verifying` is a client-only synthetic stage shown while the server is
-// running Turnstile siteverify (before any SSE event arrives). The server
-// never sends this stage; usePackRequest sets it locally between
-// `takeToken()` returning and the first onProgress callback firing, so
-// the loading UI displays a meaningful step instead of a generic "...".
-export type PackProgressStage =
-  | 'verifying'
-  | 'cache-check'
-  | 'cloning'
-  | 'repository-fetch'
-  | 'extracting'
-  | 'processing';
+// Wire-protocol stages — must stay aligned with the server-emitted SSE
+// values (`website/server/src/types.ts:PackProgressStage`). `onProgress`
+// callbacks receive only these, so any new server stage requires a
+// deliberate type update on both sides.
+export type PackProgressStage = 'cache-check' | 'cloning' | 'repository-fetch' | 'extracting' | 'processing';
+
+// Display-only superset. `verifying` is a client-only synthetic stage
+// shown while the server runs Turnstile siteverify (before any SSE event
+// arrives); usePackRequest sets it locally between `takeToken()` returning
+// and the first onProgress callback firing, so the loading UI shows a
+// meaningful step instead of a generic "...". Keeping it out of
+// `PackProgressStage` prevents the wire contract from drifting silently
+// when display-only stages get added or renamed.
+export type DisplayProgressStage = PackProgressStage | 'verifying';
 
 export interface PackStreamCallbacks {
   onProgress?: (stage: PackProgressStage, message?: string) => void;

--- a/website/client/components/api/client.ts
+++ b/website/client/components/api/client.ts
@@ -60,7 +60,18 @@ export class ApiError extends Error {
   }
 }
 
-export type PackProgressStage = 'cache-check' | 'cloning' | 'repository-fetch' | 'extracting' | 'processing';
+// `verifying` is a client-only synthetic stage shown while the server is
+// running Turnstile siteverify (before any SSE event arrives). The server
+// never sends this stage; usePackRequest sets it locally between
+// `takeToken()` returning and the first onProgress callback firing, so
+// the loading UI displays a meaningful step instead of a generic "...".
+export type PackProgressStage =
+  | 'verifying'
+  | 'cache-check'
+  | 'cloning'
+  | 'repository-fetch'
+  | 'extracting'
+  | 'processing';
 
 export interface PackStreamCallbacks {
   onProgress?: (stage: PackProgressStage, message?: string) => void;

--- a/website/client/composables/usePackRequest.ts
+++ b/website/client/composables/usePackRequest.ts
@@ -158,9 +158,11 @@ export function usePackRequest() {
       if (isCurrent()) {
         loading.value = false;
         requestController = null;
-        // Clear progressStage so a subsequent submit's brief verifying
-        // window doesn't pick up the previous run's stale state.
+        // Clear progressStage and progressMessage so a subsequent submit's
+        // brief verifying window doesn't pick up the previous run's stale
+        // state. Mirrors the initialization at the top of submitRequest.
         progressStage.value = null;
+        progressMessage.value = null;
         error.value = abortMessage(tokenResult.reason);
         errorType.value = 'warning';
       }
@@ -172,6 +174,7 @@ export function usePackRequest() {
         loading.value = false;
         requestController = null;
         progressStage.value = null;
+        progressMessage.value = null;
         error.value = tokenResult.message;
         errorType.value = 'error';
       }

--- a/website/client/composables/usePackRequest.ts
+++ b/website/client/composables/usePackRequest.ts
@@ -129,7 +129,11 @@ export function usePackRequest() {
     errorType.value = 'error';
     result.value = null;
     hasExecuted.value = true;
-    progressStage.value = null;
+    // Show a meaningful loading step while the server runs Turnstile
+    // siteverify (typically 100-1000ms before the first SSE 'cache-check'
+    // event arrives). The first onProgress callback from handlePackRequest
+    // overwrites this with the real server-reported stage.
+    progressStage.value = 'verifying';
     progressMessage.value = null;
     inputRepositoryUrl.value = inputUrl.value;
 

--- a/website/client/composables/usePackRequest.ts
+++ b/website/client/composables/usePackRequest.ts
@@ -1,5 +1,5 @@
 import { computed, onMounted, ref } from 'vue';
-import type { FileInfo, PackProgressStage, PackResult } from '../components/api/client';
+import type { DisplayProgressStage, FileInfo, PackResult } from '../components/api/client';
 import { handlePackRequest } from '../components/utils/requestHandlers';
 import { isValidRemoteValue } from '../components/utils/validation';
 import { parseUrlParameters } from '../utils/urlParams';
@@ -43,7 +43,7 @@ export function usePackRequest() {
   const errorType = ref<'error' | 'warning'>('error');
   const result = ref<PackResult | null>(null);
   const hasExecuted = ref(false);
-  const progressStage = ref<PackProgressStage | null>(null);
+  const progressStage = ref<DisplayProgressStage | null>(null);
   const progressMessage = ref<string | null>(null);
 
   // Request controller for cancellation
@@ -158,6 +158,9 @@ export function usePackRequest() {
       if (isCurrent()) {
         loading.value = false;
         requestController = null;
+        // Clear progressStage so a subsequent submit's brief verifying
+        // window doesn't pick up the previous run's stale state.
+        progressStage.value = null;
         error.value = abortMessage(tokenResult.reason);
         errorType.value = 'warning';
       }
@@ -168,6 +171,7 @@ export function usePackRequest() {
       if (isCurrent()) {
         loading.value = false;
         requestController = null;
+        progressStage.value = null;
         error.value = tokenResult.message;
         errorType.value = 'error';
       }

--- a/website/server/monitoring/README.md
+++ b/website/server/monitoring/README.md
@@ -28,6 +28,13 @@ field presence so success and failure paths are captured uniformly; the
 `outcome` and `reason` labels on the counter metric drive the breakdown
 in the "outcomes" widget.
 
+Pre-network rejections (`secret_missing`, `missing_token`,
+`token_too_long`) intentionally don't carry `siteverifyDurationMs` —
+they short-circuit before the timer starts, so they're excluded from
+both metrics. Those reject reasons still appear in the existing
+`pack_requests` metric (under `outcome=turnstile_failed`) for
+operational counting, just not in the latency distribution.
+
 ## Apply the dashboard
 
 ```bash

--- a/website/server/monitoring/README.md
+++ b/website/server/monitoring/README.md
@@ -9,40 +9,24 @@ persist on the project and do not need to be redefined here.
 ## Turnstile siteverify metrics
 
 The dashboard's "Turnstile siteverify latency" and "Turnstile siteverify
-outcomes" widgets depend on two log-based metrics that need to exist before
-the widgets render data. Create them once in the GCP Console
-(Logging → Log-based Metrics → Create Metric):
+outcomes" widgets depend on two log-based metrics. Definitions live in
+`metrics/` and are applied once per project:
 
-### `turnstile_siteverify_duration` (Distribution)
+```bash
+gcloud logging metrics create turnstile_siteverify_duration \
+  --config-from-file=metrics/turnstile_siteverify_duration.yaml \
+  --project=repomix
 
-- Filter:
-  ```
-  resource.type="cloud_run_revision"
-  resource.labels.service_name="repomix-server-us"
-  jsonPayload.siteverifyDurationMs!=""
-  ```
-- Field name: `jsonPayload.siteverifyDurationMs`
-- Units: `ms`
-- Histogram type: `Exponential`, base 2, growth factor 2, num buckets 16,
-  scale 1 (covers 1ms — 32s, plenty for the 0–5s siteverify window).
+gcloud logging metrics create turnstile_siteverify_outcomes \
+  --config-from-file=metrics/turnstile_siteverify_outcomes.yaml \
+  --project=repomix
+```
 
-### `turnstile_siteverify_outcomes` (Counter)
-
-- Filter:
-  ```
-  resource.type="cloud_run_revision"
-  resource.labels.service_name="repomix-server-us"
-  jsonPayload.siteverifyDurationMs!=""
-  ```
-- Labels:
-  - `outcome` ← `EXTRACT(jsonPayload.outcome)` (success, turnstile_failed)
-  - `reason` ← `EXTRACT(jsonPayload.reason)` (siteverify_unavailable,
-    siteverify_rejected, action_mismatch, hostname_mismatch — empty for
-    success)
-
-Both metrics filter on `siteverifyDurationMs` field presence so success
-and failure paths are captured uniformly. Once created, the widgets in
-`dashboard.json` will pick them up automatically.
+To update an existing metric (e.g. after editing the filter or buckets),
+swap `create` for `update`. Both metrics filter on `siteverifyDurationMs`
+field presence so success and failure paths are captured uniformly; the
+`outcome` and `reason` labels on the counter metric drive the breakdown
+in the "outcomes" widget.
 
 ## Apply the dashboard
 

--- a/website/server/monitoring/README.md
+++ b/website/server/monitoring/README.md
@@ -6,6 +6,44 @@ Log-based metrics used by the dashboard are managed directly in the GCP Console
 (`logging.googleapis.com/user/oom_terminations` and `container_killed`). They
 persist on the project and do not need to be redefined here.
 
+## Turnstile siteverify metrics
+
+The dashboard's "Turnstile siteverify latency" and "Turnstile siteverify
+outcomes" widgets depend on two log-based metrics that need to exist before
+the widgets render data. Create them once in the GCP Console
+(Logging → Log-based Metrics → Create Metric):
+
+### `turnstile_siteverify_duration` (Distribution)
+
+- Filter:
+  ```
+  resource.type="cloud_run_revision"
+  resource.labels.service_name="repomix-server-us"
+  jsonPayload.siteverifyDurationMs!=""
+  ```
+- Field name: `jsonPayload.siteverifyDurationMs`
+- Units: `ms`
+- Histogram type: `Exponential`, base 2, growth factor 2, num buckets 16,
+  scale 1 (covers 1ms — 32s, plenty for the 0–5s siteverify window).
+
+### `turnstile_siteverify_outcomes` (Counter)
+
+- Filter:
+  ```
+  resource.type="cloud_run_revision"
+  resource.labels.service_name="repomix-server-us"
+  jsonPayload.siteverifyDurationMs!=""
+  ```
+- Labels:
+  - `outcome` ← `EXTRACT(jsonPayload.outcome)` (success, turnstile_failed)
+  - `reason` ← `EXTRACT(jsonPayload.reason)` (siteverify_unavailable,
+    siteverify_rejected, action_mismatch, hostname_mismatch — empty for
+    success)
+
+Both metrics filter on `siteverifyDurationMs` field presence so success
+and failure paths are captured uniformly. Once created, the widgets in
+`dashboard.json` will pick them up automatically.
+
 ## Apply the dashboard
 
 ```bash

--- a/website/server/monitoring/README.md
+++ b/website/server/monitoring/README.md
@@ -35,6 +35,19 @@ both metrics. Those reject reasons still appear in the existing
 `pack_requests` metric (under `outcome=turnstile_failed`) for
 operational counting, just not in the latency distribution.
 
+The metric filter pins `service_name="repomix-server-us"`, so requests
+served from any future region (`-eu`, `-asia`) silently drop out of the
+distribution until either the filter is broadened or per-region
+counterparts are applied. Surface this in the migration plan when
+adding the next region.
+
+To verify a YAML edit was actually applied to the live metric (gcloud
+update is silent on no-op vs effective change):
+
+```bash
+gcloud logging metrics describe turnstile_siteverify_duration --project=repomix
+```
+
 ## Apply the dashboard
 
 ```bash

--- a/website/server/monitoring/dashboard.json
+++ b/website/server/monitoring/dashboard.json
@@ -605,6 +605,95 @@
             "yAxis": { "label": "count / 5min", "scale": "LINEAR" }
           }
         }
+      },
+      {
+        "xPos": 0,
+        "yPos": 32,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Turnstile siteverify latency P50 / P95 / P99",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/turnstile_siteverify_duration\"",
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_PERCENTILE_50",
+                      "crossSeriesReducer": "REDUCE_MAX"
+                    }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "P50",
+                "targetAxis": "Y1"
+              },
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/turnstile_siteverify_duration\"",
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_PERCENTILE_95",
+                      "crossSeriesReducer": "REDUCE_MAX"
+                    }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "P95",
+                "targetAxis": "Y1"
+              },
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/turnstile_siteverify_duration\"",
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_PERCENTILE_99",
+                      "crossSeriesReducer": "REDUCE_MAX"
+                    }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "P99",
+                "targetAxis": "Y1"
+              }
+            ],
+            "thresholds": [{ "value": 1000, "label": "1s" }],
+            "yAxis": { "label": "ms", "scale": "LINEAR" }
+          }
+        }
+      },
+      {
+        "xPos": 6,
+        "yPos": 32,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Turnstile siteverify outcomes (by outcome)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"logging.googleapis.com/user/turnstile_siteverify_outcomes\"",
+                    "aggregation": {
+                      "alignmentPeriod": "300s",
+                      "perSeriesAligner": "ALIGN_DELTA",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": ["metric.label.outcome"]
+                    }
+                  }
+                },
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1"
+              }
+            ],
+            "yAxis": { "label": "count / 5min", "scale": "LINEAR" }
+          }
+        }
       }
     ]
   }

--- a/website/server/monitoring/dashboard.json
+++ b/website/server/monitoring/dashboard.json
@@ -672,7 +672,7 @@
         "width": 6,
         "height": 4,
         "widget": {
-          "title": "Turnstile siteverify outcomes (by outcome)",
+          "title": "Turnstile siteverify outcomes (by outcome / reason)",
           "xyChart": {
             "dataSets": [
               {
@@ -683,7 +683,7 @@
                       "alignmentPeriod": "300s",
                       "perSeriesAligner": "ALIGN_DELTA",
                       "crossSeriesReducer": "REDUCE_SUM",
-                      "groupByFields": ["metric.label.outcome"]
+                      "groupByFields": ["metric.label.outcome", "metric.label.reason"]
                     }
                   }
                 },

--- a/website/server/monitoring/metrics/turnstile_siteverify_duration.yaml
+++ b/website/server/monitoring/metrics/turnstile_siteverify_duration.yaml
@@ -13,10 +13,15 @@ metricDescriptor:
   valueType: DISTRIBUTION
   unit: ms
 bucketOptions:
-  # Exponential buckets covering 1ms to ~32s (16 finite + 1 overflow + 1
-  # underflow). Aligns with the 5s siteverify timeout, with headroom above
-  # to catch any timeout-then-error case that might still report duration.
+  # Exponential buckets tuned for the 100ms-1s SLO band where decisions
+  # actually get made. growthFactor=2 (doubling) only places ~3 boundaries
+  # between 100ms and 1s, leaving p99 reads ±100% of bucket width when
+  # the alert threshold sits at 1s. growthFactor=1.5 with scale=10 places
+  # boundaries at roughly 10, 15, 23, 34, 51, 76, 114, 171, 256, 384,
+  # 577, 865, 1297, 1946ms (8 boundaries inside 100ms-1s). 18 finite
+  # buckets cover 10ms to ~9.85s, comfortably above the 5s siteverify
+  # timeout so timeout cases stay out of overflow.
   exponentialBuckets:
-    numFiniteBuckets: 16
-    growthFactor: 2.0
-    scale: 1.0
+    numFiniteBuckets: 18
+    growthFactor: 1.5
+    scale: 10.0

--- a/website/server/monitoring/metrics/turnstile_siteverify_duration.yaml
+++ b/website/server/monitoring/metrics/turnstile_siteverify_duration.yaml
@@ -1,0 +1,22 @@
+# Log-based distribution metric for Turnstile siteverify call latency.
+# Captures both success and failure outcomes (the field is attached to all
+# reject branches in turnstileMiddleware), so the distribution covers
+# steady-state performance and Cloudflare-incident timeouts uniformly.
+description: Turnstile siteverify call duration in milliseconds (success + failure paths)
+filter: |
+  resource.type="cloud_run_revision"
+  resource.labels.service_name="repomix-server-us"
+  jsonPayload.siteverifyDurationMs!=""
+valueExtractor: EXTRACT(jsonPayload.siteverifyDurationMs)
+metricDescriptor:
+  metricKind: DELTA
+  valueType: DISTRIBUTION
+  unit: ms
+bucketOptions:
+  # Exponential buckets covering 1ms to ~32s (16 finite + 1 overflow + 1
+  # underflow). Aligns with the 5s siteverify timeout, with headroom above
+  # to catch any timeout-then-error case that might still report duration.
+  exponentialBuckets:
+    numFiniteBuckets: 16
+    growthFactor: 2.0
+    scale: 1.0

--- a/website/server/monitoring/metrics/turnstile_siteverify_duration.yaml
+++ b/website/server/monitoring/metrics/turnstile_siteverify_duration.yaml
@@ -6,6 +6,7 @@ description: Turnstile siteverify call duration in milliseconds (success + failu
 filter: |
   resource.type="cloud_run_revision"
   resource.labels.service_name="repomix-server-us"
+  jsonPayload.event=("turnstile_siteverify" OR "pack_completed")
   jsonPayload.siteverifyDurationMs!=""
 valueExtractor: EXTRACT(jsonPayload.siteverifyDurationMs)
 metricDescriptor:

--- a/website/server/monitoring/metrics/turnstile_siteverify_outcomes.yaml
+++ b/website/server/monitoring/metrics/turnstile_siteverify_outcomes.yaml
@@ -1,0 +1,24 @@
+# Log-based counter metric for Turnstile siteverify outcomes.
+# Filters on `siteverifyDurationMs` field presence so both the success log
+# (`event=turnstile_siteverify`) and the rejected paths (`event=pack_completed`,
+# `outcome=turnstile_failed`) are captured uniformly. The `outcome` label
+# distinguishes success vs failure; `reason` further breaks down failures
+# (siteverify_unavailable, siteverify_rejected, action_mismatch,
+# hostname_mismatch — empty for success).
+description: Turnstile siteverify outcomes — success vs failure reasons
+filter: |
+  resource.type="cloud_run_revision"
+  resource.labels.service_name="repomix-server-us"
+  jsonPayload.siteverifyDurationMs!=""
+labelExtractors:
+  outcome: EXTRACT(jsonPayload.outcome)
+  reason: EXTRACT(jsonPayload.reason)
+metricDescriptor:
+  metricKind: DELTA
+  valueType: INT64
+  unit: "1"
+  labels:
+    - key: outcome
+      valueType: STRING
+    - key: reason
+      valueType: STRING

--- a/website/server/monitoring/metrics/turnstile_siteverify_outcomes.yaml
+++ b/website/server/monitoring/metrics/turnstile_siteverify_outcomes.yaml
@@ -9,6 +9,7 @@ description: Turnstile siteverify outcomes — success vs failure reasons
 filter: |
   resource.type="cloud_run_revision"
   resource.labels.service_name="repomix-server-us"
+  jsonPayload.event=("turnstile_siteverify" OR "pack_completed")
   jsonPayload.siteverifyDurationMs!=""
 labelExtractors:
   outcome: EXTRACT(jsonPayload.outcome)

--- a/website/server/src/middlewares/turnstile.ts
+++ b/website/server/src/middlewares/turnstile.ts
@@ -126,16 +126,26 @@ export function turnstileMiddleware(deps: TurnstileDeps = defaultDeps) {
       });
     }
 
+    // Time the siteverify round-trip so Cloud Monitoring can chart p50/p95/p99
+    // latency. The cost is one log line per request, which is well within
+    // Cloud Logging's free tier on Repomix's traffic. All reject branches
+    // include `siteverifyDurationMs` so the distribution metric covers
+    // success, network failure, and rejected outcomes uniformly.
+    const siteverifyStart = Date.now();
     const verifyResult = await runSiteverify(deps, secret, token, clientInfo);
+    const siteverifyDurationMs = Date.now() - siteverifyStart;
+
     if (verifyResult instanceof Error) {
       return rejectAndLog('siteverify_unavailable', 'Turnstile siteverify network failure', 'warn', {
         error: verifyResult.message,
+        siteverifyDurationMs,
       });
     }
 
     if (!verifyResult?.success) {
       return rejectAndLog('siteverify_rejected', 'Turnstile verification rejected', 'info', {
         errorCodes: verifyResult?.['error-codes'],
+        siteverifyDurationMs,
       });
     }
 
@@ -147,6 +157,7 @@ export function turnstileMiddleware(deps: TurnstileDeps = defaultDeps) {
     if (verifyResult.action !== undefined && verifyResult.action !== EXPECTED_TURNSTILE_ACTION) {
       return rejectAndLog('action_mismatch', 'Turnstile verification rejected: action mismatch', 'info', {
         action: verifyResult.action,
+        siteverifyDurationMs,
       });
     }
 
@@ -156,8 +167,23 @@ export function turnstileMiddleware(deps: TurnstileDeps = defaultDeps) {
     if (verifyResult.hostname !== undefined && !ALLOWED_HOSTNAMES.includes(verifyResult.hostname)) {
       return rejectAndLog('hostname_mismatch', 'Turnstile verification rejected: hostname mismatch', 'info', {
         hostname: verifyResult.hostname,
+        siteverifyDurationMs,
       });
     }
+
+    // Success path: emit a structured event log so Cloud Monitoring can
+    // build a log-based distribution metric on `siteverifyDurationMs`,
+    // filtered by `event=turnstile_siteverify` and `outcome=success`.
+    // Used to validate the latency hypothesis flagged in PR #1544 and to
+    // alert on regressions during Cloudflare incidents.
+    logInfo('Turnstile siteverify success', {
+      event: 'turnstile_siteverify',
+      outcome: 'success',
+      siteverifyDurationMs,
+      requestId,
+      source: clientInfo.source,
+      ...(cf && { cf }),
+    });
 
     await next();
   };

--- a/website/server/src/middlewares/turnstile.ts
+++ b/website/server/src/middlewares/turnstile.ts
@@ -126,26 +126,37 @@ export function turnstileMiddleware(deps: TurnstileDeps = defaultDeps) {
       });
     }
 
-    // Time the siteverify round-trip so Cloud Monitoring can chart p50/p95/p99
-    // latency. The cost is one log line per request, which is well within
-    // Cloud Logging's free tier on Repomix's traffic. All reject branches
-    // include `siteverifyDurationMs` so the distribution metric covers
-    // success, network failure, and rejected outcomes uniformly.
+    // Time the siteverify round-trip and attach `siteverifyDurationMs` to
+    // every outcome (success + four reject branches below). The Cloud
+    // Monitoring metrics in `monitoring/metrics/` filter on the field's
+    // presence, not on `event=`, so success and failure paths are captured
+    // uniformly without conflating with the `pack_completed` lifecycle
+    // metric. Pre-network rejections (`secret_missing`, `missing_token`,
+    // `token_too_long`) intentionally lack the field — they short-circuit
+    // before the timer starts.
     const siteverifyStart = Date.now();
     const verifyResult = await runSiteverify(deps, secret, token, clientInfo);
     const siteverifyDurationMs = Date.now() - siteverifyStart;
 
+    // Wrap rejectAndLog so every post-siteverify branch automatically
+    // carries the duration. Without this, a fifth reject reason added
+    // later would silently drop out of the latency distribution.
+    const rejectWithDuration = (
+      reason: string,
+      logMessage: string,
+      level: 'info' | 'warn' = 'info',
+      extra?: Record<string, unknown>,
+    ) => rejectAndLog(reason, logMessage, level, { ...extra, siteverifyDurationMs });
+
     if (verifyResult instanceof Error) {
-      return rejectAndLog('siteverify_unavailable', 'Turnstile siteverify network failure', 'warn', {
+      return rejectWithDuration('siteverify_unavailable', 'Turnstile siteverify network failure', 'warn', {
         error: verifyResult.message,
-        siteverifyDurationMs,
       });
     }
 
     if (!verifyResult?.success) {
-      return rejectAndLog('siteverify_rejected', 'Turnstile verification rejected', 'info', {
+      return rejectWithDuration('siteverify_rejected', 'Turnstile verification rejected', 'info', {
         errorCodes: verifyResult?.['error-codes'],
-        siteverifyDurationMs,
       });
     }
 
@@ -155,9 +166,8 @@ export function turnstileMiddleware(deps: TurnstileDeps = defaultDeps) {
     // backward-compat fallback for older client builds. The strict check kicks
     // in once the client started sending an action.
     if (verifyResult.action !== undefined && verifyResult.action !== EXPECTED_TURNSTILE_ACTION) {
-      return rejectAndLog('action_mismatch', 'Turnstile verification rejected: action mismatch', 'info', {
+      return rejectWithDuration('action_mismatch', 'Turnstile verification rejected: action mismatch', 'info', {
         action: verifyResult.action,
-        siteverifyDurationMs,
       });
     }
 
@@ -165,17 +175,16 @@ export function turnstileMiddleware(deps: TurnstileDeps = defaultDeps) {
     // an attacker-controlled origin. Test sitekeys omit hostname, so allow
     // undefined for backward-compat (same pattern as the action check).
     if (verifyResult.hostname !== undefined && !ALLOWED_HOSTNAMES.includes(verifyResult.hostname)) {
-      return rejectAndLog('hostname_mismatch', 'Turnstile verification rejected: hostname mismatch', 'info', {
+      return rejectWithDuration('hostname_mismatch', 'Turnstile verification rejected: hostname mismatch', 'info', {
         hostname: verifyResult.hostname,
-        siteverifyDurationMs,
       });
     }
 
-    // Success path: emit a structured event log so Cloud Monitoring can
-    // build a log-based distribution metric on `siteverifyDurationMs`,
-    // filtered by `event=turnstile_siteverify` and `outcome=success`.
-    // Used to validate the latency hypothesis flagged in PR #1544 and to
-    // alert on regressions during Cloudflare incidents.
+    // Success path emits a parallel info log with `event: 'turnstile_siteverify'`
+    // so the metric (filtered on `siteverifyDurationMs` field presence — see
+    // monitoring/README.md) captures success alongside the failure paths
+    // logged via rejectAndLog. The dedicated event name keeps successful
+    // siteverify out of the `pack_completed` lifecycle metric.
     logInfo('Turnstile siteverify success', {
       event: 'turnstile_siteverify',
       outcome: 'success',

--- a/website/server/tests/turnstile.test.ts
+++ b/website/server/tests/turnstile.test.ts
@@ -400,6 +400,163 @@ describe('turnstileMiddleware', () => {
 
     expect(res.status).toBe(403);
   });
+
+  // The latency distribution metric in `monitoring/metrics/turnstile_siteverify_duration.yaml`
+  // filters log entries on `jsonPayload.siteverifyDurationMs` field presence, so a refactor
+  // that drops the field on any post-siteverify branch silently breaks the metric without
+  // any other test failing. Lock the contract: every branch that called siteverify must
+  // attach `siteverifyDurationMs` to its log.
+  describe('siteverifyDurationMs is attached to every post-siteverify log', () => {
+    test('success path emits logInfo with siteverifyDurationMs and event=turnstile_siteverify', async () => {
+      const logInfoSpy = vi.spyOn(logger, 'logInfo').mockImplementation(() => {});
+      try {
+        const fetchMock = vi.fn().mockResolvedValue(okResponse({ success: true, action: 'pack' }));
+        const middleware = turnstileMiddleware({
+          fetch: fetchMock,
+          getSecret: () => SECRET,
+          isProduction: () => false,
+        });
+        const app = buildApp({ middleware });
+
+        const res = await app.request('/api/pack', {
+          method: 'POST',
+          headers: { 'X-Turnstile-Token': 'good-token' },
+        });
+
+        expect(res.status).toBe(200);
+        const successCall = logInfoSpy.mock.calls.find(
+          (call) => (call[1] as Record<string, unknown> | undefined)?.event === 'turnstile_siteverify',
+        );
+        expect(successCall).toBeDefined();
+        // biome-ignore lint/style/noNonNullAssertion: guarded by toBeDefined above
+        const payload = successCall![1] as Record<string, unknown>;
+        expect(payload.outcome).toBe('success');
+        expect(payload.siteverifyDurationMs).toEqual(expect.any(Number));
+      } finally {
+        logInfoSpy.mockRestore();
+      }
+    });
+
+    test('siteverify_rejected reject carries siteverifyDurationMs', async () => {
+      const logInfoSpy = vi.spyOn(logger, 'logInfo').mockImplementation(() => {});
+      try {
+        const fetchMock = vi
+          .fn()
+          .mockResolvedValue(okResponse({ success: false, 'error-codes': ['invalid-input-response'] }));
+        const middleware = turnstileMiddleware({
+          fetch: fetchMock,
+          getSecret: () => SECRET,
+          isProduction: () => false,
+        });
+        const app = buildApp({ middleware });
+
+        const res = await app.request('/api/pack', {
+          method: 'POST',
+          headers: { 'X-Turnstile-Token': 'bad-token' },
+        });
+
+        expect(res.status).toBe(403);
+        const rejectCall = logInfoSpy.mock.calls.find(
+          (call) => (call[1] as Record<string, unknown> | undefined)?.reason === 'siteverify_rejected',
+        );
+        expect(rejectCall).toBeDefined();
+        // biome-ignore lint/style/noNonNullAssertion: guarded by toBeDefined above
+        const rejectPayload = rejectCall![1] as Record<string, unknown>;
+        expect(rejectPayload.siteverifyDurationMs).toEqual(expect.any(Number));
+      } finally {
+        logInfoSpy.mockRestore();
+      }
+    });
+
+    test('action_mismatch reject carries siteverifyDurationMs', async () => {
+      const logInfoSpy = vi.spyOn(logger, 'logInfo').mockImplementation(() => {});
+      try {
+        const fetchMock = vi.fn().mockResolvedValue(okResponse({ success: true, action: 'login' }));
+        const middleware = turnstileMiddleware({
+          fetch: fetchMock,
+          getSecret: () => SECRET,
+          isProduction: () => false,
+        });
+        const app = buildApp({ middleware });
+
+        const res = await app.request('/api/pack', {
+          method: 'POST',
+          headers: { 'X-Turnstile-Token': 'wrong-action-token' },
+        });
+
+        expect(res.status).toBe(403);
+        const rejectCall = logInfoSpy.mock.calls.find(
+          (call) => (call[1] as Record<string, unknown> | undefined)?.reason === 'action_mismatch',
+        );
+        expect(rejectCall).toBeDefined();
+        // biome-ignore lint/style/noNonNullAssertion: guarded by toBeDefined above
+        const rejectPayload = rejectCall![1] as Record<string, unknown>;
+        expect(rejectPayload.siteverifyDurationMs).toEqual(expect.any(Number));
+      } finally {
+        logInfoSpy.mockRestore();
+      }
+    });
+
+    test('hostname_mismatch reject carries siteverifyDurationMs', async () => {
+      const logInfoSpy = vi.spyOn(logger, 'logInfo').mockImplementation(() => {});
+      try {
+        const fetchMock = vi
+          .fn()
+          .mockResolvedValue(okResponse({ success: true, action: 'pack', hostname: 'evil.example.com' }));
+        const middleware = turnstileMiddleware({
+          fetch: fetchMock,
+          getSecret: () => SECRET,
+          isProduction: () => false,
+        });
+        const app = buildApp({ middleware });
+
+        const res = await app.request('/api/pack', {
+          method: 'POST',
+          headers: { 'X-Turnstile-Token': 'leaked-sitekey-token' },
+        });
+
+        expect(res.status).toBe(403);
+        const rejectCall = logInfoSpy.mock.calls.find(
+          (call) => (call[1] as Record<string, unknown> | undefined)?.reason === 'hostname_mismatch',
+        );
+        expect(rejectCall).toBeDefined();
+        // biome-ignore lint/style/noNonNullAssertion: guarded by toBeDefined above
+        const rejectPayload = rejectCall![1] as Record<string, unknown>;
+        expect(rejectPayload.siteverifyDurationMs).toEqual(expect.any(Number));
+      } finally {
+        logInfoSpy.mockRestore();
+      }
+    });
+
+    test('siteverify_unavailable reject carries siteverifyDurationMs (warn-level)', async () => {
+      const logWarningSpy = vi.spyOn(logger, 'logWarning').mockImplementation(() => {});
+      try {
+        const fetchMock = vi.fn().mockRejectedValue(new Error('network'));
+        const middleware = turnstileMiddleware({
+          fetch: fetchMock,
+          getSecret: () => SECRET,
+          isProduction: () => false,
+        });
+        const app = buildApp({ middleware });
+
+        const res = await app.request('/api/pack', {
+          method: 'POST',
+          headers: { 'X-Turnstile-Token': 'token' },
+        });
+
+        expect(res.status).toBe(403);
+        const rejectCall = logWarningSpy.mock.calls.find(
+          (call) => (call[1] as Record<string, unknown> | undefined)?.reason === 'siteverify_unavailable',
+        );
+        expect(rejectCall).toBeDefined();
+        // biome-ignore lint/style/noNonNullAssertion: guarded by toBeDefined above
+        const rejectPayload = rejectCall![1] as Record<string, unknown>;
+        expect(rejectPayload.siteverifyDurationMs).toEqual(expect.any(Number));
+      } finally {
+        logWarningSpy.mockRestore();
+      }
+    });
+  });
 });
 
 // Cross-stack contract: the EXPECTED_TURNSTILE_ACTION on the server must


### PR DESCRIPTION
## Summary

Follow-up observation work on PR #1544. The intent-gated pre-mint flow makes click→submit feel instant, which exposed a previously-hidden ~1s gap between click and the first SSE \`cache-check\` / \`cloning\` event. This PR adds:

1. A synthetic \`verifying\` loading step on the client so the user sees \"Verifying request...\" instead of a generic \"...\" during that gap.
2. Server-side timing of the Turnstile siteverify call, emitted as a structured log so Cloud Monitoring can build a log-based distribution metric for p50/p95/p99 latency.

Neither change tries to shorten the actual wait — that's a follow-up question once we have hard numbers. This PR's job is to (a) make the loading UI honest and (b) instrument the metric so we can decide.

## Changes

### Client

- **\`PackProgressStage\` += \`verifying\`** in \`website/client/components/api/client.ts\`. Documented as a client-only synthetic stage; the server never sends it.
- **\`TryItLoading.vue\`**: \`verifying: 'Verifying request...'\` added to \`stageMessages\`.
- **\`usePackRequest.ts\`**: \`progressStage.value = 'verifying'\` is set at the start of \`submitRequest\` (replacing the previous \`null\` reset). The first \`onProgress\` callback from the SSE stream overwrites it with the real server-reported stage. Covers both client-side cold mint (cache miss) and server-side siteverify wait.

### Server

- **\`turnstileMiddleware\`**: time the \`runSiteverify\` round-trip and attach \`siteverifyDurationMs\` to every outcome:
  - Success → \`logInfo('Turnstile siteverify success', { event: 'turnstile_siteverify', outcome: 'success', siteverifyDurationMs, ... })\`
  - Network failure / rejected / action mismatch / hostname mismatch → existing \`rejectAndLog\` calls extended with \`siteverifyDurationMs\` in the extra fields.

The success log uses a dedicated \`event: 'turnstile_siteverify'\` (vs. the existing \`event: 'pack_completed'\` for failure outcomes) so Cloud Monitoring can filter cleanly without conflating with pack lifecycle metrics.

## Cloud Monitoring setup (manual, post-deploy)

To build a distribution metric:

1. Cloud Logging → Log-based Metrics → Create Metric
2. Filter: \`jsonPayload.event=\"turnstile_siteverify\" AND jsonPayload.outcome=\"success\"\`
3. Type: Distribution, Field name: \`jsonPayload.siteverifyDurationMs\`
4. Add to dashboard with p50/p95/p99 panels

Alerting candidate: p95 > 1500ms over 10min → likely Cloudflare incident.

## Verification

- \`npm run test\`: 1253/1253 passed (3 server tests are existing turnstile coverage; no new tests for the timing log since the existing suite mocks \`fetch\` and would need a clock injection to assert duration)
- \`npm run lint\`: clean for touched files
- Manual: with \`VITE_TURNSTILE_SITE_KEY=test-key npm run docs:dev\`, clicking Pack now shows \"Verifying request...\" briefly before \"Checking cache...\" / \"Cloning repository...\"

## Test plan

- [ ] After deploy, hit \`/api/pack\` from the Try It form and confirm \"Verifying request...\" briefly appears before \"Cloning repository...\"
- [ ] Cloud Logging: confirm \`event=turnstile_siteverify\` entries appear with \`siteverifyDurationMs\` numeric field
- [ ] Wait 24h, create the log-based distribution metric, observe p50/p95/p99 over a representative traffic window
- [ ] If p95 > 1s consistently, open a follow-up to consider HTTP/2 keep-alive (undici Pool), Cloud Run min-instances, or the pack-grant pattern discussed in #1544 review

🤖 Generated with [Claude Code](https://claude.com/claude-code)