### PR TITLE
perf(core): Overlap metrics warm-up with searchFiles (#1 + #4 only)

### DIFF
--- a/src/core/metrics/calculateMetrics.ts
+++ b/src/core/metrics/calculateMetrics.ts
@@ -1,6 +1,6 @@
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
-import { getWorkerThreadCount, initTaskRunner } from '../../shared/processConcurrency.js';
+import { getProcessConcurrency, initTaskRunner } from '../../shared/processConcurrency.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
 import type { ProcessedFile } from '../file/fileTypes.js';
 import type { GitDiffResult } from '../git/gitDiffHandle.js';
@@ -31,24 +31,46 @@ export interface MetricsTaskRunnerWithWarmup {
 }
 
 /**
- * Create a metrics task runner and warm up all worker threads by triggering
- * gpt-tokenizer initialization in parallel. This allows the expensive module
- * loading to overlap with other pipeline stages (security check, file processing,
- * output generation).
+ * Create the metrics worker pool and warm up its threads by triggering
+ * gpt-tokenizer initialization in parallel. Called BEFORE `searchFiles` so
+ * the ~200-285ms-per-worker BPE table parse overlaps the entire search +
+ * collect + security + process pipeline rather than only the post-search
+ * stages.
+ *
+ * Because the pool is now created without knowing the file count, the
+ * `ceil(numOfTasks / 100)` heuristic in `getWorkerThreadCount` no longer
+ * applies; we size to the host's full process concurrency instead. The
+ * runtime upper bound matches what `ceil(numOfTasks / 100)` would have
+ * returned for any repo with ≥ `processConcurrency * 100` files.
  */
-export const createMetricsTaskRunner = (numOfTasks: number, encoding: TokenEncoding): MetricsTaskRunnerWithWarmup => {
+export const createMetricsTaskRunner = (encoding: TokenEncoding): MetricsTaskRunnerWithWarmup => {
+  const maxThreads = Math.max(1, getProcessConcurrency());
+
   const taskRunner = initTaskRunner<MetricsWorkerTask, MetricsWorkerResult>({
-    numOfTasks,
+    // numOfTasks is no longer meaningful at create time; pool size is bounded
+    // by maxWorkerThreads instead. Use a sentinel large enough that the
+    // per-task heuristic in `getWorkerThreadCount` cannot drop us below the cap.
+    numOfTasks: maxThreads * 100,
     workerType: 'calculateMetrics',
     runtime: 'worker_threads',
+    maxWorkerThreads: maxThreads,
   });
 
-  const { maxThreads } = getWorkerThreadCount(numOfTasks);
-  const warmupPromise = Promise.all(
-    Array.from({ length: maxThreads }, () => taskRunner.run({ content: '', encoding }).catch(() => 0)),
-  );
+  try {
+    const warmupPromise = Promise.all(
+      Array.from({ length: maxThreads }, () => taskRunner.run({ content: '', encoding }).catch(() => 0)),
+    );
 
-  return { taskRunner, warmupPromise };
+    return { taskRunner, warmupPromise };
+  } catch (error) {
+    // The Tinypool was already created above. If anything between pool
+    // creation and the return throws synchronously (e.g. a `run()` call
+    // dispatches an immediate error in a future Tinypool release), tear
+    // the pool down before rethrowing so the caller never receives a half-
+    // constructed runner and we don't leak worker_threads.
+    void taskRunner.cleanup();
+    throw error;
+  }
 };
 
 const defaultDeps = {

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -92,42 +92,50 @@ export const pack = async (
     logger.trace('Failed to prefetch sort data:', error);
   });
 
-  progressCallback('Searching for files...');
-  const searchResultsByDir = await withMemoryLogging('Search Files', async () =>
-    Promise.all(
-      rootDirs.map(async (rootDir) => {
-        const result = await deps.searchFiles(rootDir, config, explicitFiles);
-        return { rootDir, filePaths: result.filePaths, emptyDirPaths: result.emptyDirPaths };
-      }),
-    ),
-  );
-
-  // Deduplicate and sort empty directory paths for reuse during output generation,
-  // avoiding a redundant searchFiles call in buildOutputGeneratorContext.
-  const emptyDirPaths = config.output.includeEmptyDirectories
-    ? [...new Set(searchResultsByDir.flatMap((r) => r.emptyDirPaths))].sort()
-    : undefined;
-
-  // Sort file paths
-  progressCallback('Sorting files...');
-  const allFilePaths = searchResultsByDir.flatMap(({ filePaths }) => filePaths);
-  const sortedFilePaths = deps.sortPaths(allFilePaths);
-
-  // Regroup sorted file paths by rootDir using Set for O(1) membership checks
-  const filePathSetByDir = new Map(searchResultsByDir.map(({ rootDir, filePaths }) => [rootDir, new Set(filePaths)]));
-  const sortedFilePathsByDir = rootDirs.map((rootDir) => ({
-    rootDir,
-    filePaths: sortedFilePaths.filter((filePath) => filePathSetByDir.get(rootDir)?.has(filePath) ?? false),
-  }));
-
-  // Pre-initialize metrics worker pool to overlap gpt-tokenizer loading with subsequent pipeline stages
-  // (security check, file processing, output generation).
+  // Pre-initialize the metrics worker pool BEFORE searchFiles so that
+  // gpt-tokenizer's ~200-285ms-per-worker BPE table parse overlaps the
+  // search + collect + security + process pipeline rather than only the
+  // post-search stages. Pool sizing no longer depends on the file count
+  // (it now uses host concurrency) so it can be created without waiting
+  // on searchFiles to resolve.
+  //
+  // `createMetricsTaskRunner` cleans up its own pool internally if a
+  // synchronous failure occurs after the Tinypool is constructed, so a
+  // partial pool can never escape this call and reach the surrounding
+  // `try`/`finally` — the `finally` below handles the normal-return case.
   const { taskRunner: metricsTaskRunner, warmupPromise: metricsWarmupPromise } = deps.createMetricsTaskRunner(
-    allFilePaths.length,
     config.tokenCount.encoding,
   );
 
   try {
+    progressCallback('Searching for files...');
+    const searchResultsByDir = await withMemoryLogging('Search Files', async () =>
+      Promise.all(
+        rootDirs.map(async (rootDir) => {
+          const result = await deps.searchFiles(rootDir, config, explicitFiles);
+          return { rootDir, filePaths: result.filePaths, emptyDirPaths: result.emptyDirPaths };
+        }),
+      ),
+    );
+
+    // Deduplicate and sort empty directory paths for reuse during output generation,
+    // avoiding a redundant searchFiles call in buildOutputGeneratorContext.
+    const emptyDirPaths = config.output.includeEmptyDirectories
+      ? [...new Set(searchResultsByDir.flatMap((r) => r.emptyDirPaths))].sort()
+      : undefined;
+
+    // Sort file paths
+    progressCallback('Sorting files...');
+    const allFilePaths = searchResultsByDir.flatMap(({ filePaths }) => filePaths);
+    const sortedFilePaths = deps.sortPaths(allFilePaths);
+
+    // Regroup sorted file paths by rootDir using Set for O(1) membership checks
+    const filePathSetByDir = new Map(searchResultsByDir.map(({ rootDir, filePaths }) => [rootDir, new Set(filePaths)]));
+    const sortedFilePathsByDir = rootDirs.map((rootDir) => ({
+      rootDir,
+      filePaths: sortedFilePaths.filter((filePath) => filePathSetByDir.get(rootDir)?.has(filePath) ?? false),
+    }));
+
     // Run file collection and git operations in parallel since they are independent:
     // - collectFiles reads file contents from disk
     // - getGitDiffs/getGitLogs spawn git subprocesses
@@ -213,16 +221,12 @@ export const pack = async (
       files: filePaths,
     }));
 
-    // Ensure warm-up task completes before metrics calculation
-    await metricsWarmupPromise;
-    // Ensure the token-count cache is loaded before calculateFileMetrics reads
-    // from it. The load was started at the very beginning of pack() and is
-    // typically already resolved; this await is a safety net for fast machines.
-    await tokenCacheLoadPromise;
-
     // Generate and write output, overlapping with metrics calculation.
     // File and git metrics don't depend on the output, so they start immediately
-    // while output generation runs concurrently.
+    // while output generation runs concurrently. The metrics warm-up and
+    // token-count cache load are awaited INSIDE the metrics branch only —
+    // produceOutput has no dependency on either, so blocking the whole pipeline
+    // on them would idle the main thread while workers are still spinning up.
     const outputPromise = deps.produceOutput(
       rootDirs,
       config,
@@ -236,11 +240,24 @@ export const pack = async (
     );
 
     const outputForMetricsPromise = outputPromise.then((r) => r.outputForMetrics);
+    // Without this `.catch`, if `produceOutput` rejects while the metrics
+    // branch is still awaiting `metricsWarmupPromise` / `tokenCacheLoadPromise`,
+    // the derived `outputForMetricsPromise` rejection lands before
+    // `calculateMetrics` has attached its own handler — Node observes an
+    // unhandled rejection. The outer `Promise.all` below still propagates
+    // the original `outputPromise` rejection, so the no-op catch only
+    // suppresses the duplicate warning without swallowing the failure.
+    outputForMetricsPromise.catch(() => {});
 
     const [{ outputFiles }, metrics] = await Promise.all([
       outputPromise,
-      withMemoryLogging('Calculate Metrics', () =>
-        deps.calculateMetrics(
+      withMemoryLogging('Calculate Metrics', async () => {
+        // Ensure warm-up is done and the token cache is loaded before
+        // calculateMetrics tasks fire. Both promises were kicked off at the
+        // very start of pack(); these awaits are typically already-resolved
+        // by the time we get here.
+        await Promise.all([metricsWarmupPromise, tokenCacheLoadPromise]);
+        return deps.calculateMetrics(
           processedFiles,
           outputForMetricsPromise,
           progressCallback,
@@ -250,8 +267,8 @@ export const pack = async (
           {
             taskRunner: metricsTaskRunner,
           },
-        ),
-      ),
+        );
+      }),
     ]);
 
     // Create a result object that includes metrics and security results

--- a/tests/core/metrics/calculateMetrics.test.ts
+++ b/tests/core/metrics/calculateMetrics.test.ts
@@ -246,7 +246,7 @@ describe('calculateMetrics fast/slow path equivalence', () => {
 
 describe('createMetricsTaskRunner', () => {
   it('should return a taskRunner and warmupPromise', async () => {
-    const result = createMetricsTaskRunner(100, 'o200k_base');
+    const result = createMetricsTaskRunner('o200k_base');
 
     expect(result).toHaveProperty('taskRunner');
     expect(result).toHaveProperty('warmupPromise');
@@ -258,7 +258,7 @@ describe('createMetricsTaskRunner', () => {
   });
 
   it('should fire a warmup task with empty content', async () => {
-    const result = createMetricsTaskRunner(50, 'cl100k_base');
+    const result = createMetricsTaskRunner('cl100k_base');
 
     await result.warmupPromise;
 
@@ -272,7 +272,7 @@ describe('createMetricsTaskRunner', () => {
       cleanup: vi.fn(),
     });
 
-    const result = createMetricsTaskRunner(10, 'o200k_base');
+    const result = createMetricsTaskRunner('o200k_base');
 
     // warmupPromise should resolve (errors swallowed by .catch on each task)
     const resolved = await result.warmupPromise;

--- a/tests/core/packager.test.ts
+++ b/tests/core/packager.test.ts
@@ -185,6 +185,20 @@ describe('packager', () => {
       };
     };
 
+    test('cleans up the metrics worker pool when searchFiles rejects', async () => {
+      // Regression: the metrics pool is now created BEFORE searchFiles so the
+      // gpt-tokenizer warm-up overlaps the search phase. If searchFiles throws
+      // (e.g. a glob pattern collides with an unreadable directory), the
+      // surrounding try/finally must still tear the pool down — otherwise the
+      // Tinypool workers leak and Node.js keeps the process alive.
+      const { cleanup, deps } = baseDeps();
+      deps.searchFiles = vi.fn().mockRejectedValue(new Error('search failed'));
+
+      await expect(pack(['root'], createMockConfig(), vi.fn(), deps)).rejects.toThrow('search failed');
+
+      expect(cleanup).toHaveBeenCalled();
+    });
+
     test('cleans up the metrics worker pool when validateFileSafety rejects', async () => {
       const { cleanup, deps } = baseDeps();
       deps.validateFileSafety = vi.fn().mockRejectedValue(new Error('security check failed'));


### PR DESCRIPTION
## Summary

Companion / alternative to PR #1576. That PR bundles four coupled changes; this one isolates just the two that the analysis pointed to as the most likely contributors to the CI benchmark gains:

1. **Move `createMetricsTaskRunner` to BEFORE `searchFiles`.** The ~200-285ms-per-worker gpt-tokenizer BPE table parse now overlaps the search phase too, not just collect/security/process. Pool sizing switches from file-count-based (`min(cpu, ceil(N/100))`) to host-concurrency-based (`getProcessConcurrency()`) so it can be constructed without waiting on `searchFiles`.

2. **Drop the `await metricsWarmupPromise` / `await tokenCacheLoadPromise` barriers** that sat just before `produceOutput`. They move inside the metrics branch of the trailing `Promise.all`, where they are actually needed.

Deliberately **not included** here:
- The hard `METRICS_PREWARM_THREAD_CAP = 3` on the pool (from PR #1576). This branch keeps the pool sized by `getProcessConcurrency()` so very-large-repo / many-vCPU hosts retain the same metrics parallelism as `main`.
- The lazy `produceOutput` import (from PR #1576).

The goal is to measure CI benchmarks for this minimal variant and compare against PR #1576, so we know which knob each contribution is buying.

## Safety nets

- `try`/`finally` block expands upward to wrap `searchFiles` so a search failure still triggers `metricsTaskRunner.cleanup()`. New packager test pins the leak path.
- `createMetricsTaskRunner` catches its own synchronous post-pool failures so a half-constructed runner cannot escape.
- `outputForMetricsPromise` carries a no-op `.catch` to avoid an unhandled-rejection window if `produceOutput` rejects while the metrics branch is still awaiting the warm-up promise.

## Checklist

- [x] Run `npm run test` — 1304 → 1305 passing (+1 new `searchFiles` cleanup leak test)
- [x] Run `npm run lint` — clean (3 pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)