### PR TITLE
docs(github-actions): add opt-in understand-quickly publish snippet

### DIFF
--- a/website/client/src/en/guide/github-actions.md
+++ b/website/client/src/en/guide/github-actions.md
@@ -131,7 +131,7 @@ See the [complete workflow example](https://github.com/yamadashy/repomix/blob/ma
 
 [`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) is a public, machine-readable registry of code-knowledge and code-context artifacts. It indexes Repomix output through its [`bundle@1`](https://github.com/looptech-ai/understand-quickly/blob/main/schemas/bundle@1.json) format so AI agents (Claude, Codex, Cursor via MCP) can resolve a repo URL to its packed-context bundle.
 
-Publishing is opt-in. Drop this workflow into `.github/workflows/understand-quickly-publish.yml` to pack with Repomix and publish a small JSON pointer (the body stays in your repo and is fetched from `raw.githubusercontent.com`):
+Publishing is opt-in and only runs for public repos (the body is fetched from `raw.githubusercontent.com`). The workflow packs with Repomix, commits the output to a dedicated `understand-quickly` branch (so the URL is reachable), then publishes a small JSON pointer pinned to that commit SHA. Drop this into `.github/workflows/understand-quickly-publish.yml`:
 
 ```yaml
 name: understand-quickly publish
@@ -141,27 +141,42 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions: { contents: read }
+    permissions: { contents: write }   # needs write to commit packed output
     steps:
       - uses: actions/checkout@v4
-      - uses: yamadashy/repomix/.github/actions/repomix@main
+      - uses: yamadashy/repomix/.github/actions/repomix@main   # consider pinning @<sha>
         with: { output: repomix-output.xml, style: xml }
+      - name: Commit packed output to understand-quickly branch
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout --orphan understand-quickly
+          git rm -rf --cached . >/dev/null 2>&1 || true
+          git add -f repomix-output.xml
+          git commit -m "chore(uq): publish $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          git push --force origin understand-quickly
+          echo "UQ_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
       - name: Build bundle@1 sidecar
+        env:
+          REPO: ${{ github.repository }}
+          SHA: ${{ env.UQ_SHA }}
         run: |
           node -e "
             const fs=require('fs');
             const b=fs.statSync('repomix-output.xml').size;
             fs.writeFileSync('repomix-output.bundle.json', JSON.stringify({
               format:'bundle@1',
-              manifest:{tool:'repomix',tool_version:'latest',generated_at:new Date().toISOString(),
-                file_count:0,byte_count:b,token_estimate:Math.round(b/4),format:'xml'},
-              content_url:'https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/repomix-output.xml'
+              manifest:{tool:'repomix',generated_at:new Date().toISOString(),
+                byte_count:b,token_estimate:Math.round(b/4),format:'xml'},
+              content_url:\`https://raw.githubusercontent.com/\${process.env.REPO}/\${process.env.SHA}/repomix-output.xml\`
             },null,2));"
-      - uses: looptech-ai/uq-publish-action@v0.1.0
+      - uses: looptech-ai/uq-publish-action@v0.1.0   # consider pinning @<sha>
         with:
           graph-path: repomix-output.bundle.json
           format: bundle@1
           token: ${{ secrets.UNDERSTAND_QUICKLY_TOKEN }}
 ```
 
-Set `UNDERSTAND_QUICKLY_TOKEN` to a fine-grained PAT with `Repository dispatches: write` on `looptech-ai/understand-quickly` only. Register your repo once via [`npx @understand-quickly/cli add`](https://github.com/looptech-ai/understand-quickly#add-a-repo) or the [wizard](https://looptech-ai.github.io/understand-quickly/add.html); subsequent pushes auto-refresh. See the [protocol](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md) and [DATA-LICENSE.md](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) for the data-grant semantics — submission is opt-in, gated on the secret being set.
+Set `UNDERSTAND_QUICKLY_TOKEN` to a fine-grained PAT with `Repository dispatches: write` on `looptech-ai/understand-quickly` only. Register your repo once via [`npx @understand-quickly/cli add`](https://github.com/looptech-ai/understand-quickly#add-a-repo) or the [wizard](https://looptech-ai.github.io/understand-quickly/add.html); subsequent pushes auto-refresh. See the [protocol](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md) and [DATA-LICENSE.md](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) for the data-grant semantics — submission is opt-in, gated on the secret being set, and only suitable for public repos.

--- a/website/client/src/en/guide/github-actions.md
+++ b/website/client/src/en/guide/github-actions.md
@@ -126,3 +126,42 @@ jobs:
 ```
 
 See the [complete workflow example](https://github.com/yamadashy/repomix/blob/main/.github/workflows/pack-repository.yml).
+
+## Publishing to the understand-quickly registry
+
+[`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) is a public, machine-readable registry of code-knowledge and code-context artifacts. It indexes Repomix output through its [`bundle@1`](https://github.com/looptech-ai/understand-quickly/blob/main/schemas/bundle@1.json) format so AI agents (Claude, Codex, Cursor via MCP) can resolve a repo URL to its packed-context bundle.
+
+Publishing is opt-in. Drop this workflow into `.github/workflows/understand-quickly-publish.yml` to pack with Repomix and publish a small JSON pointer (the body stays in your repo and is fetched from `raw.githubusercontent.com`):
+
+```yaml
+name: understand-quickly publish
+on:
+  push:
+    branches: [main]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions: { contents: read }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: yamadashy/repomix/.github/actions/repomix@main
+        with: { output: repomix-output.xml, style: xml }
+      - name: Build bundle@1 sidecar
+        run: |
+          node -e "
+            const fs=require('fs');
+            const b=fs.statSync('repomix-output.xml').size;
+            fs.writeFileSync('repomix-output.bundle.json', JSON.stringify({
+              format:'bundle@1',
+              manifest:{tool:'repomix',tool_version:'latest',generated_at:new Date().toISOString(),
+                file_count:0,byte_count:b,token_estimate:Math.round(b/4),format:'xml'},
+              content_url:'https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/repomix-output.xml'
+            },null,2));"
+      - uses: looptech-ai/uq-publish-action@v0.1.0
+        with:
+          graph-path: repomix-output.bundle.json
+          format: bundle@1
+          token: ${{ secrets.UNDERSTAND_QUICKLY_TOKEN }}
+```
+
+Set `UNDERSTAND_QUICKLY_TOKEN` to a fine-grained PAT with `Repository dispatches: write` on `looptech-ai/understand-quickly` only. Register your repo once via [`npx @understand-quickly/cli add`](https://github.com/looptech-ai/understand-quickly#add-a-repo) or the [wizard](https://looptech-ai.github.io/understand-quickly/add.html); subsequent pushes auto-refresh. See the [protocol](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md) and [DATA-LICENSE.md](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) for the data-grant semantics — submission is opt-in, gated on the secret being set.


### PR DESCRIPTION
## Why

[`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) is a public, machine-readable registry of code-knowledge and code-context artifacts. It indexes Repomix output through its [`bundle@1`](https://github.com/looptech-ai/understand-quickly/blob/main/schemas/bundle@1.json) format — a tiny JSON pointer plus a raw URL to the packed body — so AI agents (Claude, Codex, Cursor via MCP) can resolve a repo URL to its Repomix-packed context. The registry stores no bodies; the XML/markdown stays in the user's repo.

This PR documents the opt-in workflow for Repomix users who want their packed output to land in the registry. No CLI changes, no runtime changes — only the GitHub Actions guide gets a new subsection.

## What changes

- `website/client/src/en/guide/github-actions.md`: appends a "Publishing to the understand-quickly registry" subsection (~30 lines of YAML + ~5 lines of prose) showing how to chain the existing `yamadashy/repomix/.github/actions/repomix` action with the new [`looptech-ai/uq-publish-action@v0.1.0`](https://github.com/looptech-ai/uq-publish-action) Marketplace Action. The snippet builds a small bundle@1 sidecar (file size, generated_at, content_url) and hands it off to publish.

## Opt-in / no-op

Submission is gated entirely on the user setting `UNDERSTAND_QUICKLY_TOKEN` (a fine-grained PAT scoped to `looptech-ai/understand-quickly` only with `Repository dispatches: write`). Without the secret, the publish action only stamps metadata locally and exits cleanly. Without the workflow file, nothing changes.

## Why no CLI change

The flow is entirely orchestrated in Actions: Repomix already emits the packed body, the Marketplace Action builds the bundle@1 sidecar and posts the dispatch. Keeping the integration on the CI side means no new flag in the CLI surface, no test churn, and no behavior change for anyone not opting in.

## Test plan

- [x] Diff is docs-only (39 LoC added to one existing English guide page).
- [x] No tests touched, no `package.json`/`biome` changes, no lint impact.
- [ ] (Reviewer) Render of the page in the docs preview shows the new section under \"Example: Full Workflow\".

## Notes

- This is opt-in for early adopters; nothing in Repomix's existing surface changes.
- License & data-grant semantics for users who opt in are described in [`DATA-LICENSE.md`](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) and [protocol §12](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#12-licensing-of-submitted-data) — opt-in, gated on the secret, never invisible.
- Localized copies (de/es/fr/ja/ko/zh-cn/etc.) intentionally omitted; happy to follow up with translations if you'd prefer them in the same PR.

## Links

- Registry: <https://github.com/looptech-ai/understand-quickly>
- Producer protocol: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md>
- bundle@1 schema: <https://github.com/looptech-ai/understand-quickly/blob/main/schemas/bundle@1.json>
- Marketplace Action: <https://github.com/looptech-ai/uq-publish-action>