### PR TITLE
chore(renovate): Group GitHub Actions, Dockerfile, and Nix updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -58,8 +58,10 @@
     },
     // GitHub Actions
     {
+      // Actions are SHA-pinned via pinact, so `pin` and `digest`
+      // updates need to be grouped alongside `minor` / `patch`.
       matchManagers: ['github-actions'],
-      matchUpdateTypes: ['minor', 'patch'],
+      matchUpdateTypes: ['minor', 'patch', 'pin', 'digest'],
       groupName: 'github-actions non-major dependencies',
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,6 +56,17 @@
       matchUpdateTypes: ['major'],
       groupName: 'scripts major dependencies',
     },
+    // GitHub Actions
+    {
+      matchManagers: ['github-actions'],
+      matchUpdateTypes: ['minor', 'patch'],
+      groupName: 'github-actions non-major dependencies',
+    },
+    {
+      matchManagers: ['github-actions'],
+      matchUpdateTypes: ['major'],
+      groupName: 'github-actions major dependencies',
+    },
   ],
   "ignoreDeps": [
     "node",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -67,6 +67,28 @@
       matchUpdateTypes: ['major'],
       groupName: 'github-actions major dependencies',
     },
+    // Dockerfiles
+    {
+      matchManagers: ['dockerfile'],
+      matchUpdateTypes: ['minor', 'patch'],
+      groupName: 'dockerfile non-major dependencies',
+    },
+    {
+      matchManagers: ['dockerfile'],
+      matchUpdateTypes: ['major'],
+      groupName: 'dockerfile major dependencies',
+    },
+    // Nix flake
+    {
+      matchManagers: ['nix'],
+      matchUpdateTypes: ['minor', 'patch'],
+      groupName: 'nix non-major dependencies',
+    },
+    {
+      matchManagers: ['nix'],
+      matchUpdateTypes: ['major'],
+      groupName: 'nix major dependencies',
+    },
   ],
   "ignoreDeps": [
     "node",


### PR DESCRIPTION
## Summary

Extend manager-based grouping in `.github/renovate.json5` so workflow / image / flake bumps batch into one PR per update channel, mirroring the existing `package.json` grouping.

- `github-actions`: workflow action version bumps
- `dockerfile`: base image bumps across root / `.devcontainer/` / `website/server/` / `website/client/`
- `nix`: `flake.nix` input bumps

Each manager gets a non-major (minor + patch) and a major group.

## Checklist

- [ ] Run \`npm run test\`
- [ ] Run \`npm run lint\`