### PR TITLE
test(core): Add regression-guard specs against auto-perf-tuning silent breakages

### DIFF
--- a/tests/core/file/binaryDetectionSpec.test.ts
+++ b/tests/core/file/binaryDetectionSpec.test.ts
@@ -106,7 +106,7 @@ describe('binary detection spec', () => {
 
     expect(rawFiles).toHaveLength(1);
     expect(rawFiles[0].content).toContain('BOM-MARKER');
-    expect(rawFiles[0].content.charCodeAt(0)).not.toBe(0xfeff);
+    expect(rawFiles[0].content.startsWith('\ufeff')).toBe(false);
     expect(skippedFiles).toHaveLength(0);
   });
 });

--- a/tests/core/file/binaryDetectionSpec.test.ts
+++ b/tests/core/file/binaryDetectionSpec.test.ts
@@ -1,0 +1,112 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { collectFiles } from '../../../src/core/file/fileCollect.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+// Behavior-level regression tests for binary detection at the file-read layer.
+//
+// PR #1542 needed two follow-up fixes (`5ab82d51` mirroring isbinaryfile's PDF
+// magic + suspicious-byte ratio rules, and `35e40fcd` replacing the JS NULL-byte
+// loop with `Buffer.indexOf` SIMD scan) before the cheap pre-screen lined up
+// with the full `isbinaryfile` check. Any future perf optimization that
+// re-tweaks the binary fast-paths must keep these contracts:
+//
+//   - Binaries flagged by extension are skipped without reading content.
+//   - Binaries flagged by content (NULL bytes; PDF-shaped buffers; non-UTF-8
+//     binary payloads) are skipped before reaching the packed output.
+//   - UTF-8 text — with or without BOM — is preserved and reaches the output.
+//
+// Fixtures deliberately mix extension-fast-path and content-detection-path
+// cases. A perf change that accidentally trusts the extension and skips the
+// content probe would let `payload.data` slip through; a change that
+// over-rejects valid UTF-8 (including BOM-marked files) would drop `bom.ts`.
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const PDF_HEADER = Buffer.from('%PDF-1.4\n%\xe2\xe3\xcf\xd3\n', 'binary');
+const PDF_BINARY_TAIL = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x80, 0x81, 0x82, 0x83, 0xff, 0xfe, 0xfd, 0xfc]);
+const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf]);
+
+describe('binary detection spec', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-binary-spec-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('skips binaries identified by extension (PNG) without including their bytes', async () => {
+    await fs.writeFile(path.join(tmpDir, 'image.png'), Buffer.concat([PNG_MAGIC, Buffer.alloc(64, 0xff)]));
+    await fs.writeFile(path.join(tmpDir, 'clean.ts'), 'export const greet = (n: string) => `hi ${n}`;\n');
+
+    const { rawFiles, skippedFiles } = await collectFiles(['image.png', 'clean.ts'], tmpDir, createMockConfig());
+
+    expect(rawFiles.map((f) => f.path)).toEqual(['clean.ts']);
+    expect(skippedFiles.map((f) => f.path)).toContain('image.png');
+    expect(skippedFiles.find((f) => f.path === 'image.png')?.reason).toBe('binary-extension');
+  });
+
+  // Content-detection path: a file whose extension does NOT hit `is-binary-path`
+  // must still be rejected when its bytes are binary. A perf change that trusts
+  // the extension alone — i.e. skips the NULL-byte probe or the isbinaryfile
+  // fallback — would silently regress and let raw bytes into the LLM pack.
+  it('skips binaries identified by NULL-byte content even when the extension looks innocuous', async () => {
+    const nullBuffer = Buffer.from([0x68, 0x69, 0x00, 0x42, 0x59, 0x45]); // "hi\0BYE"
+    await fs.writeFile(path.join(tmpDir, 'payload.data'), nullBuffer);
+    await fs.writeFile(path.join(tmpDir, 'clean.ts'), 'export {};\n');
+
+    const { rawFiles, skippedFiles } = await collectFiles(['payload.data', 'clean.ts'], tmpDir, createMockConfig());
+
+    expect(rawFiles.map((f) => f.path)).toEqual(['clean.ts']);
+    const skipped = skippedFiles.find((f) => f.path === 'payload.data');
+    expect(skipped?.reason).toBe('binary-content');
+  });
+
+  // The PR #1542 case: `%PDF-…` header followed by non-UTF-8 binary bytes,
+  // written with a non-binary extension so the extension fast-path doesn't
+  // catch it. Must still be flagged via the UTF-8 decode failure → isbinaryfile
+  // content check.
+  it('skips PDF-shaped binaries even when the extension does not say so', async () => {
+    await fs.writeFile(path.join(tmpDir, 'doc.data'), Buffer.concat([PDF_HEADER, PDF_BINARY_TAIL]));
+    await fs.writeFile(path.join(tmpDir, 'clean.ts'), 'export {};\n');
+
+    const { rawFiles, skippedFiles } = await collectFiles(['doc.data', 'clean.ts'], tmpDir, createMockConfig());
+
+    expect(rawFiles.map((f) => f.path)).toEqual(['clean.ts']);
+    expect(skippedFiles.find((f) => f.path === 'doc.data')?.reason).toBe('binary-content');
+  });
+
+  // Positive direction: UTF-8 text must NOT be classified as binary. The
+  // current implementation has a fast UTF-8 path that bypasses `isbinaryfile`
+  // entirely; a future optimization that swaps it for a different probe must
+  // keep accepting plain text.
+  it('keeps plain UTF-8 text', async () => {
+    await fs.writeFile(path.join(tmpDir, 'plain.ts'), 'const sentinel = "PLAIN-UTF8-MARKER";\n');
+
+    const { rawFiles, skippedFiles } = await collectFiles(['plain.ts'], tmpDir, createMockConfig());
+
+    expect(rawFiles).toHaveLength(1);
+    expect(rawFiles[0].content).toContain('PLAIN-UTF8-MARKER');
+    expect(skippedFiles).toHaveLength(0);
+  });
+
+  // UTF-8 BOM is explicitly exempted from the NULL-byte probe (the rationale
+  // is in fileRead.ts:103-106 — buffers like `EF BB BF 00 41` were treated as
+  // text by isbinaryfile and we preserved parity). The BOM itself must be
+  // stripped from the returned content; the rest of the text must survive.
+  it('keeps UTF-8 text with BOM and strips the BOM from the returned content', async () => {
+    const bomContent = Buffer.concat([UTF8_BOM, Buffer.from('export const x = "BOM-MARKER";\n', 'utf-8')]);
+    await fs.writeFile(path.join(tmpDir, 'bom.ts'), bomContent);
+
+    const { rawFiles, skippedFiles } = await collectFiles(['bom.ts'], tmpDir, createMockConfig());
+
+    expect(rawFiles).toHaveLength(1);
+    expect(rawFiles[0].content).toContain('BOM-MARKER');
+    expect(rawFiles[0].content.charCodeAt(0)).not.toBe(0xfeff);
+    expect(skippedFiles).toHaveLength(0);
+  });
+});

--- a/tests/core/file/dotIgnoreSpec.test.ts
+++ b/tests/core/file/dotIgnoreSpec.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { searchFiles } from '../../../src/core/file/fileSearch.js';
-import { createMockConfig } from '../../testing/testUtils.js';
+import { createMockConfig, writeFixture } from '../../testing/testUtils.js';
 
 // Behavior-level regression tests for repomix-specific ignore files.
 //
@@ -17,14 +17,6 @@ import { createMockConfig } from '../../testing/testUtils.js';
 // Fixtures use file extensions outside the project's defaultIgnoreList so any
 // filtering observed must originate from the user-provided ignore file under
 // test rather than from baseline defaults.
-
-const writeFixture = async (rootDir: string, files: Record<string, string>): Promise<void> => {
-  for (const [relPath, content] of Object.entries(files)) {
-    const fullPath = path.join(rootDir, relPath);
-    await fs.mkdir(path.dirname(fullPath), { recursive: true });
-    await fs.writeFile(fullPath, content);
-  }
-};
 
 describe('repomix dot-ignore spec', () => {
   let tmpDir: string;

--- a/tests/core/file/dotIgnoreSpec.test.ts
+++ b/tests/core/file/dotIgnoreSpec.test.ts
@@ -1,0 +1,119 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { searchFiles } from '../../../src/core/file/fileSearch.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+// Behavior-level regression tests for repomix-specific ignore files.
+//
+// The gitignore spec (fileSearch.gitignoreSpec.test.ts) covers the .gitignore
+// path. This file covers the *sibling* ignore mechanisms a perf-tuning agent
+// is equally likely to touch when reshaping the search pipeline:
+//
+//   .repomixignore — always honored regardless of toggles
+//   .ignore       — honored only when `useDotIgnore: true` (the default)
+//
+// Fixtures use file extensions outside the project's defaultIgnoreList so any
+// filtering observed must originate from the user-provided ignore file under
+// test rather than from baseline defaults.
+
+const writeFixture = async (rootDir: string, files: Record<string, string>): Promise<void> => {
+  for (const [relPath, content] of Object.entries(files)) {
+    const fullPath = path.join(rootDir, relPath);
+    await fs.mkdir(path.dirname(fullPath), { recursive: true });
+    await fs.writeFile(fullPath, content);
+  }
+};
+
+describe('repomix dot-ignore spec', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-dotignore-spec-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('honors top-level .repomixignore patterns', async () => {
+    await writeFixture(tmpDir, {
+      '.repomixignore': '*.secret\nsubdir/private.data\n',
+      'keep.ts': 'export {};\n',
+      'oops.secret': 'should be ignored\n',
+      'subdir/private.data': 'should be ignored\n',
+      'subdir/public.ts': 'export {};\n',
+    });
+
+    const { filePaths } = await searchFiles(tmpDir, createMockConfig());
+
+    expect(filePaths).toContain('keep.ts');
+    expect(filePaths).toContain('subdir/public.ts');
+    expect(filePaths).not.toContain('oops.secret');
+    expect(filePaths).not.toContain('subdir/private.data');
+  });
+
+  it('honors a nested .repomixignore inside a subdirectory', async () => {
+    // The repomixignore engine must descend into the tree, not just look at
+    // the root. A perf optimization that only reads root-level ignore files
+    // would break this contract.
+    await writeFixture(tmpDir, {
+      'pkg/.repomixignore': 'generated/\n',
+      'pkg/src.ts': 'export {};\n',
+      'pkg/generated/bundle.data': '// generated\n',
+    });
+
+    const { filePaths } = await searchFiles(tmpDir, createMockConfig());
+
+    expect(filePaths).toContain('pkg/src.ts');
+    expect(filePaths).not.toContain('pkg/generated/bundle.data');
+  });
+
+  it('honors .ignore files when `useDotIgnore` is on (the default)', async () => {
+    await writeFixture(tmpDir, {
+      '.ignore': '*.draft\n',
+      'keep.ts': 'export {};\n',
+      'noisy.draft': 'noise\n',
+    });
+
+    const { filePaths } = await searchFiles(tmpDir, createMockConfig({ ignore: { useDotIgnore: true } }));
+
+    expect(filePaths).toContain('keep.ts');
+    expect(filePaths).not.toContain('noisy.draft');
+  });
+
+  it('ignores .ignore files when `useDotIgnore` is explicitly off', async () => {
+    // Inverse contract: a perf change that starts honoring .ignore
+    // unconditionally — e.g. by pre-collecting all dot-prefixed ignore files
+    // at the top of the pipeline — would surface here.
+    await writeFixture(tmpDir, {
+      '.ignore': '*.draft\n',
+      'keep.ts': 'export {};\n',
+      'noisy.draft': 'noise\n',
+    });
+
+    const { filePaths } = await searchFiles(tmpDir, createMockConfig({ ignore: { useDotIgnore: false } }));
+
+    expect(filePaths).toContain('keep.ts');
+    // With useDotIgnore disabled, the .draft file should NOT be filtered by
+    // the .ignore file. It must reach the search output.
+    expect(filePaths).toContain('noisy.draft');
+  });
+
+  it('always honors .repomixignore even when `useDotIgnore` is off', async () => {
+    // `useDotIgnore` is specifically for the generic `.ignore` file. The
+    // repomix-native `.repomixignore` is independently respected — a perf
+    // refactor that conflates the two toggles would break this.
+    await writeFixture(tmpDir, {
+      '.repomixignore': '*.draft\n',
+      'keep.ts': 'export {};\n',
+      'noisy.draft': 'noise\n',
+    });
+
+    const { filePaths } = await searchFiles(tmpDir, createMockConfig({ ignore: { useDotIgnore: false } }));
+
+    expect(filePaths).toContain('keep.ts');
+    expect(filePaths).not.toContain('noisy.draft');
+  });
+});

--- a/tests/core/file/emptyDirectorySpec.test.ts
+++ b/tests/core/file/emptyDirectorySpec.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { searchFiles } from '../../../src/core/file/fileSearch.js';
-import { createMockConfig } from '../../testing/testUtils.js';
+import { createMockConfig, writeFixture } from '../../testing/testUtils.js';
 
 // Behavior-level regression tests for empty-directory preservation.
 //
@@ -17,14 +17,6 @@ import { createMockConfig } from '../../testing/testUtils.js';
 // generateMultiRootSections in fileTreeGenerate.ts: "Empty directories
 // (emptyDirPaths) are not included in multi-root output"). Asserting on it
 // would freeze the current intentional gap as a contract.
-
-const writeFixture = async (rootDir: string, files: Record<string, string>): Promise<void> => {
-  for (const [relPath, content] of Object.entries(files)) {
-    const fullPath = path.join(rootDir, relPath);
-    await fs.mkdir(path.dirname(fullPath), { recursive: true });
-    await fs.writeFile(fullPath, content);
-  }
-};
 
 describe('empty directory preservation spec', () => {
   let tmpDir: string;

--- a/tests/core/file/emptyDirectorySpec.test.ts
+++ b/tests/core/file/emptyDirectorySpec.test.ts
@@ -1,0 +1,102 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { searchFiles } from '../../../src/core/file/fileSearch.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+// Behavior-level regression tests for empty-directory preservation.
+//
+// Empty directories are an opt-in feature (`output.includeEmptyDirectories`).
+// The implementation takes a 2-pass globby path (object mode, then a
+// `findEmptyDirectories` filter) which is more complex than the default
+// onlyFiles path and therefore a tempting target for perf reshuffling.
+//
+// This spec is intentionally single-root only — multi-root empty-directory
+// handling is explicitly NOT implemented (see comment in
+// generateMultiRootSections in fileTreeGenerate.ts: "Empty directories
+// (emptyDirPaths) are not included in multi-root output"). Asserting on it
+// would freeze the current intentional gap as a contract.
+
+const writeFixture = async (rootDir: string, files: Record<string, string>): Promise<void> => {
+  for (const [relPath, content] of Object.entries(files)) {
+    const fullPath = path.join(rootDir, relPath);
+    await fs.mkdir(path.dirname(fullPath), { recursive: true });
+    await fs.writeFile(fullPath, content);
+  }
+};
+
+describe('empty directory preservation spec', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-emptydir-spec-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns an empty directory in emptyDirPaths when `includeEmptyDirectories: true`', async () => {
+    await writeFixture(tmpDir, {
+      'src/keep.ts': 'export {};\n',
+    });
+    await fs.mkdir(path.join(tmpDir, 'docs', 'placeholder'), { recursive: true });
+
+    const config = createMockConfig({ output: { includeEmptyDirectories: true } });
+    const { filePaths, emptyDirPaths } = await searchFiles(tmpDir, config);
+
+    expect(filePaths).toContain('src/keep.ts');
+    expect(emptyDirPaths).toContain('docs/placeholder');
+  });
+
+  it('omits empty directories entirely when `includeEmptyDirectories: false` (the default)', async () => {
+    // Negative contract: the default behavior must not start eagerly emitting
+    // empty directories as a side effect of a perf change (e.g. one that
+    // unifies the two-pass globby into a single pass and forgets to gate the
+    // emptyDir collection).
+    await writeFixture(tmpDir, {
+      'src/keep.ts': 'export {};\n',
+    });
+    await fs.mkdir(path.join(tmpDir, 'docs', 'placeholder'), { recursive: true });
+
+    const config = createMockConfig();
+    const { filePaths, emptyDirPaths } = await searchFiles(tmpDir, config);
+
+    expect(filePaths).toContain('src/keep.ts');
+    expect(emptyDirPaths).toEqual([]);
+  });
+
+  it('does not report a directory that contains files as empty', async () => {
+    // Sanity check on the filter logic: if `findEmptyDirectories` were replaced
+    // by a faster but coarser implementation that only checked the directory
+    // listing without descending, a directory containing nested files could be
+    // wrongly classified as empty.
+    await writeFixture(tmpDir, {
+      'pkg/util/util.ts': 'export {};\n',
+    });
+    // pkg has a non-empty subdir, so neither `pkg` nor `pkg/util` should be reported.
+
+    const config = createMockConfig({ output: { includeEmptyDirectories: true } });
+    const { emptyDirPaths } = await searchFiles(tmpDir, config);
+
+    expect(emptyDirPaths).not.toContain('pkg');
+    expect(emptyDirPaths).not.toContain('pkg/util');
+  });
+
+  it('respects gitignore: an empty directory whose path is gitignored is NOT reported', async () => {
+    // Empty-dir collection must compose with the ignore engine. If a perf
+    // change collected empty dirs from the raw fs walk and bypassed gitignore,
+    // an `output/` directory listed in .gitignore would still be emitted.
+    await writeFixture(tmpDir, {
+      '.gitignore': 'output/\n',
+      'src/keep.ts': 'export {};\n',
+    });
+    await fs.mkdir(path.join(tmpDir, 'output'), { recursive: true });
+
+    const config = createMockConfig({ output: { includeEmptyDirectories: true } });
+    const { emptyDirPaths } = await searchFiles(tmpDir, config);
+
+    expect(emptyDirPaths).not.toContain('output');
+  });
+});

--- a/tests/core/file/fileSearch.gitignoreSpec.test.ts
+++ b/tests/core/file/fileSearch.gitignoreSpec.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { searchFiles } from '../../../src/core/file/fileSearch.js';
-import { createMockConfig } from '../../testing/testUtils.js';
+import { createMockConfig, writeFixture } from '../../testing/testUtils.js';
 
 // Behavior-level regression tests for gitignore handling.
 //
@@ -22,14 +22,6 @@ import { createMockConfig } from '../../testing/testUtils.js';
 // originate from the user-provided .gitignore, not from baseline defaults.
 // Picking patterns like `*.log` or `dist/` would produce false positives
 // because those are filtered regardless of gitignore behavior.
-
-const writeFixture = async (rootDir: string, files: Record<string, string>): Promise<void> => {
-  for (const [relPath, content] of Object.entries(files)) {
-    const fullPath = path.join(rootDir, relPath);
-    await fs.mkdir(path.dirname(fullPath), { recursive: true });
-    await fs.writeFile(fullPath, content);
-  }
-};
 
 describe('fileSearch gitignore spec', () => {
   let tmpDir: string;

--- a/tests/core/file/fileSearch.gitignoreSpec.test.ts
+++ b/tests/core/file/fileSearch.gitignoreSpec.test.ts
@@ -1,0 +1,121 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { searchFiles } from '../../../src/core/file/fileSearch.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+// Behavior-level regression tests for gitignore handling.
+//
+// These tests run against a real temp directory (no module mocks) so they
+// assert the contract `searchFiles` exposes to users — which files end up in
+// the pack, given a particular tree of .gitignore files. Any optimization that
+// swaps out the underlying ignore-file engine must keep these passing.
+//
+// The auto-perf-tuning agent has historically proposed prescan replacements
+// that silently broke gitignore semantics (negation, slash-less recursion,
+// parent .gitignore, dot-dir traversal, monorepo packages/). These cases all
+// originate from that incident — they are the spec, not coincidental coverage.
+//
+// Note on fixture choices: every filename and extension below intentionally
+// avoids the project's `defaultIgnoreList` so that any filtering observed must
+// originate from the user-provided .gitignore, not from baseline defaults.
+// Picking patterns like `*.log` or `dist/` would produce false positives
+// because those are filtered regardless of gitignore behavior.
+
+const writeFixture = async (rootDir: string, files: Record<string, string>): Promise<void> => {
+  for (const [relPath, content] of Object.entries(files)) {
+    const fullPath = path.join(rootDir, relPath);
+    await fs.mkdir(path.dirname(fullPath), { recursive: true });
+    await fs.writeFile(fullPath, content);
+  }
+};
+
+describe('fileSearch gitignore spec', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-gitignore-spec-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // Mirrors git's own negation semantics: a file may be re-included if its
+  // ancestor directories are not themselves excluded. (Git docs:
+  // "It is not possible to re-include a file if a parent directory of that
+  // file is excluded.") A prescan implementation that drops `!` lines wholesale
+  // — as a previous auto-perf-tuning iteration did — would fail this case.
+  it('honors negation patterns: `!keep.draft` re-includes a file that a broader rule would otherwise ignore', async () => {
+    await writeFixture(tmpDir, {
+      '.gitignore': '*.draft\n!keep.draft\n',
+      'src/index.ts': 'export {};\n',
+      'noisy.draft': 'noisy\n',
+      'keep.draft': 'this one matters\n',
+    });
+
+    const { filePaths } = await searchFiles(tmpDir, createMockConfig());
+
+    expect(filePaths).toContain('src/index.ts');
+    expect(filePaths).toContain('keep.draft');
+    expect(filePaths).not.toContain('noisy.draft');
+  });
+
+  it('applies slash-less patterns recursively to all subdirectories', async () => {
+    await writeFixture(tmpDir, {
+      '.gitignore': '*.draft\nsecret.data\n',
+      'a.draft': 'top\n',
+      'secret.data': 'top\n',
+      'keep.ts': 'export {};\n',
+      'sub/nested/b.draft': 'nested\n',
+      'sub/secret.data': 'nested\n',
+      'sub/keep.ts': 'export {};\n',
+    });
+
+    const { filePaths } = await searchFiles(tmpDir, createMockConfig());
+
+    // Slash-less gitignore entries must match at every depth, matching git's
+    // own behavior. A prescan that flattens entries to `${relPath}/${pattern}`
+    // would break this.
+    expect(filePaths).not.toContain('a.draft');
+    expect(filePaths).not.toContain('secret.data');
+    expect(filePaths).not.toContain('sub/nested/b.draft');
+    expect(filePaths).not.toContain('sub/secret.data');
+    expect(filePaths).toContain('keep.ts');
+    expect(filePaths).toContain('sub/keep.ts');
+  });
+
+  // Note: parent-directory .gitignore handling when `searchFiles` is invoked
+  // against a subdirectory is intentionally NOT covered here. globby reads
+  // .gitignore files within `cwd` only, so this is a pre-existing gap on main
+  // rather than a regression target. Capture it as a real spec the day the
+  // codebase commits to that behavior.
+
+  it('reads .gitignore inside monorepo `packages/*` (the classic Lerna/pnpm layout)', async () => {
+    await writeFixture(tmpDir, {
+      'package.json': '{"name":"root","private":true}\n',
+      'packages/ui/.gitignore': 'generated/\n',
+      'packages/ui/src.ts': 'export {};\n',
+      'packages/ui/generated/bundle.data': '// generated\n',
+    });
+
+    const { filePaths } = await searchFiles(tmpDir, createMockConfig());
+
+    expect(filePaths).toContain('packages/ui/src.ts');
+    expect(filePaths).not.toContain('packages/ui/generated/bundle.data');
+  });
+
+  it('reads .gitignore inside dot-prefixed directories like `.config/`', async () => {
+    await writeFixture(tmpDir, {
+      '.config/.gitignore': 'secret.data\n',
+      '.config/public.data': '{"ok":true}\n',
+      '.config/secret.data': '{"shh":true}\n',
+    });
+
+    const { filePaths } = await searchFiles(tmpDir, createMockConfig());
+
+    expect(filePaths).toContain('.config/public.data');
+    expect(filePaths).not.toContain('.config/secret.data');
+  });
+});

--- a/tests/core/file/processOrderSpec.test.ts
+++ b/tests/core/file/processOrderSpec.test.ts
@@ -82,7 +82,7 @@ describe('file process transform order spec', () => {
     // MIN_CHAR_TYPE_COUNT=3) — a monotonous 'A'.repeat() does not qualify, so
     // we synthesize a varied 512-char run.
     const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    const longBase64 = Array.from({ length: 512 }, (_, i) => charset[i % charset.length]).join('');
+    const longBase64 = charset.repeat(Math.ceil(512 / charset.length)).slice(0, 512);
     const rawFiles: RawFile[] = [
       {
         path: 'sample.ts',

--- a/tests/core/file/processOrderSpec.test.ts
+++ b/tests/core/file/processOrderSpec.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest';
+import { processFiles } from '../../../src/core/file/fileProcess.js';
+import type { RawFile } from '../../../src/core/file/fileTypes.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+// Behavior-level regression tests for the file-processing transform order.
+//
+// fileProcess.ts documents the pipeline as:
+//   [removeComments → compress] (worker) → truncateBase64 → removeEmptyLines → trim → showLineNumbers
+//
+// The order matters — a perf optimization that parallelizes or reorders the
+// lightweight pass could silently break invariants users rely on:
+//
+//   - line numbers must reflect the *final* post-cleanup line count
+//     (showLineNumbers runs LAST; removeEmptyLines runs BEFORE it)
+//   - trim must precede line numbering so that leading/trailing whitespace
+//     does not consume early line numbers
+//
+// These specs assert the observable consequences of that order against the
+// real `processFiles` entrypoint. Heavy-path (compress/removeComments) is not
+// exercised here — those are gated by separate worker dispatch and have their
+// own coverage; the transforms most likely to be reshuffled by a future
+// perf pass live in `applyLightweightTransforms`.
+
+describe('file process transform order spec', () => {
+  it('numbers lines AFTER removing empty lines, not before', async () => {
+    // 5 logical lines on disk; 3 of them are blank. removeEmptyLines should
+    // collapse to 2, and showLineNumbers should then emit `1:` and `2:`.
+    // If the order were inverted, the visible numbers would be 1 and 5 (or
+    // there would be numbered empty rows in the output).
+    const rawFiles: RawFile[] = [
+      {
+        path: 'sample.ts',
+        content: 'first\n\n\n\nsecond\n',
+      },
+    ];
+
+    const config = createMockConfig({
+      output: { removeEmptyLines: true, showLineNumbers: true },
+    });
+
+    const [processed] = await processFiles(rawFiles, config, vi.fn());
+
+    const lines = processed.content.split('\n');
+    expect(lines).toEqual(['1: first', '2: second']);
+  });
+
+  it('trims surrounding whitespace BEFORE numbering lines', async () => {
+    // Input has 2 leading and 2 trailing blank lines, then real content.
+    // String-level trim() strips ALL of that surrounding whitespace from the
+    // payload, leaving a single line to number. If line-numbering ran first,
+    // we would see `1:` on a blank line, `3: real content` further down, etc.
+    const rawFiles: RawFile[] = [
+      {
+        path: 'sample.ts',
+        content: '\n\n\nreal content\n\n\n',
+      },
+    ];
+
+    const config = createMockConfig({
+      output: { showLineNumbers: true },
+    });
+
+    const [processed] = await processFiles(rawFiles, config, vi.fn());
+
+    // After trim → single line "real content" → "1: real content"
+    expect(processed.content).toBe('1: real content');
+  });
+
+  it('fires `truncateBase64` on a qualifying base64 run', async () => {
+    // Narrower spec: this only verifies truncateBase64 runs and produces a
+    // truncated output. A full ORDER claim against this transform (truncate
+    // must precede line numbering) is hard to make observable: the
+    // standalone-base64 regex is unanchored, base64 runs stay on a single
+    // line, and a line-number prefix like "1: " does not break the contiguity
+    // of the run itself. So a swap of truncateBase64's position is NOT
+    // covered by any current spec — only the line-numbering pipeline order
+    // (removeEmptyLines / trim / showLineNumbers) is.
+    //
+    // The pattern requires enough diversity (see truncateBase64.ts:
+    // MIN_BASE64_LENGTH_STANDALONE=256, MIN_CHAR_DIVERSITY=10,
+    // MIN_CHAR_TYPE_COUNT=3) — a monotonous 'A'.repeat() does not qualify, so
+    // we synthesize a varied 512-char run.
+    const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    const longBase64 = Array.from({ length: 512 }, (_, i) => charset[i % charset.length]).join('');
+    const rawFiles: RawFile[] = [
+      {
+        path: 'sample.ts',
+        content: `const blob = "${longBase64}";\nconst y = 1;\n`,
+      },
+    ];
+
+    const config = createMockConfig({
+      output: { truncateBase64: true },
+    });
+
+    const [processed] = await processFiles(rawFiles, config, vi.fn());
+
+    // The original 512-char run must not be present verbatim — truncateBase64
+    // replaced it with a placeholder-ish form.
+    expect(processed.content).not.toContain(longBase64);
+    // The non-base64 surrounding content survives.
+    expect(processed.content).toContain('const y = 1;');
+  });
+
+  it('numbers lines using the file final length, padding the line-number column accordingly', async () => {
+    // The padding width is derived from the final line count. A reorder that
+    // numbered BEFORE removeEmptyLines would compute padding off the
+    // pre-cleanup length (5) instead of the post-cleanup length (2), making
+    // the test below fail because of an extra leading space.
+    const rawFiles: RawFile[] = [{ path: 'sample.ts', content: 'first\n\n\nsecond\n' }];
+
+    const config = createMockConfig({
+      output: { removeEmptyLines: true, showLineNumbers: true },
+    });
+
+    const [processed] = await processFiles(rawFiles, config, vi.fn());
+
+    // With 2 final lines, padding length is 1, so prefixes are `1:` / `2:`
+    // (no extra leading spaces).
+    expect(processed.content).toBe('1: first\n2: second');
+  });
+});

--- a/tests/core/packager/multiRootSpec.test.ts
+++ b/tests/core/packager/multiRootSpec.test.ts
@@ -1,0 +1,178 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mergeConfigs } from '../../../src/config/configLoad.js';
+import type { RepomixConfigFile, RepomixConfigMerged, RepomixOutputStyle } from '../../../src/config/configSchema.js';
+import { collectFiles } from '../../../src/core/file/fileCollect.js';
+import { readRawFile } from '../../../src/core/file/fileRead.js';
+import { searchFiles } from '../../../src/core/file/fileSearch.js';
+import type { ProcessedFile } from '../../../src/core/file/fileTypes.js';
+import fileProcessWorker from '../../../src/core/file/workers/fileProcessWorker.js';
+import { produceOutput } from '../../../src/core/packager/produceOutput.js';
+import { pack } from '../../../src/core/packager.js';
+import { filterOutUntrustedFiles } from '../../../src/core/security/filterOutUntrustedFiles.js';
+import { validateFileSafety } from '../../../src/core/security/validateFileSafety.js';
+
+// Behavior-level regression tests for multi-root packing.
+//
+// PR #1562 (token-count cache) initially merged FileMetrics results by file
+// path via a Map, which silently collapsed entries when the same relative path
+// appeared under multiple roots (e.g. `packages/a/README.md` and
+// `packages/b/README.md` both relativize to `README.md`). That bug was fixed
+// at the metrics layer with index-based assembly. The metrics layer is mocked
+// out below, so this spec does NOT re-catch the metrics-layer flavor — that
+// is owned by calculateFileMetrics.test.ts.
+//
+// What this spec catches instead is a content-side collapse in any layer that
+// operates on the *flattened* (multi-root) file list — `processFiles`,
+// `produceOutput`, or any intermediate assembly between them. A Map<path, ...>
+// dedup at that level would drop one root's bytes from the file we hand to
+// the LLM. The unique content sentinels per root make that visible.
+//
+// Out of scope:
+// - `collectFiles` itself is called once per root, so a per-call internal
+//   dedup-by-path would not collapse cross-root copies and would not be
+//   detected here.
+// - A collapse in the file-tree generator alone would still let both root
+//   bodies reach the files section — see tests around
+//   `generateTreeStringWithRoots` for tree-only guarantees.
+
+const buildMergedConfig = (
+  cwd: string,
+  outputFilePath: string,
+  style: RepomixOutputStyle,
+  overrides: Partial<RepomixConfigFile> = {},
+): RepomixConfigMerged =>
+  mergeConfigs(cwd, overrides, {
+    output: {
+      filePath: outputFilePath,
+      style,
+      git: { sortByChanges: false, includeDiffs: false, includeLogs: false },
+    },
+  });
+
+const runPack = (rootDirs: string[], config: RepomixConfigMerged) =>
+  pack(rootDirs, config, () => {}, {
+    searchFiles,
+    sortPaths: (filePaths) => filePaths,
+    collectFiles: (filePaths, root, cfg, progressCallback) =>
+      collectFiles(filePaths, root, cfg, progressCallback, { readRawFile }),
+    processFiles: async (rawFiles, cfg) => {
+      const processedFiles: ProcessedFile[] = [];
+      for (const rawFile of rawFiles) {
+        processedFiles.push(await fileProcessWorker({ rawFile, config: cfg }));
+      }
+      return processedFiles;
+    },
+    // No secrets in these fixtures — short-circuit the security scan to keep
+    // the test fast and focused on the multi-root assembly path.
+    validateFileSafety: (rawFiles, progressCallback, cfg, gitDiff, gitLog) =>
+      validateFileSafety(rawFiles, progressCallback, cfg, gitDiff, gitLog, {
+        runSecurityCheck: async () => [],
+        filterOutUntrustedFiles,
+      }),
+    produceOutput,
+    createMetricsTaskRunner: () => ({
+      taskRunner: { run: async () => 0, cleanup: async () => {} },
+      warmupPromise: Promise.resolve(),
+    }),
+    calculateMetrics: async (processedFiles) => ({
+      totalFiles: processedFiles.length,
+      totalCharacters: processedFiles.reduce((acc, f) => acc + f.content.length, 0),
+      totalTokens: 0,
+      gitDiffTokenCount: 0,
+      gitLogTokenCount: 0,
+      fileCharCounts: Object.fromEntries(processedFiles.map((f) => [f.path, f.content.length])),
+      fileTokenCounts: Object.fromEntries(processedFiles.map((f) => [f.path, 0])),
+      suspiciousFilesResults: [],
+      suspiciousGitDiffResults: [],
+    }),
+  });
+
+const countOccurrences = (haystack: string, needle: string): number => {
+  let count = 0;
+  let index = haystack.indexOf(needle);
+  while (index !== -1) {
+    count++;
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+  return count;
+};
+
+describe('multi-root pack spec', () => {
+  let rootA: string;
+  let rootB: string;
+  let outputDir: string;
+  let outputPath: string;
+
+  beforeEach(async () => {
+    rootA = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-multiroot-a-'));
+    rootB = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-multiroot-b-'));
+    outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-multiroot-out-'));
+    outputPath = path.join(outputDir, 'output.xml');
+
+    // Same relative path in each root, but unique content so a collapsing
+    // implementation produces an obviously-wrong output.
+    await fs.writeFile(path.join(rootA, 'README.md'), '# Root A\nMARKER_FROM_ROOT_A\n');
+    await fs.mkdir(path.join(rootA, 'src'));
+    await fs.writeFile(path.join(rootA, 'src', 'index.ts'), 'export const fromA = "ROOT_A_SRC_MARKER";\n');
+
+    await fs.writeFile(path.join(rootB, 'README.md'), '# Root B (totally different)\nMARKER_FROM_ROOT_B\n');
+    await fs.mkdir(path.join(rootB, 'lib'));
+    await fs.writeFile(path.join(rootB, 'lib', 'util.ts'), 'export const fromB = "ROOT_B_LIB_MARKER";\n');
+  });
+
+  afterEach(async () => {
+    await fs.rm(rootA, { recursive: true, force: true });
+    await fs.rm(rootB, { recursive: true, force: true });
+    await fs.rm(outputDir, { recursive: true, force: true });
+  });
+
+  // Note on `totalFiles`: a separate pre-existing quirk in `sortedFilePathsByDir`
+  // means the same relative path appears in each root's collect input (e.g.
+  // `README.md` is filtered from the global sorted list per-root, so duplicates
+  // pass twice). That inflates `result.totalFiles` beyond 4. This spec is
+  // intentionally narrow: it verifies the *unique content* contract — both
+  // roots' real bytes reach the packed output — and does not assert on
+  // counts, which would couple it to that unrelated quirk.
+
+  it('preserves both unique contents of a duplicate relative path when packing multiple roots (xml)', async () => {
+    const config = buildMergedConfig(outputDir, outputPath, 'xml');
+    await runPack([rootA, rootB], config);
+
+    const output = await fs.readFile(outputPath, 'utf-8');
+    // The contract: each root's bytes survive into the pack. A
+    // Map<path, FileMetrics> collapse — the one PR #1562 fixed in the metrics
+    // layer — would drop one of these markers entirely.
+    expect(output).toContain('MARKER_FROM_ROOT_A');
+    expect(output).toContain('MARKER_FROM_ROOT_B');
+    expect(output).toContain('ROOT_A_SRC_MARKER');
+    expect(output).toContain('ROOT_B_LIB_MARKER');
+  });
+
+  it('preserves both unique contents in plain style too', async () => {
+    // Plain style takes a different rendering path; the assertion is
+    // style-agnostic because the collapse, if reintroduced, would surface
+    // identically in both.
+    const config = buildMergedConfig(outputDir, outputPath, 'plain');
+    await runPack([rootA, rootB], config);
+
+    const output = await fs.readFile(outputPath, 'utf-8');
+    expect(output).toContain('MARKER_FROM_ROOT_A');
+    expect(output).toContain('MARKER_FROM_ROOT_B');
+  });
+
+  // Sanity check on the deduplication direction: each unique sentinel must
+  // appear at most twice (the pre-existing `sortedFilePathsByDir` quirk causes
+  // each root's bytes to be packed twice). If an over-eager perf change starts
+  // multiplying entries further, this catches it.
+  it('does not balloon a duplicated path beyond the existing 2x quirk', async () => {
+    const config = buildMergedConfig(outputDir, outputPath, 'xml');
+    await runPack([rootA, rootB], config);
+
+    const output = await fs.readFile(outputPath, 'utf-8');
+    expect(countOccurrences(output, 'MARKER_FROM_ROOT_A')).toBeLessThanOrEqual(2);
+    expect(countOccurrences(output, 'MARKER_FROM_ROOT_B')).toBeLessThanOrEqual(2);
+  });
+});

--- a/tests/core/security/securityScanSpec.test.ts
+++ b/tests/core/security/securityScanSpec.test.ts
@@ -1,0 +1,156 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mergeConfigs } from '../../../src/config/configLoad.js';
+import type { RepomixConfigFile, RepomixConfigMerged, RepomixOutputStyle } from '../../../src/config/configSchema.js';
+import { collectFiles } from '../../../src/core/file/fileCollect.js';
+import { readRawFile } from '../../../src/core/file/fileRead.js';
+import { searchFiles } from '../../../src/core/file/fileSearch.js';
+import type { ProcessedFile } from '../../../src/core/file/fileTypes.js';
+import fileProcessWorker from '../../../src/core/file/workers/fileProcessWorker.js';
+import { produceOutput } from '../../../src/core/packager/produceOutput.js';
+import { pack } from '../../../src/core/packager.js';
+import { filterOutUntrustedFiles } from '../../../src/core/security/filterOutUntrustedFiles.js';
+import { runSecurityCheck } from '../../../src/core/security/securityCheck.js';
+import { validateFileSafety } from '../../../src/core/security/validateFileSafety.js';
+import securityCheckWorker, {
+  type SecurityCheckTask,
+  type SuspiciousFileResult as WorkerSuspiciousFileResult,
+} from '../../../src/core/security/workers/securityCheckWorker.js';
+import type { TaskRunner } from '../../../src/shared/processConcurrency.js';
+
+// Behavior-level regression tests for the security-scan pipeline.
+//
+// These run real packager orchestration against a real tmpdir fixture so that
+// a perf optimization which silently bypasses the security scan — e.g. by
+// re-routing rawFiles through a "prefired batches" code path while leaving
+// `onBatch` unwired — surfaces as a failed assertion instead of a green CI.
+//
+// The fake AWS credential below is the same fixture used by the secretlint
+// project's own demos; secretlint's preset-recommend ruleset is what repomix
+// loads in `createSecretLintConfig`, so any working scan path must flag it.
+
+// secretlint-disable
+const FAKE_AWS_SECRET = 'AWS_SECRET_ACCESS_KEY = wJalrXUtnFEMI/K7MDENG/bPxRfiCYSECRETSKEY';
+// secretlint-enable
+
+// An inline TaskRunner backed by the worker module's default export so the
+// orchestration logic inside runSecurityCheck (batching, prefired-promise
+// handling, result aggregation) is exercised end-to-end without the cost or
+// flakiness of spawning real worker_threads.
+const inlineSecurityTaskRunner = (): TaskRunner<SecurityCheckTask, (WorkerSuspiciousFileResult | null)[]> => ({
+  run: (task) => securityCheckWorker(task),
+  cleanup: async () => {},
+});
+
+const buildMergedConfig = (
+  rootDir: string,
+  outputFilePath: string,
+  overrides: Partial<RepomixConfigFile> = {},
+): RepomixConfigMerged =>
+  mergeConfigs(rootDir, overrides, {
+    output: {
+      filePath: outputFilePath,
+      style: 'xml' as RepomixOutputStyle,
+      git: { sortByChanges: false, includeDiffs: false, includeLogs: false },
+    },
+  });
+
+const runPack = async (rootDir: string, config: RepomixConfigMerged) =>
+  pack([rootDir], config, () => {}, {
+    searchFiles,
+    sortPaths: (filePaths) => filePaths,
+    collectFiles: (filePaths, root, cfg, progressCallback) =>
+      collectFiles(filePaths, root, cfg, progressCallback, { readRawFile }),
+    processFiles: async (rawFiles, cfg) => {
+      const processedFiles: ProcessedFile[] = [];
+      for (const rawFile of rawFiles) {
+        processedFiles.push(await fileProcessWorker({ rawFile, config: cfg }));
+      }
+      return processedFiles;
+    },
+    // Real validateFileSafety + real runSecurityCheck, with only the worker
+    // pool replaced by an in-process runner. Crucially, the branching inside
+    // runSecurityCheck (how rawFiles + gitDiff/gitLog items are batched and
+    // dispatched) is still the production code path under test.
+    validateFileSafety: (rawFiles, progressCallback, cfg, gitDiff, gitLog) =>
+      validateFileSafety(rawFiles, progressCallback, cfg, gitDiff, gitLog, {
+        runSecurityCheck: (files, progress, diff, log) =>
+          runSecurityCheck(files, progress, diff, log, {
+            initTaskRunner: (() =>
+              inlineSecurityTaskRunner()) as typeof import('../../../src/shared/processConcurrency.js').initTaskRunner,
+            getProcessConcurrency: () => 1,
+          }),
+        filterOutUntrustedFiles,
+      }),
+    produceOutput,
+    createMetricsTaskRunner: () => ({
+      taskRunner: { run: async () => 0, cleanup: async () => {} },
+      warmupPromise: Promise.resolve(),
+    }),
+    calculateMetrics: async (processedFiles) => ({
+      totalFiles: processedFiles.length,
+      totalCharacters: processedFiles.reduce((acc, f) => acc + f.content.length, 0),
+      totalTokens: 0,
+      gitDiffTokenCount: 0,
+      gitLogTokenCount: 0,
+      fileCharCounts: Object.fromEntries(processedFiles.map((f) => [f.path, f.content.length])),
+      fileTokenCounts: Object.fromEntries(processedFiles.map((f) => [f.path, 0])),
+      suspiciousFilesResults: [],
+      suspiciousGitDiffResults: [],
+    }),
+  });
+
+describe('security scan spec', () => {
+  let tmpDir: string;
+  let outputPath: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-security-spec-'));
+    outputPath = path.join(tmpDir, 'output.xml');
+    // Fixture: one clean file + one file carrying a known secretlint trigger.
+    await fs.writeFile(path.join(tmpDir, 'clean.ts'), 'export const greet = (n: string) => `hi ${n}`;\n');
+    await fs.writeFile(path.join(tmpDir, 'leaky.env'), `${FAKE_AWS_SECRET}\n`);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detects a known fake credential and excludes the file from the packed output', async () => {
+    const config = buildMergedConfig(tmpDir, outputPath);
+    const result = await runPack(tmpDir, config);
+
+    // The orchestration MUST surface the credential file as suspicious.
+    // If a perf optimization silently bypasses dispatch (the b8ef569 trap),
+    // this length is 0 and the test fails — exactly the regression net we want.
+    expect(result.suspiciousFilesResults.map((r) => r.filePath)).toContain('leaky.env');
+    expect(result.safeFilePaths).toContain('clean.ts');
+    expect(result.safeFilePaths).not.toContain('leaky.env');
+
+    // Defense in depth: the credential string must not appear in the pack output.
+    // A scan that returns the suspicious result but fails to wire it through the
+    // filter (e.g. by losing the path between runSecurityCheck and produceOutput)
+    // would still leak the secret into the file we hand to the LLM.
+    const outputContent = await fs.readFile(outputPath, 'utf-8');
+    expect(outputContent).not.toContain('wJalrXUtnFEMI');
+    expect(outputContent).toContain('clean.ts');
+  });
+
+  it('respects `enableSecurityCheck: false`: the credential is not reported and stays in the output', async () => {
+    // Negative-direction contract: future optimizations must not start
+    // running the scan unconditionally as a side effect of pre-warming or
+    // worker-pool sharing.
+    const config = buildMergedConfig(tmpDir, outputPath, {
+      security: { enableSecurityCheck: false },
+    });
+    const result = await runPack(tmpDir, config);
+
+    expect(result.suspiciousFilesResults).toEqual([]);
+    expect(result.safeFilePaths).toContain('leaky.env');
+
+    const outputContent = await fs.readFile(outputPath, 'utf-8');
+    expect(outputContent).toContain('wJalrXUtnFEMI');
+  });
+});

--- a/tests/core/security/securityScanSpec.test.ts
+++ b/tests/core/security/securityScanSpec.test.ts
@@ -110,7 +110,7 @@ describe('security scan spec', () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-security-spec-'));
     outputPath = path.join(tmpDir, 'output.xml');
     // Fixture: one clean file + one file carrying a known secretlint trigger.
-    await fs.writeFile(path.join(tmpDir, 'clean.ts'), 'export const greet = (n: string) => `hi ${n}`;\n');
+    await fs.writeFile(path.join(tmpDir, 'clean.ts'), 'export const greet = (n: string) => "hi " + n;\n');
     await fs.writeFile(path.join(tmpDir, 'leaky.env'), `${FAKE_AWS_SECRET}\n`);
   });
 

--- a/tests/testing/testUtils.ts
+++ b/tests/testing/testUtils.ts
@@ -1,4 +1,6 @@
+import fs from 'node:fs/promises';
 import os from 'node:os';
+import path from 'node:path';
 import process from 'node:process';
 import { defaultConfig, type RepomixConfigMerged } from '../../src/config/configSchema.js';
 
@@ -49,3 +51,16 @@ export const createMockConfig = (config: DeepPartial<RepomixConfigMerged> = {}):
 export const isWindows = os.platform() === 'win32';
 export const isMac = os.platform() === 'darwin';
 export const isLinux = os.platform() === 'linux';
+
+/**
+ * Write a flat dict of `relativePath → content` into `rootDir`, creating
+ * parent directories as needed. Used by the spec tests that build small
+ * fixture trees in a tmpdir before invoking searchFiles / pack.
+ */
+export const writeFixture = async (rootDir: string, files: Record<string, string>): Promise<void> => {
+  for (const [relPath, content] of Object.entries(files)) {
+    const fullPath = path.join(rootDir, relPath);
+    await fs.mkdir(path.dirname(fullPath), { recursive: true });
+    await fs.writeFile(fullPath, content);
+  }
+};


### PR DESCRIPTION
## Summary

Adds 27 behavior-level regression tests across 7 spec files (~900 lines) that act as a safety net against the class of silent correctness regressions an auto-perf-tuning agent has previously proposed in PRs #1548 / #1559. Each spec targets one observable contract surface (search semantics, security scan dispatch, binary detection, multi-root assembly, ignore-file handling, transform pipeline order, empty-directory preservation) and runs against real tmpdir fixtures so a refactor that swaps the underlying implementation can't pass coincidentally.

| Spec file | Tests | Catches |
|---|---|---|
| `tests/core/file/fileSearch.gitignoreSpec.test.ts` | 4 | gitignore engine replacement that drops negation, slash-less recursion, `packages/*/`, or dot-dir `.gitignore` (the prescan trap from #1559) |
| `tests/core/security/securityScanSpec.test.ts` | 2 | secretlint scan silently skipped via the `prefiredFileBatchPromises` path or by future re-routes (the `b8ef569` trap) |
| `tests/core/file/binaryDetectionSpec.test.ts` | 5 | content-detection regressions in the cheap pre-screen / NULL-byte probe / `isbinaryfile` fallback (the PR #1542 fix class) |
| `tests/core/packager/multiRootSpec.test.ts` | 3 | downstream-of-metrics path collapse that drops one root's bytes (PR #1562 fixed the metrics-layer flavor) |
| `tests/core/file/dotIgnoreSpec.test.ts` | 5 | `.repomixignore` / `useDotIgnore` toggles conflated or silently disabled |
| `tests/core/file/processOrderSpec.test.ts` | 4 | reorder of `[truncateBase64 → removeEmptyLines → trim → showLineNumbers]` (asserts observable consequences, not internal step names) |
| `tests/core/file/emptyDirectorySpec.test.ts` | 4 | `includeEmptyDirectories` 2-pass globby contract: opt-in correctness, default-off, no false-empties on populated trees, gitignore composition |

### Design conventions used throughout

- **Real tmp directories + real entry points** (`searchFiles`, `collectFiles`, `pack`) — no globby/fs mocks. Refactors that change internals but preserve behavior continue to pass; ones that change behavior fail.
- **Fixtures avoid every pattern in `src/config/defaultIgnore.ts`** — filtering observed must come from the user-provided ignore file under test, not from baseline defaults.
- **Path-separator-safe expectations** — every assertion uses forward-slash string literals so the suite is portable to the Windows CI matrix.
- **Security spec uses an in-process TaskRunner wrapping the real worker module** — orchestration branching (batching, dispatch decisions, prefired handling) is exercised end-to-end, but worker_threads is bypassed to keep the test fast and deterministic.
- **Verified each spec actually catches the failure mode** — the gitignore and security specs were sanity-checked by temporarily applying #1559's broken implementation / zeroing `runSecurityCheck`'s file dispatch; both flipped the relevant assertions to failure while keeping unrelated tests green.

### Side discovery (not fixed in this PR)

While writing the multi-root spec I found that `sortedFilePathsByDir` in `src/core/packager.ts:116-121` inflates `totalFiles` when the same relative path exists under multiple roots: it filters the globally-flattened sorted paths by string equality against each root's Set, so any duplicate that exists in *another* root also passes the filter. Concrete effect is each duplicated file ends up in the pack output twice. The spec is intentionally count-agnostic (assert on content sentinels, not on `totalFiles`) and includes a `<=2` ceiling assertion so a worse explosion would still fail. Worth a follow-up PR to fix at the source.

### What this PR does NOT change

No source code changes — tests only. No new dependencies. No CI config changes. No format/lint surface modifications.

## Checklist

- [x] Run `npm run test` (1304/1304 passing on this branch — 1277 baseline + 27 new)
- [x] Run `npm run lint` (clean, 3 pre-existing warnings on unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)