### PR TITLE
perf(core): Automated performance tuning by Claude

### DIFF
--- a/src/core/file/fileCollect.ts
+++ b/src/core/file/fileCollect.ts
@@ -10,6 +10,10 @@ import type { RawFile } from './fileTypes.js';
 // 50 balances I/O throughput with FD/memory safety across different machines.
 const FILE_COLLECT_CONCURRENCY = 50;
 
+// Default batch size for the optional `onBatch` streaming callback. Matches
+// the security-check worker batch size so caller-side re-batching is unnecessary.
+const DEFAULT_STREAM_BATCH_SIZE = 50;
+
 export interface SkippedFileInfo {
   path: string;
   reason: FileSkipReason;
@@ -18,6 +22,21 @@ export interface SkippedFileInfo {
 export interface FileCollectResults {
   rawFiles: RawFile[];
   skippedFiles: SkippedFileInfo[];
+}
+
+export interface CollectFilesOptions {
+  /**
+   * Fires synchronously each time `streamBatchSize` raw files have been read,
+   * letting downstream consumers (e.g. the security check) start work while
+   * collection is still in flight. The callback runs on the main event-loop
+   * tick that completed the file read; do not `await` long-running work
+   * inside it — return quickly (e.g. dispatch to a worker pool and stash the
+   * promise for later) so the read pool keeps draining.
+   * The final partial batch (if any) is delivered after all reads complete.
+   */
+  onBatch?: (batch: RawFile[]) => void;
+  /** Defaults to {@link DEFAULT_STREAM_BATCH_SIZE} (50). */
+  streamBatchSize?: number;
 }
 
 const promisePool = async <T, R>(items: T[], concurrency: number, fn: (item: T) => Promise<R>): Promise<R[]> => {
@@ -44,6 +63,7 @@ export const collectFiles = async (
   deps = {
     readRawFile: defaultReadRawFile,
   },
+  options: CollectFilesOptions = {},
 ): Promise<FileCollectResults> => {
   const startTime = process.hrtime.bigint();
   logger.trace(`Starting file collection for ${filePaths.length} files`);
@@ -51,6 +71,19 @@ export const collectFiles = async (
   let completedTasks = 0;
   const totalTasks = filePaths.length;
   const maxFileSize = config.input.maxFileSize;
+
+  // Streaming-batch state: keep a pending bucket of successfully-read files and
+  // hand it off to `onBatch` whenever it reaches the configured size. This lets
+  // the security check overlap with the rest of file I/O instead of running
+  // strictly afterwards. `pendingBatch` is shared across the up-to-50 concurrent
+  // promisePool coroutines, but the push + length check + swap below is a
+  // synchronous sequence between two `await` points (`readRawFile` above and
+  // the implicit yield on the next loop iteration), so JavaScript's
+  // single-threaded execution guarantees no other coroutine observes the
+  // intermediate state.
+  const onBatch = options.onBatch;
+  const streamBatchSize = options.streamBatchSize ?? DEFAULT_STREAM_BATCH_SIZE;
+  let pendingBatch: RawFile[] = [];
 
   const results = await promisePool(filePaths, FILE_COLLECT_CONCURRENCY, async (filePath) => {
     const fullPath = path.resolve(rootDir, filePath);
@@ -60,8 +93,25 @@ export const collectFiles = async (
     progressCallback(`Collect file... (${completedTasks}/${totalTasks}) ${pc.dim(filePath)}`);
     logger.trace(`Collect files... (${completedTasks}/${totalTasks}) ${filePath}`);
 
+    if (onBatch !== undefined && result.content !== null) {
+      pendingBatch.push({ path: filePath, content: result.content });
+      if (pendingBatch.length >= streamBatchSize) {
+        const flushed = pendingBatch;
+        pendingBatch = [];
+        onBatch(flushed);
+      }
+    }
+
     return { filePath, result };
   });
+
+  // Flush the final partial batch — collectFiles guarantees onBatch has seen
+  // every successfully-read file before returning.
+  if (onBatch !== undefined && pendingBatch.length > 0) {
+    const flushed = pendingBatch;
+    pendingBatch = [];
+    onBatch(flushed);
+  }
 
   const rawFiles: RawFile[] = [];
   const skippedFiles: SkippedFileInfo[] = [];

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -197,6 +197,39 @@ export const pack = async (
     // This overlaps the ~50 ms load with the collectFiles + security-check phase.
     prefetchCompiledTemplate(config.output.style);
 
+    // Stream collected file batches into the security worker pool while
+    // collectFiles is still in flight. The security check normally runs
+    // sequentially after file collection finishes (~95 ms wall on a 1k-file
+    // warm run), but its only file-content dependency is the rawFiles array;
+    // by handing each 50-file batch off to the pre-warmed security task
+    // runner the moment it is ready, the per-file scan overlaps with the
+    // remaining file reads instead of stretching the critical path. The
+    // git-diff/log items are dispatched later inside `validateFileSafety`
+    // because they are produced by the parallel git operations and would
+    // otherwise force us to stall.
+    const securityTaskRunner = securityTaskRunnerWithWarmup?.taskRunner;
+    const prefiredSecurityBatchPromises: Promise<(SuspiciousFileResult | null)[]>[] = [];
+    const onSecurityBatch =
+      config.security.enableSecurityCheck && securityTaskRunner
+        ? (batch: { path: string; content: string }[]) => {
+            if (batch.length === 0) return;
+            const dispatched = securityTaskRunner.run({
+              items: batch.map((file) => ({
+                filePath: file.path,
+                content: file.content,
+                type: 'file',
+              })),
+            });
+            // Attach a no-op catch so a worker rejection does not surface as an
+            // unhandled-rejection warning if the pipeline aborts before
+            // `validateFileSafety` (which awaits this array via runSecurityCheck)
+            // is reached. The original promise is still pushed for awaiting,
+            // so a real failure still propagates through Promise.all.
+            dispatched.catch(() => {});
+            prefiredSecurityBatchPromises.push(dispatched);
+          }
+        : undefined;
+
     // Run file collection and git operations in parallel since they are independent:
     // - collectFiles reads file contents from disk
     // - getGitDiffs/getGitLogs spawn git subprocesses
@@ -208,7 +241,9 @@ export const pack = async (
         async () =>
           await Promise.all(
             sortedFilePathsByDir.map(({ rootDir, filePaths }) =>
-              deps.collectFiles(filePaths, rootDir, config, progressCallback),
+              deps.collectFiles(filePaths, rootDir, config, progressCallback, undefined, {
+                onBatch: onSecurityBatch,
+              }),
             ),
           ),
       ),
@@ -226,7 +261,8 @@ export const pack = async (
     const [validationResult, allProcessedFiles] = await Promise.all([
       withMemoryLogging('Security Check', () =>
         deps.validateFileSafety(rawFiles, progressCallback, config, gitDiffResult, gitLogResult, {
-          taskRunner: securityTaskRunnerWithWarmup?.taskRunner,
+          taskRunner: securityTaskRunner,
+          prefiredFileBatchPromises: onSecurityBatch ? prefiredSecurityBatchPromises : undefined,
         }),
       ),
       withMemoryLogging('Process Files', () => {

--- a/src/core/security/securityCheck.ts
+++ b/src/core/security/securityCheck.ts
@@ -96,10 +96,19 @@ export const runSecurityCheck = async (
     // Optional pre-warmed task runner. When provided, the caller owns its lifecycle
     // (creation and cleanup); when omitted, we create and clean up a fresh pool.
     taskRunner?: SecurityTaskRunner;
+    // Optional file-batch promises that the caller has already dispatched to
+    // `taskRunner` while file collection was still in flight. When supplied,
+    // `runSecurityCheck` skips its own file-batch dispatch and only batches the
+    // git-diff/git-log items + aggregates results across the merged set. This
+    // is what `pack()` uses to overlap the security check with collectFiles.
+    prefiredFileBatchPromises?: Promise<(SuspiciousFileResult | null)[]>[];
   } = {},
 ): Promise<SuspiciousFileResult[]> => {
   const initTaskRunnerFn = deps.initTaskRunner ?? initTaskRunner;
   const getProcessConcurrencyFn = deps.getProcessConcurrency ?? defaultGetProcessConcurrency;
+  const prefiredFileBatchPromises = deps.prefiredFileBatchPromises;
+  const usePrefired = prefiredFileBatchPromises !== undefined;
+
   const gitDiffItems: SecurityCheckItem[] = [];
   const gitLogItems: SecurityCheckItem[] = [];
 
@@ -133,17 +142,21 @@ export const runSecurityCheck = async (
     }
   }
 
-  const fileItems: SecurityCheckItem[] = rawFiles.map((file) => ({
-    filePath: file.path,
-    content: file.content,
-    type: 'file',
-  }));
+  // When file batches are pre-fired, only the git-content items still need to
+  // be dispatched here. Otherwise we batch + dispatch the rawFiles ourselves.
+  const fileItems: SecurityCheckItem[] = usePrefired
+    ? []
+    : rawFiles.map((file) => ({
+        filePath: file.path,
+        content: file.content,
+        type: 'file',
+      }));
 
-  // Combine all items, then split into batches
-  const allItems = [...fileItems, ...gitDiffItems, ...gitLogItems];
-  const totalItems = allItems.length;
+  const itemsToBatch = [...fileItems, ...gitDiffItems, ...gitLogItems];
+  const fileItemCount = usePrefired ? rawFiles.length : fileItems.length;
+  const totalItems = fileItemCount + gitDiffItems.length + gitLogItems.length;
 
-  if (totalItems === 0) {
+  if (totalItems === 0 && (!usePrefired || prefiredFileBatchPromises.length === 0)) {
     return [];
   }
 
@@ -159,30 +172,49 @@ export const runSecurityCheck = async (
       maxWorkerThreads: Math.min(MAX_SECURITY_WORKER_THREADS, getProcessConcurrencyFn()),
     });
 
-  // Split items into batches to reduce IPC round-trips
+  // Batches we still need to dispatch from this call (git diff/log only when
+  // pre-fired, all items otherwise).
   const batches: SecurityCheckItem[][] = [];
-  for (let i = 0; i < allItems.length; i += BATCH_SIZE) {
-    batches.push(allItems.slice(i, i + BATCH_SIZE));
+  for (let i = 0; i < itemsToBatch.length; i += BATCH_SIZE) {
+    batches.push(itemsToBatch.slice(i, i + BATCH_SIZE));
   }
 
+  const totalBatches = batches.length + (usePrefired ? prefiredFileBatchPromises.length : 0);
+
   try {
-    logger.trace(`Starting security check for ${totalItems} files/content in ${batches.length} batches`);
+    logger.trace(`Starting security check for ${totalItems} files/content in ${totalBatches} batches`);
     const startTime = process.hrtime.bigint();
 
     let completedItems = 0;
+    const totalForProgress = totalItems;
 
-    const batchResults = await Promise.all(
-      batches.map(async (batch) => {
-        const results = await taskRunner.run({ items: batch });
+    const newBatchPromises = batches.map(async (batch) => {
+      const results = await taskRunner.run({ items: batch });
 
-        completedItems += batch.length;
-        const lastItem = batch[batch.length - 1];
-        progressCallback(`Running security check... (${completedItems}/${totalItems}) ${pc.dim(lastItem.filePath)}`);
-        logger.trace(`Running security check... (${completedItems}/${totalItems}) ${lastItem.filePath}`);
+      completedItems += batch.length;
+      const lastItem = batch[batch.length - 1];
+      progressCallback(
+        `Running security check... (${completedItems}/${totalForProgress}) ${pc.dim(lastItem.filePath)}`,
+      );
+      logger.trace(`Running security check... (${completedItems}/${totalForProgress}) ${lastItem.filePath}`);
 
-        return results;
-      }),
-    );
+      return results;
+    });
+
+    // Pre-fired batches just need to be awaited and counted toward progress.
+    const prefiredAwaits = usePrefired
+      ? prefiredFileBatchPromises.map((p, idx) =>
+          p.then((results) => {
+            completedItems += results.length;
+            progressCallback(
+              `Running security check... (${completedItems}/${totalForProgress}) batch ${idx + 1}/${prefiredFileBatchPromises.length}`,
+            );
+            return results;
+          }),
+        )
+      : [];
+
+    const batchResults = await Promise.all([...newBatchPromises, ...prefiredAwaits]);
 
     const endTime = process.hrtime.bigint();
     const duration = Number(endTime - startTime) / 1e6;

--- a/src/core/security/validateFileSafety.ts
+++ b/src/core/security/validateFileSafety.ts
@@ -23,6 +23,11 @@ export const validateFileSafety = async (
     // reuses it instead of creating a fresh pool, letting the caller (packager)
     // overlap worker module loading with earlier pipeline phases.
     taskRunner?: SecurityTaskRunner;
+    // File-batch promises that the caller (packager) already dispatched while
+    // collectFiles was streaming raw files in. When provided, `runSecurityCheck`
+    // skips re-batching the same files and only awaits these promises +
+    // dispatches the git-diff/log items.
+    prefiredFileBatchPromises?: Promise<(SuspiciousFileResult | null)[]>[];
   } = {},
 ) => {
   const runSecurityCheckFn = deps.runSecurityCheck ?? runSecurityCheck;
@@ -36,6 +41,7 @@ export const validateFileSafety = async (
     progressCallback('Running security check...');
     const allResults = await runSecurityCheckFn(rawFiles, progressCallback, gitDiffResult, gitLogResult, {
       taskRunner: deps.taskRunner,
+      prefiredFileBatchPromises: deps.prefiredFileBatchPromises,
     });
 
     // Separate Git diff and Git log results from regular file results

--- a/tests/core/file/fileCollect.test.ts
+++ b/tests/core/file/fileCollect.test.ts
@@ -143,4 +143,71 @@ describe('fileCollect', () => {
 
     expect(mockProgress).toHaveBeenCalledTimes(2);
   });
+
+  describe('onBatch streaming', () => {
+    it('should emit a batch once streamBatchSize successful reads have accumulated', async () => {
+      const mockFilePaths = ['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt'];
+      const mockConfig = createMockConfig();
+      mockReadRawFile.mockResolvedValue({ content: 'content' });
+
+      const onBatch = vi.fn();
+      await collectFiles(
+        mockFilePaths,
+        '/root',
+        mockConfig,
+        () => {},
+        { readRawFile: mockReadRawFile },
+        { onBatch, streamBatchSize: 2 },
+      );
+
+      // 5 successful reads with batchSize=2 → batches of 2, 2, and a final partial batch of 1
+      expect(onBatch).toHaveBeenCalledTimes(3);
+      expect(onBatch.mock.calls[0][0]).toHaveLength(2);
+      expect(onBatch.mock.calls[1][0]).toHaveLength(2);
+      expect(onBatch.mock.calls[2][0]).toHaveLength(1);
+
+      // Every collected file is delivered to onBatch exactly once.
+      const seen = onBatch.mock.calls.flatMap((call) => call[0].map((f: { path: string }) => f.path)).sort();
+      expect(seen).toEqual(['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt']);
+    });
+
+    it('should not emit skipped files via onBatch', async () => {
+      const mockFilePaths = ['ok.txt', 'skip.bin', 'ok2.txt'];
+      const mockConfig = createMockConfig();
+      mockReadRawFile.mockImplementation(async (filePath) => {
+        if (filePath.endsWith('skip.bin')) {
+          return { content: null, skippedReason: 'binary-extension' };
+        }
+        return { content: 'content' };
+      });
+
+      const onBatch = vi.fn();
+      await collectFiles(
+        mockFilePaths,
+        '/root',
+        mockConfig,
+        () => {},
+        { readRawFile: mockReadRawFile },
+        { onBatch, streamBatchSize: 5 },
+      );
+
+      // The 2 successful reads are delivered as a single final partial batch.
+      expect(onBatch).toHaveBeenCalledTimes(1);
+      expect(onBatch.mock.calls[0][0]).toEqual([
+        { path: 'ok.txt', content: 'content' },
+        { path: 'ok2.txt', content: 'content' },
+      ]);
+    });
+
+    it('should not emit when no files are collected (only skipped files)', async () => {
+      const mockFilePaths = ['skip.bin'];
+      const mockConfig = createMockConfig();
+      mockReadRawFile.mockResolvedValue({ content: null, skippedReason: 'binary-extension' });
+
+      const onBatch = vi.fn();
+      await collectFiles(mockFilePaths, '/root', mockConfig, () => {}, { readRawFile: mockReadRawFile }, { onBatch });
+
+      expect(onBatch).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/core/packager.test.ts
+++ b/tests/core/packager.test.ts
@@ -87,7 +87,16 @@ describe('packager', () => {
     const result = await pack(['root'], mockConfig, progressCallback, mockDeps);
 
     expect(mockDeps.searchFiles).toHaveBeenCalledWith('root', mockConfig, undefined);
-    expect(mockDeps.collectFiles).toHaveBeenCalledWith(mockFilePaths, 'root', mockConfig, progressCallback);
+    expect(mockDeps.collectFiles).toHaveBeenCalledWith(
+      mockFilePaths,
+      'root',
+      mockConfig,
+      progressCallback,
+      undefined,
+      // Streams collected raw-file batches to the security worker pool while
+      // collectFiles is still draining; see pack() in src/core/packager.ts.
+      expect.objectContaining({ onBatch: expect.any(Function) }),
+    );
     expect(mockDeps.validateFileSafety).toHaveBeenCalled();
     expect(mockDeps.processFiles).toHaveBeenCalled();
     expect(mockDeps.produceOutput).toHaveBeenCalled();

--- a/tests/core/security/securityCheck.test.ts
+++ b/tests/core/security/securityCheck.test.ts
@@ -227,4 +227,66 @@ describe('runSecurityCheck', () => {
     // With batch size 50, all in a single batch
     expect(progressCallback).toHaveBeenCalledTimes(1);
   });
+
+  describe('prefiredFileBatchPromises', () => {
+    it('should skip its own file-batch dispatch and aggregate pre-fired results', async () => {
+      // Simulate the packager streaming path: caller has already dispatched a
+      // batch to the worker and stashed the resulting promise.
+      const prefiredResult = await securityCheckWorker({
+        items: mockFiles.map((file) => ({ filePath: file.path, content: file.content, type: 'file' })),
+      });
+      const prefiredPromise = Promise.resolve(prefiredResult);
+
+      const taskRunnerRun = vi.fn();
+      const stubTaskRunner = {
+        run: taskRunnerRun,
+        cleanup: async () => {},
+      };
+
+      const result = await runSecurityCheck([...mockFiles], () => {}, undefined, undefined, {
+        taskRunner: stubTaskRunner,
+        prefiredFileBatchPromises: [prefiredPromise],
+      });
+
+      // Files were already dispatched by the caller — runSecurityCheck must not
+      // call taskRunner.run for them again. (It would only call run if there were
+      // git-diff/log items still to dispatch, and there aren't any here.)
+      expect(taskRunnerRun).not.toHaveBeenCalled();
+
+      // Suspicious files from the pre-fired batch are still surfaced.
+      expect(result).toHaveLength(1);
+      expect(result[0].filePath).toBe('test1.js');
+    });
+
+    it('should still dispatch git diff/log items when file batches are pre-fired', async () => {
+      const prefiredResult = await securityCheckWorker({
+        items: mockFiles.map((file) => ({ filePath: file.path, content: file.content, type: 'file' })),
+      });
+      const prefiredPromise = Promise.resolve(prefiredResult);
+
+      const taskRunnerRun = vi.fn().mockImplementation(async (task: SecurityCheckTask) => {
+        return await securityCheckWorker(task);
+      });
+      const stubTaskRunner = {
+        run: taskRunnerRun,
+        cleanup: async () => {},
+      };
+
+      const gitDiffResult: GitDiffResult = {
+        workTreeDiffContent: 'diff --git a/test.js b/test.js\n+const secret = "password123";',
+        stagedDiffContent: '',
+      };
+
+      await runSecurityCheck([...mockFiles], () => {}, gitDiffResult, undefined, {
+        taskRunner: stubTaskRunner,
+        prefiredFileBatchPromises: [prefiredPromise],
+      });
+
+      // The git-diff item still needs to be dispatched — should be 1 batch.
+      expect(taskRunnerRun).toHaveBeenCalledTimes(1);
+      const dispatchedTask = taskRunnerRun.mock.calls[0][0];
+      expect(dispatchedTask.items).toHaveLength(1);
+      expect(dispatchedTask.items[0].type).toBe('gitDiff');
+    });
+  });
 });

--- a/website/client/composables/usePackRequest.ts
+++ b/website/client/composables/usePackRequest.ts
@@ -2,6 +2,7 @@ import { computed, onMounted, ref } from 'vue';
 import type { DisplayProgressStage, FileInfo, PackResult } from '../components/api/client';
 import { handlePackRequest } from '../components/utils/requestHandlers';
 import { isValidRemoteValue } from '../components/utils/validation';
+import { isBot } from '../utils/botDetect';
 import { parseUrlParameters } from '../utils/urlParams';
 import { abortMessage, acquireTurnstileToken } from './turnstileSubmit';
 import { usePackOptions } from './usePackOptions';
@@ -31,10 +32,16 @@ export function usePackRequest() {
   const uploadedFile = ref<File | null>(null);
   // True once the user has signalled real intent: typed/pasted a URL,
   // uploaded a file/folder, switched modes, or tweaked options. Used to
-  // gate the Turnstile pre-mint so URL-parameter hydration (`?repo=...`),
-  // browser autofill, form restoration, and JS-executing link unfurlers
-  // don't trigger background challenges. Set-only — once true, it stays
-  // true for the session.
+  // gate the Turnstile pre-mint so URL-parameter hydration (`?repo=...`)
+  // and form restoration don't trigger background challenges. Set-only —
+  // once true, it stays true for the session.
+  //
+  // Caveat: modern Chromium / Firefox DO fire `input` events on browser
+  // autofill, which would flip this flag through TryItUrlInput's handler
+  // and trigger a wasted pre-mint for JS-executing crawlers that have
+  // autofill-like behaviour. The `isBot()` check at the pre-mint trigger
+  // sites covers that gap for well-behaved crawler UAs; sophisticated
+  // bots that spoof UA still get filtered server-side by siteverify.
   const userTouched = ref(false);
 
   // Request states
@@ -89,6 +96,19 @@ export function usePackRequest() {
     userTouched,
     loading,
     onTrigger: () => {
+      // Skip background pre-mint for known crawlers. These visitors can't
+      // solve the Turnstile challenge anyway (the JS challenge requires
+      // real browser fingerprints), so issuing one only inflates the CF
+      // dashboard "提示チャレンジ" (issued challenges) / "未解決"
+      // (unsolved) counters without producing a usable token. The actual
+      // security gate is the server-side siteverify in
+      // turnstileMiddleware — that stays unchanged, so a crawler that
+      // spoofs UA past `isBot()` still gets blocked there. The click-path
+      // `acquireTurnstileToken()` (cold-mint at submit time) is
+      // intentionally NOT gated to avoid false-positive lockouts of legit
+      // users with unusual UAs; only the warm-up paths short-circuit here
+      // and at the post-submit re-mint below.
+      if (isBot()) return;
       turnstile.preMintToken().catch(() => {
         /* errors surface on the actual submit path */
       });
@@ -224,12 +244,14 @@ export function usePackRequest() {
         // Repeat-pack convenience: warm the cache for a likely follow-up
         // submission (option tweak + repack, or `repackWithSelectedFiles`
         // triggered from the result view). Skipped on abort/cancel since
-        // the user may have given up, and on invalid form (user may have
-        // cleared the URL mid-request). userTouched is necessarily true
+        // the user may have given up, on invalid form (user may have
+        // cleared the URL mid-request), and on bot-shaped UAs (same
+        // rationale as the debounce gate above — avoid burning a CF
+        // challenge that can't be solved). userTouched is necessarily true
         // here — it was a precondition for isSubmitValid to be true at
         // submit start. Failures swallow silently — they surface on the
         // next click via takeToken's cold path.
-        if (!controller.signal.aborted && isSubmitValid.value) {
+        if (!controller.signal.aborted && isSubmitValid.value && !isBot()) {
           turnstile.preMintToken().catch(() => {});
         }
       }

--- a/website/client/utils/botDetect.ts
+++ b/website/client/utils/botDetect.ts
@@ -1,5 +1,19 @@
 import { isbot } from 'isbot';
 
+// Cache the `isbot()` result keyed by the UA string itself. In a browser
+// `navigator.userAgent` is immutable for the page lifetime so this acts
+// as a per-session memo, avoiding a non-trivial regex match on every
+// Turnstile pre-mint debounce / post-submit re-mint check. In any Node
+// context where the same module instance might be reused across requests
+// (VitePress SSG, dev server, preview server with `navigator` polyfilled)
+// the UA-keyed cache invalidates automatically when a different UA shows
+// up, so a long-lived process can't hand a stale answer to the next
+// caller. The SSR fallback (`navigator === undefined`) intentionally
+// returns false without caching, since absence of UA isn't a stable
+// signal worth memoizing.
+let cachedFor: string | undefined;
+let cached: boolean | undefined;
+
 /**
  * Detects whether the current user agent is a bot/crawler.
  * Used to prevent automatic API calls when bots render pages with JavaScript.
@@ -8,5 +22,10 @@ export function isBot(): boolean {
   if (typeof navigator === 'undefined') {
     return false;
   }
-  return isbot(navigator.userAgent);
+  const ua = navigator.userAgent;
+  if (cachedFor !== ua) {
+    cached = isbot(ua);
+    cachedFor = ua;
+  }
+  return cached as boolean;
 }


### PR DESCRIPTION
## Summary

This PR automatically extends `perf/auto-perf-tuning` (PR #1548) with one additional, measurement-driven optimization:

> **`perf(core): Stream collected file batches into the security scan`**

The pipeline previously waited for `collectFiles` to finish before kicking off the secretlint worker pool. This change hands each ~50-file batch off to the pre-warmed security task runner the moment the read promise pool produces it, so the per-file scan overlaps with the remaining file reads (and with the parallel git diff/log subprocesses) instead of running serially after them.

> **Note on branching**: the harness for this run is restricted to push to `claude/sleepy-tesla-MQPTS`, so the changes are landing here on top of the latest `perf/auto-perf-tuning` state (with `main` merged in) rather than directly on `perf/auto-perf-tuning`. The single new commit on top is `perf(core): Stream collected file batches into the security scan` — that is the only behavioral change for this run.

---

## Single optimization included this run

### Stream collected file batches into the security scan

**Before**

```
collectFiles (~280 ms)  ──►  validateFileSafety
                                   └─ runSecurityCheck
                                        └─ batch + dispatch all rawFiles
                                        └─ workers process (~95 ms wall)
                                        └─ aggregate
```

**After**

```
collectFiles  ──►  every 50 files → onBatch(batch)
                              └─ securityTaskRunner.run({items}) (immediate)
                              └─ promise stashed in `prefiredSecurityBatchPromises`
   └─ collectFiles done
                                                                ▼
                              validateFileSafety
                                   └─ runSecurityCheck
                                        └─ skip re-batching files
                                        └─ batch + dispatch git-diff/log items only
                                        └─ Promise.all(prefiredFileBatchPromises + new)
                                        └─ aggregate
```

By the time `runSecurityCheck` is awaited, most batches have already been processed (only the tail + git items remain). On the repomix self-pack the `Security check completed in …` trace drops from ~95 ms to ~30 ms.

### Behavioral parity

- Same `SecurityCheckItem` payload reaches the worker; secretlint runs against the same bytes.
- File order is unchanged in the returned `rawFiles` array; only the security scan's input ordering shifts, and `runSecurityCheck` does not depend on input order.
- Both the legacy path (no pre-fired promises) and the new path return the same `SuspiciousFileResult[]` shape; downstream filtering (`suspiciousPathSet`) is identical.
- The streaming path is gated on the same conditions that already create a pre-warmed pool (`enableSecurityCheck` + `securityTaskRunner` from `createSecurityTaskRunner`). Paths without a pre-warmed pool (`--no-security-check`, `hasExplicitScope=true`, MCP-style direct callers) keep the original serial behavior.
- A no-op `.catch(() => {})` is attached to the dispatched promise to suppress an `unhandledRejection` warning in the rare case the pipeline aborts before `validateFileSafety` (the original promise is still pushed and re-throws through `Promise.all` if a real failure occurs).

### Files changed

| File | What |
|---|---|
| `src/core/file/fileCollect.ts` | Add optional `onBatch(batch)` + `streamBatchSize` (default 50). Single shared `pendingBatch` is safe under JS single-thread semantics; the push + length-check + swap is atomic between `await` points. |
| `src/core/packager.ts` | Register `onSecurityBatch` when `enableSecurityCheck && securityTaskRunner !== undefined`; dispatch each batch synchronously to the worker pool and stash promise. Pass it to `validateFileSafety` via `prefiredFileBatchPromises`. |
| `src/core/security/securityCheck.ts` | New `prefiredFileBatchPromises` deps field on `runSecurityCheck`. When supplied, skip re-batching file items and aggregate across both new git-item batches and the pre-fired promises. |
| `src/core/security/validateFileSafety.ts` | Forward `prefiredFileBatchPromises` from caller to `runSecurityCheck`. |
| `tests/core/file/fileCollect.test.ts` | New tests: batch flush at threshold, final partial batch, skipped files not delivered, no-emit when nothing collected. |
| `tests/core/security/securityCheck.test.ts` | New tests: prefired-batches path skips re-dispatch but still runs git-diff items + aggregates results correctly. |
| `tests/core/packager.test.ts` | Mock expectation updated to include the new `onBatch` option passed to `collectFiles`. |

---

## Benchmark

Repository: this repo (~1047 files, ~5 MB XML output), warm token-count cache (the disk cache from PR #1548).

### Paired benchmark (n=15, alternating MOD/BASE; baseline = HEAD~1, i.e. perf/auto-perf-tuning before this commit)

```
MOD  mean = 0.924s
BASE mean = 0.961s
DIFF mean = 0.037s (3.90%)
       sd = 0.054s,  se = 0.014s
       t  = 2.76 (df=14)
       faster = 10/15
```

### Larger pool (n=57 across earlier paired runs; same commit, same workload)

```
MOD  mean = 0.978s
BASE mean = 1.029s
DIFF mean = 0.052s (5.03%)
       sd = 0.068s,  se = 0.009s
       t  = 5.78 (df=56),  p < 0.0001
       faster = 45/57 (79%)
```

### Verbose phase trace

```
Before:                                    After:
File collection      ~283 ms              File collection      ~285 ms
Security check       ~95 ms      ── ►     Security check       ~30 ms
File processing      ~28 ms                File processing      ~28 ms
File metrics         ~14 ms                File metrics         ~14 ms (cache)
```

`Security check completed in …` trace drops by ~65 ms because most pre-fired batches finish on the worker pool while file collection is still in flight.

### Path coverage

- Default unconstrained scan (`enableSecurityCheck=true`, `hasExplicitScope=false`): **streaming on**, full benefit.
- `--no-security-check`: streaming inert (`onSecurityBatch=undefined`); behavior identical to `main`.
- `--include 'src,tests'` / `config.include` / `--stdin`: `securityTaskRunnerWithWarmup` stays `null`, streaming inert; behavior identical to `main`.
- MCP / `runSecurityCheck` direct callers: no `prefiredFileBatchPromises` argument, default path unchanged.

---

## Test plan

- [x] `npm run lint` — clean (0 warnings, 0 errors from oxlint; 2 pre-existing biome warnings on unrelated files).
- [x] `npm run test` — 1265/1265 passing (was 1260; +5 new tests covering the new `onBatch` callback semantics and the `prefiredFileBatchPromises` aggregation in `runSecurityCheck`).
- [x] Smoke tests with `--no-security-check`, `--include 'src'`, `--style markdown`, `--style json`: all produce identical output to `main` (modulo the new code being included in the self-pack).
- [x] Paired benchmark confirms ≥ 2 % wall-clock improvement (warm cache, 3.9 % small sample / 5.0 % larger sample, t > 2.7).

---
_Generated by [Claude Code](https://claude.ai/code/session_01222vPPowwygsyHWnQ7HxZm)_