### PR TITLE
perf(website): Skip Turnstile pre-mint for bot-shaped user agents

### DIFF
--- a/website/client/composables/usePackRequest.ts
+++ b/website/client/composables/usePackRequest.ts
@@ -2,6 +2,7 @@ import { computed, onMounted, ref } from 'vue';
 import type { DisplayProgressStage, FileInfo, PackResult } from '../components/api/client';
 import { handlePackRequest } from '../components/utils/requestHandlers';
 import { isValidRemoteValue } from '../components/utils/validation';
+import { isBot } from '../utils/botDetect';
 import { parseUrlParameters } from '../utils/urlParams';
 import { abortMessage, acquireTurnstileToken } from './turnstileSubmit';
 import { usePackOptions } from './usePackOptions';
@@ -89,6 +90,16 @@ export function usePackRequest() {
     userTouched,
     loading,
     onTrigger: () => {
+      // Skip background pre-mint for known crawlers. These visitors can't
+      // solve the Turnstile challenge anyway (the JS challenge requires
+      // real browser fingerprints), so issuing one only inflates the CF
+      // dashboard "提示チャレンジ" / "未解決" counters without producing a
+      // usable token. The actual security gate is the server-side
+      // siteverify in turnstileMiddleware — that stays unchanged, so a
+      // crawler that spoofs UA past `isBot()` still gets blocked there.
+      // Submit-path takeToken is intentionally NOT gated to avoid
+      // false-positive lockouts of legit users with unusual UAs.
+      if (isBot()) return;
       turnstile.preMintToken().catch(() => {
         /* errors surface on the actual submit path */
       });
@@ -224,12 +235,14 @@ export function usePackRequest() {
         // Repeat-pack convenience: warm the cache for a likely follow-up
         // submission (option tweak + repack, or `repackWithSelectedFiles`
         // triggered from the result view). Skipped on abort/cancel since
-        // the user may have given up, and on invalid form (user may have
-        // cleared the URL mid-request). userTouched is necessarily true
+        // the user may have given up, on invalid form (user may have
+        // cleared the URL mid-request), and on bot-shaped UAs (same
+        // rationale as the debounce gate above — avoid burning a CF
+        // challenge that can't be solved). userTouched is necessarily true
         // here — it was a precondition for isSubmitValid to be true at
         // submit start. Failures swallow silently — they surface on the
         // next click via takeToken's cold path.
-        if (!controller.signal.aborted && isSubmitValid.value) {
+        if (!controller.signal.aborted && isSubmitValid.value && !isBot()) {
           turnstile.preMintToken().catch(() => {});
         }
       }

--- a/website/client/composables/usePackRequest.ts
+++ b/website/client/composables/usePackRequest.ts
@@ -32,10 +32,16 @@ export function usePackRequest() {
   const uploadedFile = ref<File | null>(null);
   // True once the user has signalled real intent: typed/pasted a URL,
   // uploaded a file/folder, switched modes, or tweaked options. Used to
-  // gate the Turnstile pre-mint so URL-parameter hydration (`?repo=...`),
-  // browser autofill, form restoration, and JS-executing link unfurlers
-  // don't trigger background challenges. Set-only — once true, it stays
-  // true for the session.
+  // gate the Turnstile pre-mint so URL-parameter hydration (`?repo=...`)
+  // and form restoration don't trigger background challenges. Set-only —
+  // once true, it stays true for the session.
+  //
+  // Caveat: modern Chromium / Firefox DO fire `input` events on browser
+  // autofill, which would flip this flag through TryItUrlInput's handler
+  // and trigger a wasted pre-mint for JS-executing crawlers that have
+  // autofill-like behaviour. The `isBot()` check at the pre-mint trigger
+  // sites covers that gap for well-behaved crawler UAs; sophisticated
+  // bots that spoof UA still get filtered server-side by siteverify.
   const userTouched = ref(false);
 
   // Request states
@@ -93,12 +99,15 @@ export function usePackRequest() {
       // Skip background pre-mint for known crawlers. These visitors can't
       // solve the Turnstile challenge anyway (the JS challenge requires
       // real browser fingerprints), so issuing one only inflates the CF
-      // dashboard "提示チャレンジ" / "未解決" counters without producing a
-      // usable token. The actual security gate is the server-side
-      // siteverify in turnstileMiddleware — that stays unchanged, so a
-      // crawler that spoofs UA past `isBot()` still gets blocked there.
-      // Submit-path takeToken is intentionally NOT gated to avoid
-      // false-positive lockouts of legit users with unusual UAs.
+      // dashboard "提示チャレンジ" (issued challenges) / "未解決"
+      // (unsolved) counters without producing a usable token. The actual
+      // security gate is the server-side siteverify in
+      // turnstileMiddleware — that stays unchanged, so a crawler that
+      // spoofs UA past `isBot()` still gets blocked there. The click-path
+      // `acquireTurnstileToken()` (cold-mint at submit time) is
+      // intentionally NOT gated to avoid false-positive lockouts of legit
+      // users with unusual UAs; only the warm-up paths short-circuit here
+      // and at the post-submit re-mint below.
       if (isBot()) return;
       turnstile.preMintToken().catch(() => {
         /* errors surface on the actual submit path */

--- a/website/client/utils/botDetect.ts
+++ b/website/client/utils/botDetect.ts
@@ -1,5 +1,14 @@
 import { isbot } from 'isbot';
 
+// Cache the per-session result. `navigator.userAgent` is immutable for the
+// life of the page, and `isbot()` runs a non-trivial regex match — caching
+// avoids re-parsing the UA on every Turnstile pre-mint debounce or
+// post-submit re-mint check. The SSR fallback (`navigator === undefined`)
+// is intentionally NOT cached so that if the same module instance is
+// somehow reused between SSR and CSR, the CSR path still reaches the real
+// UA check on first call.
+let cached: boolean | undefined;
+
 /**
  * Detects whether the current user agent is a bot/crawler.
  * Used to prevent automatic API calls when bots render pages with JavaScript.
@@ -8,5 +17,8 @@ export function isBot(): boolean {
   if (typeof navigator === 'undefined') {
     return false;
   }
-  return isbot(navigator.userAgent);
+  if (cached === undefined) {
+    cached = isbot(navigator.userAgent);
+  }
+  return cached;
 }

--- a/website/client/utils/botDetect.ts
+++ b/website/client/utils/botDetect.ts
@@ -1,12 +1,17 @@
 import { isbot } from 'isbot';
 
-// Cache the per-session result. `navigator.userAgent` is immutable for the
-// life of the page, and `isbot()` runs a non-trivial regex match — caching
-// avoids re-parsing the UA on every Turnstile pre-mint debounce or
-// post-submit re-mint check. The SSR fallback (`navigator === undefined`)
-// is intentionally NOT cached so that if the same module instance is
-// somehow reused between SSR and CSR, the CSR path still reaches the real
-// UA check on first call.
+// Cache the `isbot()` result keyed by the UA string itself. In a browser
+// `navigator.userAgent` is immutable for the page lifetime so this acts
+// as a per-session memo, avoiding a non-trivial regex match on every
+// Turnstile pre-mint debounce / post-submit re-mint check. In any Node
+// context where the same module instance might be reused across requests
+// (VitePress SSG, dev server, preview server with `navigator` polyfilled)
+// the UA-keyed cache invalidates automatically when a different UA shows
+// up, so a long-lived process can't hand a stale answer to the next
+// caller. The SSR fallback (`navigator === undefined`) intentionally
+// returns false without caching, since absence of UA isn't a stable
+// signal worth memoizing.
+let cachedFor: string | undefined;
 let cached: boolean | undefined;
 
 /**
@@ -17,8 +22,10 @@ export function isBot(): boolean {
   if (typeof navigator === 'undefined') {
     return false;
   }
-  if (cached === undefined) {
-    cached = isbot(navigator.userAgent);
+  const ua = navigator.userAgent;
+  if (cachedFor !== ua) {
+    cached = isbot(ua);
+    cachedFor = ua;
   }
-  return cached;
+  return cached as boolean;
 }


### PR DESCRIPTION
## Summary

The CF Turnstile dashboard shows ~17k unsolved challenges over the past 7 days vs ~10k solved — a 2:1 unsolved:solved ratio that's much larger than the post-submit auto re-mint behavior can explain. Most of those are JS-executing crawlers (Slackbot, Discord / Twitter / X card validators, Apple link preview, Googlebot, etc.) that render the page, somehow trigger a DOM input event on the URL field (autofill / accessibility tools / focus tricks), and pay a CF challenge they can't solve.

Add an `isBot()` short-circuit at the two pre-mint call sites in `usePackRequest`. The actual security gate (server-side `siteverify` in `turnstileMiddleware`) is unchanged.

## Changes

- `website/client/composables/usePackRequest.ts`:
  - `usePreMintDebounce` `onTrigger` callback returns early on `isBot()`.
  - Post-submit auto re-mint in `submitRequest`'s `finally` block also short-circuits on `isBot()`.

## Why pre-mint only, not submit

`isBot()` (`isbot` npm package) is UA-based, so false positives are possible. Gating pre-mint costs a bot-misidentified user nothing visible — `takeToken()` on the click path will cold-mint at submit time. Gating submit's `takeToken()` would lock false-positive UAs out of `/api/pack` entirely. The trade-off:
- **pre-mint gated**: dashboard counters drop, no user-visible impact even on UA misclassification (worst case: ~300-500ms cold-mint latency on click)
- **submit gated**: dashboard counters drop further, but UA misclassification = pack failure for that user

Picked the conservative side. Server-side siteverify remains the authoritative bot check.

## Expected impact

- **CF dashboard "提示チャレンジ" / "未解決" counters**: sharp drop (well-behaved crawlers stop minting unsolvable tokens).
- **`pack_completed` server logs**: unchanged. Legit users don't change paths; bots couldn't reach `/api/pack` either way.
- **siteverify spend**: unchanged.

Validates the bot-driven-traffic hypothesis from the recent access-count investigation (PRs #1544 / #1545 telemetry). If the dashboard "未解決" count drops to ~3-5k post-deploy (current 17k), it confirms ~70% of the noise was UA-detectable crawlers; if it stays high, the rest is sophisticated UA-spoofing bots that need a different layer.

## Verification

- `npm run lint`: clean
- `npm run test`: 1256/1256 pass
- Manual smoke: `isBot()` returns true for `User-Agent: Googlebot/2.1`, false for `Mozilla/5.0 ... Chrome/...`. Same path also short-circuits in `TryIt.vue:266` (commented-out auto-execution code, retained for reference).

## Test plan

- [ ] After deploy, watch CF Turnstile dashboard "提示チャレンジ" / "未解決" counts over 24h
- [ ] Confirm `pack_completed` success counts in Cloud Logging stay flat (no legit user impact)
- [ ] If "未解決" stays high, follow up with sampled UA inspection on remaining unsolved challenges to identify the bot class

🤖 Generated with [Claude Code](https://claude.com/claude-code)