### PR TITLE
chore(skills): Add agent-carnet skill for repository-local notebook

### DIFF
--- a/.agents/skills/agent-carnet/SKILL.md
+++ b/.agents/skills/agent-carnet/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: agent-carnet
+description: "Use this skill when the user asks to save, recall, find, or organize notes. Triggers on: 'remember this', 'save this', 'note this', 'what did we discuss about...', 'check the notebook', 'find in carnet'. Also use proactively when discovering findings worth preserving across sessions."
+---
+
+# Agent Carnet
+
+A tiny CLI that gives you a shared markdown notebook on disk under `.carnet/<category>/<slug>.md`. Notes have a 30-day default lifespan that resets every time they are read or applied; useful ones survive, stale ones drift to `.trash/` automatically.
+
+## Quick reference
+
+```bash
+# Save (always pass --summary and --agent claude-code)
+echo "body content" | agent-carnet save deps/iconv-issue \
+  --summary "iconv-esm v0.7 types broken — pin to v0.6" \
+  --agent claude-code \
+  --tags compat,esm
+
+# Recall
+agent-carnet find iconv               # search summaries (does NOT bump lifespan)
+agent-carnet list                     # category-grouped overview, sorted by last_used
+agent-carnet list --sort use_count    # most-applied notes first
+agent-carnet show deps/iconv-issue    # read full content (bumps last_used; weak use signal)
+
+# Mark as actually applied (strong use signal — bumps last_used + use_count)
+agent-carnet used deps/iconv-issue
+
+# Maintain
+agent-carnet move <from> <to>
+agent-carnet rm <path> --yes
+```
+
+When unsure of a subcommand's full flag set, run `agent-carnet <command> -h` (e.g.
+`agent-carnet save -h`, `agent-carnet used -h`). Each subcommand prints its own
+focused help — required arguments, options, and examples — without invoking
+filesystem operations.
+
+## When to save
+
+Save proactively when you discover something worth preserving across sessions:
+- Research findings that took effort to derive
+- Non-obvious patterns / gotchas in the codebase
+- Solutions to tricky problems
+- Architectural decisions and the reasoning behind them
+- In-progress work that may be resumed later
+
+## When to recall
+
+Before starting related work or when context might exist:
+- `agent-carnet find <topic>` — quick scan of summaries
+- `agent-carnet list <category>` — browse a folder
+- `agent-carnet show <path>` — actually read (resets `last_used`; only use when the content matters)
+
+## When to call `used`
+
+Call `agent-carnet used <path>` after a carnet **actually shaped your work**:
+- You applied the recorded fix and it solved the bug.
+- You consulted the carnet before retrying a hypothesis and skipped a dead-end.
+- You used the canonical name from a `vocab` carnet in new code instead of inventing your own.
+
+`used` increments `use_count` — a durable importance signal that survives across sessions and lets future readers (and `agent-carnet list --sort use_count`) surface load-bearing notes.
+
+Reading a carnet does NOT count. `show` already keeps it alive (weak signal); `used` records that the note was worth keeping for a real reason (strong signal).
+
+## Hard rules
+
+- `--summary` is required. Make it decisive — reading the summary in isolation tells the next reader (or the next agent) whether to read further.
+- `--agent claude-code` is required.
+- `find` does NOT bump anything. `show` bumps `last_used`. `used` bumps `last_used` AND increments `use_count`.
+- `updated` tracks content modification only (`save`, `save --update`). It is independent of `last_used` and is not the lifespan driver.
+- The 30-day expiry is automatic — do not manually clean up. `keep: true` pins permanent notes.
+- Auto-prune runs on every CLI invocation; deleted carnets land in `.carnet/.trash/` for 7 days before hard delete.
+
+## Path conventions
+
+- `<category>/<slug>` — kebab-case, no leading slash, no `..`.
+- Categories are folders; create new ones freely as needed.
+- Subcategories are allowed: `deps/esm/iconv-issue` works.
+
+## When to read references/
+
+This SKILL.md is enough for everyday note-keeping. Open the references/ files **only** when one of these specific cases applies — they are not always-on context, so do not load them speculatively.
+
+| Read this file | When |
+|---|---|
+| `references/cookbook.md` | You are about to use (or are being asked about) a tag-based pattern such as `tags: [vocab]` for project terminology or `tags: [hypothesis]` for debugging dead-ends. The file shows the full pattern, including how to structure the body and `meta:` for that pattern. |
+| `references/frontmatter.md` | You need to write or read the `meta:` extension namespace, set a non-trivial `lifespan` / `keep`, or understand why an unfamiliar frontmatter field is or is not preserved on save. |
+
+If neither case applies, **do not read references/**. The base of this file already covers daily save/find/show/touch/move/rm flows.

--- a/.agents/skills/agent-carnet/references/cookbook.md
+++ b/.agents/skills/agent-carnet/references/cookbook.md
@@ -1,0 +1,103 @@
+# Cookbook patterns
+
+These are tag-based conventions that compose with the existing CLI — no new commands, no special folders. Each pattern uses `tags:` and (optionally) `meta:` to give a carnet additional structure that downstream tools or future agents can recognize.
+
+Read this file when you are about to write or read a carnet that follows one of these patterns. Do not read it for plain note-taking — the base SKILL.md is enough there.
+
+## Vocabulary alignment
+
+**Use when**: multiple agents (or a human plus an agent) keep inventing different names for the same concept across a project. Examples: "staging adapter" vs "proxy layer" vs "forward middleware" all referring to the same module.
+
+**Pattern**: one carnet per term, tagged `vocab`. The `meta.vocab.*` subtree carries machine-actionable data (canonical name, aliases) that other agents or tools can read; the body explains the *why* in narrative form.
+
+```yaml
+---
+summary: "staging adapter — the thin proxy in front of POST /v1/stage"
+agent: claude-code
+tags: [vocab]
+related:
+  - .carnet/vocab/payload-envelope.md
+  - src/staging/adapter.ts
+meta:
+  vocab:
+    canonical: staging adapter
+    aliases:
+      - proxy layer
+      - forward middleware
+      - request shim
+---
+
+# staging adapter
+
+## Definition
+The thin proxy that fronts the production gateway and reshapes incoming
+requests into the `payload-envelope` format. Nothing more.
+
+## Why this name
+"proxy" is overloaded; "middleware" collides with the Express concept.
+"staging adapter" leaves no doubt about which layer is meant.
+```
+
+**Agent flow**:
+
+1. Before naming a new concept, scan for an existing canonical name:
+   ```bash
+   agent-carnet find <candidate> --in tags
+   agent-carnet find <candidate> --in body
+   ```
+   If a vocab carnet exists, adopt that name (use it in code, in PR descriptions, in further carnets).
+2. If a name wins out as canonical, save once with the convention above. Reference it from related code or other carnets via `related:`.
+3. Refresh-on-use does the rest. Synonyms that keep getting cited stay alive; ones that nobody invokes drift to `.trash/` automatically.
+
+## Hypothesis ledger
+
+**Use when**: long debugging sessions keep producing dead-ends ("X tried, didn't work because Y") and you (or the next agent) keep re-deriving the same negative knowledge. Vector search and `CLAUDE.md` skim well for "what worked"; they're worse at "what was already tried and ruled out".
+
+**Pattern**: one carnet per hypothesis, tagged `hypothesis`. The body holds the actual reasoning (Hypothesis / Tests / Verdict). `meta.hypothesis.*` carries structured status that another tool or agent can act on without re-reading the body.
+
+```yaml
+---
+summary: "iconv-lite v0.7 esm import path — types broken upstream"
+agent: claude-code
+tags: [hypothesis]
+related:
+  - https://github.com/pillarjs/iconv-lite/issues/363
+meta:
+  hypothesis:
+    status: debunked
+    last_tested: 2026-04-30
+---
+
+## Hypothesis
+Switching to esm imports should let us run `iconv-lite` on Node 22
+(v0.7 advertises ESM support).
+
+## Tests
+1. `npm install iconv-lite@0.7.1` → type error (`Cannot find module declaration`).
+2. Set `tsconfig.moduleResolution` to `bundler` → same error.
+3. Inspected v0.7.1 source → broken `package.json#exports` types.
+
+## Verdict
+Pin to `v0.6.3`. The whole v0.7 series is broken upstream (Issue #363).
+Wait for v0.8 before retrying.
+```
+
+**Agent flow**:
+
+1. Before exploring a new theory, scan for prior hypotheses on the same area:
+   ```bash
+   agent-carnet find <symptom> --in all
+   agent-carnet find <library> --in tags
+   ```
+   If a debunked hypothesis exists, the body already has the verdict. Move on.
+2. After ruling something out, save the carnet. Use one of these statuses in `meta.hypothesis.status`:
+   - `pending` — actively being tested
+   - `confirmed` — held up
+   - `debunked` — ruled out
+3. Refresh-on-use turns staleness into signal: a debunked hypothesis nobody has needed in 30 days drops to `.trash/`. The ones that *do* keep getting cited are the load-bearing "do not retry" entries.
+
+## Adding new patterns
+
+The same shape applies to any new convention. Pick a tag name, optionally namespace structured data under `meta.<your-tag>.*`, and let the body do the rest. The CLI doesn't need to know about the pattern — `find` and `show` work the same way regardless of which tags a carnet carries.
+
+When inventing a new pattern locally, keep it documented in the project's own carnet (e.g. a `vocab/` entry whose canonical name is the pattern itself) so future agents can discover it the same way they discover any other convention.

--- a/.agents/skills/agent-carnet/references/frontmatter.md
+++ b/.agents/skills/agent-carnet/references/frontmatter.md
@@ -1,0 +1,121 @@
+# Frontmatter reference
+
+Every carnet starts with YAML frontmatter. The CLI manages a small number of fields itself; everything else is preserved untouched on round-trip, so tools and conventions can layer extra metadata on top.
+
+Read this file when you are about to write or read the `meta:` namespace, set a non-trivial `lifespan` / `keep`, or wonder whether an unfamiliar frontmatter field will survive a CLI write.
+
+## Schema
+
+```yaml
+---
+# CLI-managed (you provide these on save; usage fields update via show / used)
+summary: "one-line decisive description"   # required
+agent: claude-code                         # required (e.g. claude-code, codex, cursor, human)
+created: 2026-05-10                        # set on first save, immutable thereafter
+updated: 2026-05-10                        # bumped on save / save --update (content modification)
+last_used: 2026-05-10                      # bumped on save / show / used (drives expiry)
+use_count: 7                               # incremented on `used` only (importance signal)
+
+# Optional, CLI-known
+tags: [compat, esm]                        # free-form labels; comma-separated on save
+related:                                   # paths or other carnet paths this entry points at
+  - src/core/file/encoding.ts
+  - .carnet/deps/iconv-issue.md
+lifespan: 90d                              # override default 30d; accepts 30d / 90d / 1y / never
+keep: true                                 # pin against auto-prune (lifespan ignored)
+
+# Optional, CLI-opaque
+meta:                                      # free-form extension namespace; see "meta:" below
+  <extension>:
+    <key>: <value>
+---
+```
+
+## The four CLI-managed dates / counters
+
+`agent-carnet` deliberately separates *modification* from *usage* so each can be observed and sorted independently:
+
+| Field | Bumped by | Means |
+|---|---|---|
+| `created` | `save` (first time only) | Birth date. Never changes. |
+| `updated` | `save`, `save --update` | Last content modification. |
+| `last_used` | `save`, `show`, `used` | Last interaction. Drives expiry: `expiry = last_used + lifespan`. |
+| `use_count` | `used` (only) | How many times the carnet was explicitly applied. A reference signal of importance. |
+
+`show` is a *weak* use signal — pulling the body into context counts as use enough to keep the lifespan alive but not enough to bump `use_count`. `used` is the *strong* signal — call it after the carnet actually shaped your work.
+
+## CLI-managed vs preserved fields
+
+The CLI rewrites only the fields it knows about: `summary`, `agent`, `created`, `updated`, `last_used`, `use_count`, `tags`, `related`, `lifespan`, `keep`. On `save --update`, every other top-level frontmatter key is round-tripped untouched — including `meta:` and any custom keys an external tool may have added.
+
+This is the foundation of the extension model: as long as you stay outside the CLI-managed names, your fields survive every CLI write.
+
+## `meta:` extension namespace
+
+`meta:` is a deliberate place for structured data the CLI itself does not interpret but downstream consumers can act on (an Obsidian plugin, a sibling agent, your own script, the cookbook patterns).
+
+**Conventions**:
+
+- **Namespace your keys under the convention name**: `meta.vocab.*`, `meta.hypothesis.*`, `meta.<your-tag>.*`. This avoids collisions between independent extensions.
+- Keep the values primitive when possible (strings, numbers, lists of strings). Anything more complex should probably live in the body where humans will actually read it.
+- The CLI has no `--meta` flag (yet). To set or change `meta:`, edit the carnet file directly after `save`, or have your tool write the file. The next CLI write (`save --update`, `touch`, `show`) preserves your edits.
+
+**Reading `meta:` from another tool**: parse the file with any YAML frontmatter parser (`gray-matter`, `js-yaml` with manual frontmatter split, etc.). The CLI does not require any specific tooling on the read side.
+
+**Examples by convention**:
+
+```yaml
+meta:
+  vocab:
+    canonical: staging adapter
+    aliases: [proxy layer, forward middleware]
+```
+
+```yaml
+meta:
+  hypothesis:
+    status: debunked          # pending | confirmed | debunked
+    last_tested: 2026-04-30
+```
+
+## `lifespan`
+
+Accepts duration strings via `parse-duration`:
+
+- `30d`, `7d`, `12h` — relative durations
+- `1y`, `6mo`, `2w` — longer units
+- `never` — pin against auto-prune (equivalent to `keep: true`)
+
+If both `keep: true` and `lifespan: <duration>` are set, `keep: true` wins — the carnet is never auto-pruned regardless of the duration.
+
+Setting `lifespan` is appropriate when a category of notes naturally lives longer or shorter than the 30-day default (e.g. `1y` for stable architectural decisions, `7d` for sprint-scoped notes).
+
+## `keep`
+
+`keep: true` pins a carnet against auto-prune indefinitely. Use sparingly — it defeats the "safe to forget" model. Typical uses:
+
+- Project-level reference docs that should not decay
+- Long-running design decisions whose context is needed indefinitely
+- Personal style or persona files
+
+`keep: false` is the same as omitting `keep:` (the default).
+
+## `related`
+
+`related:` accepts a list of strings. There is no enforced format; common conventions:
+
+- File paths relative to the project root: `src/core/file/encoding.ts`
+- Other carnet paths: `.carnet/<category>/<slug>.md`
+- URLs: `https://github.com/.../issues/363`
+
+The CLI does not validate that the targets exist or follow them. They are documentation, not links the CLI traverses.
+
+## What NOT to add
+
+- **A `status:` field at the top level**. There is no place for it in the schema. If you need a debugging status, use `tags: [hypothesis:debunked]` or the `meta.hypothesis.status` convention.
+- **A new top-level field for structured data**. Use `meta.<extension>.*` instead so it composes with everything else.
+- **Multi-line `summary:`**. Keep it on one line — listing and search UI assume that.
+
+## Frontmatter parse errors
+
+If a carnet's frontmatter fails to parse (invalid YAML, mismatched delimiters), the CLI exits with `frontmatter_error` and points at the offending file. Fix it by editing the file directly; the CLI will not attempt automatic repair.

--- a/.carnet/.gitignore
+++ b/.carnet/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/.carnet/README.md
+++ b/.carnet/README.md
@@ -1,0 +1,9 @@
+# .carnet/
+
+This directory is the notebook managed by [agent-carnet](https://github.com/yamadashy/agent-carnet).
+
+Agents such as Claude Code use it to store research notes, findings, and hypotheses with a 30-day TTL, as a repository-local notebook shared across sessions.
+
+## Git policy
+
+The notes under this directory are **personal** and intentionally excluded from version control. `.carnet/.gitignore` ignores everything except `.gitignore` and this `README.md`.

--- a/.claude/skills/agent-carnet
+++ b/.claude/skills/agent-carnet
@@ -1,0 +1,1 @@
+../../.agents/skills/agent-carnet

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "agent-carnet": {
+      "source": "yamadashy/agent-carnet",
+      "sourceType": "github",
+      "skillPath": "skills/agent-carnet/SKILL.md",
+      "computedHash": "eb9b255f9c60dcb052a890907b90082c442a6fa1dc8e0dd4b89995ff92af301c"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add [agent-carnet](https://github.com/yamadashy/agent-carnet) as an installable skill for AI agents working in this repo (skill files under `.agents/skills/agent-carnet/` symlinked from `.claude/skills/agent-carnet`, locked via `skills-lock.json`).
- Create a `.carnet/` directory as the on-disk notebook location, with `.carnet/.gitignore` (`*` plus `!.gitignore` / `!README.md`) so notes stay personal and out of version control.
- Add `.carnet/README.md` describing the directory's purpose and the personal-only git policy.

## Checklist

- [x] Run \`npm run test\` (1256 passed)
- [x] Run \`npm run lint\` (no errors; 2 pre-existing warnings unrelated to this change)