### PR TITLE
fix: support negated custom ignore patterns

### DIFF
--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -21,6 +21,23 @@ export interface FileSearchResult {
 // descriptor exhaustion that unbounded `Promise.all` could cause.
 const EMPTY_DIR_CHECK_CONCURRENCY = 20;
 
+const hasNegatedCustomPatterns = (patterns: string[] = []): boolean =>
+  patterns.some((pattern) => pattern.startsWith('!') && pattern.length > 1);
+
+const createCustomGlobPatterns = (patterns: string[] = []): string[] => {
+  if (!hasNegatedCustomPatterns(patterns)) {
+    return [];
+  }
+
+  return patterns
+    .map((pattern) => {
+      const isNegated = pattern.startsWith('!');
+      const normalizedPattern = normalizeGlobPattern(isNegated ? pattern.slice(1) : pattern);
+      return normalizedPattern ? (isNegated ? normalizedPattern : `!${normalizedPattern}`) : null;
+    })
+    .filter((pattern): pattern is string => pattern !== null);
+};
+
 // No per-directory ignore-pattern check is needed here. The `directories` array
 // comes from globby with the same `ignore` patterns (e.g. `dist/**`), which
 // excludes both the directory contents AND the directory entry itself.
@@ -175,6 +192,7 @@ export const searchFiles = async (
     if (includePatterns.length === 0) {
       includePatterns = ['**/*'];
     }
+    includePatterns = [...includePatterns, ...createCustomGlobPatterns(config.ignore.customPatterns)];
 
     logger.trace('Include patterns with explicit files:', includePatterns);
     logger.trace('Ignore patterns:', adjustedIgnorePatterns);
@@ -380,8 +398,10 @@ export const getIgnorePatterns = async (rootDir: string, config: RepomixConfigMe
   // Add custom ignore patterns
   if (config.ignore.customPatterns) {
     logger.trace('Adding custom ignore patterns:', config.ignore.customPatterns);
-    for (const pattern of config.ignore.customPatterns) {
-      ignorePatterns.add(pattern);
+    if (!hasNegatedCustomPatterns(config.ignore.customPatterns)) {
+      for (const pattern of config.ignore.customPatterns) {
+        ignorePatterns.add(pattern);
+      }
     }
   }
 
@@ -416,7 +436,7 @@ export const getIgnorePatterns = async (rootDir: string, config: RepomixConfigMe
 export const listDirectories = async (rootDir: string, config: RepomixConfigMerged): Promise<string[]> => {
   const { adjustedIgnorePatterns, ignoreFilePatterns } = await prepareIgnoreContext(rootDir, config);
 
-  const directories = await globby(['**/*'], {
+  const directories = await globby(['**/*', ...createCustomGlobPatterns(config.ignore.customPatterns)], {
     ...createBaseGlobbyOptions(rootDir, config, adjustedIgnorePatterns, ignoreFilePatterns),
     onlyDirectories: true,
   });
@@ -435,7 +455,7 @@ export const listDirectories = async (rootDir: string, config: RepomixConfigMerg
 export const listFiles = async (rootDir: string, config: RepomixConfigMerged): Promise<string[]> => {
   const { adjustedIgnorePatterns, ignoreFilePatterns } = await prepareIgnoreContext(rootDir, config);
 
-  const files = await globby(['**/*'], {
+  const files = await globby(['**/*', ...createCustomGlobPatterns(config.ignore.customPatterns)], {
     ...createBaseGlobbyOptions(rootDir, config, adjustedIgnorePatterns, ignoreFilePatterns),
     onlyFiles: true,
   });

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -21,9 +21,19 @@ export interface FileSearchResult {
 // descriptor exhaustion that unbounded `Promise.all` could cause.
 const EMPTY_DIR_CHECK_CONCURRENCY = 20;
 
+/**
+ * Returns true when custom ignore patterns include a meaningful negation.
+ * A bare `!` is ignored because it normalizes to an empty include pattern.
+ */
 const hasNegatedCustomPatterns = (patterns: string[] = []): boolean =>
   patterns.some((pattern) => pattern.startsWith('!') && pattern.length > 1);
 
+/**
+ * Converts custom ignore patterns into ordered globby include patterns when
+ * negations are present. Non-negated patterns become excludes (`dist/**` ->
+ * `!dist/**`), while negated patterns become includes (`!dist/keep.js` ->
+ * `dist/keep.js`) after normalization.
+ */
 const createCustomGlobPatterns = (patterns: string[] = []): string[] => {
   if (!hasNegatedCustomPatterns(patterns)) {
     return [];

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -1116,5 +1116,26 @@ node_modules
         expect(ignorePatterns).toEqual(expect.arrayContaining(customPatterns));
       }
     });
+
+    test('should apply negated custom ignore patterns consistently across all functions', async () => {
+      const mockConfig = createMockConfig({
+        ignore: {
+          useGitignore: false,
+          useDefaultPatterns: false,
+          customPatterns: ['dist/**', '!dist/keep.js'],
+        },
+      });
+
+      vi.mocked(globby).mockResolvedValue([]);
+
+      await searchFiles('/test/root', mockConfig);
+      await listDirectories('/test/root', mockConfig);
+      await listFiles('/test/root', mockConfig);
+
+      const calls = vi.mocked(globby).mock.calls;
+      for (const call of calls) {
+        expect(call[0]).toEqual(['**/*', '!dist/**', 'dist/keep.js']);
+      }
+    });
   });
 });

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -211,6 +211,20 @@ describe('fileSearch', () => {
       expect(patterns).toContain('temp/');
     });
 
+    test('should leave custom patterns with negations out of globby ignore patterns', async () => {
+      const mockConfig = createMockConfig({
+        ignore: {
+          useGitignore: true,
+          useDefaultPatterns: false,
+          customPatterns: ['dist/**', '!dist/keep.js'],
+        },
+      });
+
+      const patterns = await getIgnorePatterns(process.cwd(), mockConfig);
+
+      expect(patterns).toEqual(['repomix-output.xml']);
+    });
+
     test('should include patterns from .git/info/exclude when useGitignore is true', async () => {
       const mockConfig = createMockConfig({
         ignore: {
@@ -307,6 +321,29 @@ node_modules
           absolute: false,
           dot: true,
           followSymbolicLinks: false,
+        }),
+      );
+    });
+
+    test('should translate custom negation patterns into ordered globby patterns', async () => {
+      const mockConfig = createMockConfig({
+        ignore: {
+          useGitignore: false,
+          useDefaultPatterns: false,
+          customPatterns: ['dist/**', '!dist/keep.js', '!'],
+        },
+      });
+
+      vi.mocked(globby).mockResolvedValue(['src/index.ts', 'dist/keep.js']);
+
+      const result = await searchFiles('/mock/root', mockConfig);
+
+      expect(result.filePaths).toEqual(['dist/keep.js', 'src/index.ts']);
+      expect(globby).toHaveBeenCalledWith(
+        ['**/*', '!dist/**', 'dist/keep.js'],
+        expect.objectContaining({
+          ignore: expect.arrayContaining([expect.stringContaining('repomix-output.xml')]),
+          onlyFiles: true,
         }),
       );
     });


### PR DESCRIPTION
## Summary

Fixes negated entries in `ignore.customPatterns` so patterns like `dist/**` followed by `!dist/keep.js` can re-include the intended file.

Repomix was passing custom ignore patterns directly through globby's `ignore` option. That works for plain excludes, but `ignore` does not support re-inclusion with `!`, so negated custom patterns were ignored.

## Details

- Keeps the existing `ignore` option path for plain custom ignore patterns.
- When custom patterns contain a negation, translates the ordered custom pattern list into main globby patterns instead:
  - `dist/**` -> `!dist/**`
  - `!dist/keep.js` -> `dist/keep.js`
- Applies the same translation to `searchFiles`, `listFiles`, and `listDirectories`.
- Adds tests that pin both the ignore-pattern routing and the generated globby pattern order.

Fixes #400

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

## Validation

- `npm test -- tests/core/file/fileSearch.test.ts`
- `npm run build`
- `PATH="/Users/vivek/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run lint`

Notes: the local default Node is v20.15.0, while this repo requires Node >=22 and uses `node --run`; I used the bundled Node v24.14.0 for lint. npm also missed two optional native bindings initially, so I installed the missing rolldown/oxlint bindings with `--no-save` before verification. No package files were changed.