### PR TITLE
perf(core): Warm-up overlap + pool cap, no lazy import (#1+#2+#4)

### DIFF
--- a/src/core/metrics/calculateMetrics.ts
+++ b/src/core/metrics/calculateMetrics.ts
@@ -1,6 +1,6 @@
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
-import { getWorkerThreadCount, initTaskRunner } from '../../shared/processConcurrency.js';
+import { getProcessConcurrency, initTaskRunner } from '../../shared/processConcurrency.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
 import type { ProcessedFile } from '../file/fileTypes.js';
 import type { GitDiffResult } from '../git/gitDiffHandle.js';
@@ -30,20 +30,40 @@ export interface MetricsTaskRunnerWithWarmup {
   warmupPromise: Promise<unknown>;
 }
 
+// Cap on metrics workers spawned for both warm-up and real tokenization.
+// The metrics phase fits comfortably in 3 workers for the typical Repomix
+// workload (≤1000 files); each extra worker pays a fresh ~200-285ms
+// gpt-tokenizer BPE table parse that contends with the file-collection
+// main thread for very small marginal benefit.
+const METRICS_PREWARM_THREAD_CAP = 3;
+
 /**
- * Create a metrics task runner and warm up all worker threads by triggering
- * gpt-tokenizer initialization in parallel. This allows the expensive module
- * loading to overlap with other pipeline stages (security check, file processing,
- * output generation).
+ * Create the metrics worker pool and warm up its threads by triggering
+ * gpt-tokenizer initialization in parallel. Called BEFORE `searchFiles` so
+ * the ~200-285ms-per-worker BPE table parse overlaps the entire search +
+ * collect + security + process pipeline rather than only the post-search
+ * stages.
+ *
+ * Because the pool is created without knowing the file count, it is sized
+ * by `min(host concurrency, METRICS_PREWARM_THREAD_CAP)` instead of the
+ * `ceil(numOfTasks / 100)` heuristic. On the worst case (>1000 files on a
+ * >3-vCPU host) this caps the metrics pool at 3 workers — acceptable because
+ * the metrics phase overlaps `produceOutput` and is no longer on the
+ * critical path after the per-file token-count cache landed.
  */
-export const createMetricsTaskRunner = (numOfTasks: number, encoding: TokenEncoding): MetricsTaskRunnerWithWarmup => {
+export const createMetricsTaskRunner = (encoding: TokenEncoding): MetricsTaskRunnerWithWarmup => {
+  const maxThreads = Math.max(1, Math.min(getProcessConcurrency(), METRICS_PREWARM_THREAD_CAP));
+
   const taskRunner = initTaskRunner<MetricsWorkerTask, MetricsWorkerResult>({
-    numOfTasks,
+    // numOfTasks is no longer meaningful at create time; maxWorkerThreads is
+    // the sole cap. Pass a sentinel large enough that the per-task heuristic
+    // in `getWorkerThreadCount` cannot drop us below the cap.
+    numOfTasks: maxThreads * 100,
     workerType: 'calculateMetrics',
     runtime: 'worker_threads',
+    maxWorkerThreads: maxThreads,
   });
 
-  const { maxThreads } = getWorkerThreadCount(numOfTasks);
   const warmupPromise = Promise.all(
     Array.from({ length: maxThreads }, () => taskRunner.run({ content: '', encoding }).catch(() => 0)),
   );

--- a/src/core/metrics/calculateMetrics.ts
+++ b/src/core/metrics/calculateMetrics.ts
@@ -64,11 +64,21 @@ export const createMetricsTaskRunner = (encoding: TokenEncoding): MetricsTaskRun
     maxWorkerThreads: maxThreads,
   });
 
-  const warmupPromise = Promise.all(
-    Array.from({ length: maxThreads }, () => taskRunner.run({ content: '', encoding }).catch(() => 0)),
-  );
+  try {
+    const warmupPromise = Promise.all(
+      Array.from({ length: maxThreads }, () => taskRunner.run({ content: '', encoding }).catch(() => 0)),
+    );
 
-  return { taskRunner, warmupPromise };
+    return { taskRunner, warmupPromise };
+  } catch (error) {
+    // The Tinypool was already created above. If anything between pool
+    // creation and the return throws synchronously (e.g. a `run()` call
+    // dispatches an immediate error in a future Tinypool release), tear
+    // the pool down before rethrowing so the caller never receives a half-
+    // constructed runner and we don't leak worker_threads.
+    void taskRunner.cleanup();
+    throw error;
+  }
 };
 
 const defaultDeps = {

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -14,7 +14,7 @@ import { getGitLogs } from './git/gitLogHandle.js';
 import { calculateMetrics, createMetricsTaskRunner } from './metrics/calculateMetrics.js';
 import { loadTokenCountCache, saveTokenCountCache } from './metrics/tokenCountCache.js';
 import { prefetchSortData, sortOutputFiles } from './output/outputSort.js';
-import type { produceOutput as produceOutputType } from './packager/produceOutput.js';
+import { produceOutput } from './packager/produceOutput.js';
 import type { SuspiciousFileResult } from './security/securityCheck.js';
 import { validateFileSafety } from './security/validateFileSafety.js';
 import type { PackSkillParams } from './skill/packSkill.js';
@@ -41,14 +41,7 @@ const defaultDeps = {
   collectFiles,
   processFiles,
   validateFileSafety,
-  // Lazy-load produceOutput so its module chain (Handlebars template compile,
-  // output-style modules) loads in parallel with searchFiles + collect rather
-  // than blocking packager.ts entry. The dependency is invoked once per pack
-  // call so the import-cache overhead amortizes to a single resolve.
-  produceOutput: (async (...args: Parameters<typeof produceOutputType>) => {
-    const { produceOutput } = await import('./packager/produceOutput.js');
-    return produceOutput(...args);
-  }) as typeof produceOutputType,
+  produceOutput,
   calculateMetrics,
   createMetricsTaskRunner,
   sortPaths,

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -246,6 +246,14 @@ export const pack = async (
     );
 
     const outputForMetricsPromise = outputPromise.then((r) => r.outputForMetrics);
+    // Without this `.catch`, if `produceOutput` rejects while the metrics
+    // branch is still awaiting `metricsWarmupPromise` / `tokenCacheLoadPromise`,
+    // the derived `outputForMetricsPromise` rejection lands before
+    // `calculateMetrics` has attached its own handler — Node observes an
+    // unhandled rejection. The outer `Promise.all` below still propagates
+    // the original `outputPromise` rejection, so the no-op catch only
+    // suppresses the duplicate warning without swallowing the failure.
+    outputForMetricsPromise.catch(() => {});
 
     const [{ outputFiles }, metrics] = await Promise.all([
       outputPromise,

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -14,7 +14,7 @@ import { getGitLogs } from './git/gitLogHandle.js';
 import { calculateMetrics, createMetricsTaskRunner } from './metrics/calculateMetrics.js';
 import { loadTokenCountCache, saveTokenCountCache } from './metrics/tokenCountCache.js';
 import { prefetchSortData, sortOutputFiles } from './output/outputSort.js';
-import { produceOutput } from './packager/produceOutput.js';
+import type { produceOutput as produceOutputType } from './packager/produceOutput.js';
 import type { SuspiciousFileResult } from './security/securityCheck.js';
 import { validateFileSafety } from './security/validateFileSafety.js';
 import type { PackSkillParams } from './skill/packSkill.js';
@@ -41,7 +41,14 @@ const defaultDeps = {
   collectFiles,
   processFiles,
   validateFileSafety,
-  produceOutput,
+  // Lazy-load produceOutput so its module chain (Handlebars template compile,
+  // output-style modules) loads in parallel with searchFiles + collect rather
+  // than blocking packager.ts entry. The dependency is invoked once per pack
+  // call so the import-cache overhead amortizes to a single resolve.
+  produceOutput: (async (...args: Parameters<typeof produceOutputType>) => {
+    const { produceOutput } = await import('./packager/produceOutput.js');
+    return produceOutput(...args);
+  }) as typeof produceOutputType,
   calculateMetrics,
   createMetricsTaskRunner,
   sortPaths,
@@ -92,42 +99,49 @@ export const pack = async (
     logger.trace('Failed to prefetch sort data:', error);
   });
 
-  progressCallback('Searching for files...');
-  const searchResultsByDir = await withMemoryLogging('Search Files', async () =>
-    Promise.all(
-      rootDirs.map(async (rootDir) => {
-        const result = await deps.searchFiles(rootDir, config, explicitFiles);
-        return { rootDir, filePaths: result.filePaths, emptyDirPaths: result.emptyDirPaths };
-      }),
-    ),
-  );
-
-  // Deduplicate and sort empty directory paths for reuse during output generation,
-  // avoiding a redundant searchFiles call in buildOutputGeneratorContext.
-  const emptyDirPaths = config.output.includeEmptyDirectories
-    ? [...new Set(searchResultsByDir.flatMap((r) => r.emptyDirPaths))].sort()
-    : undefined;
-
-  // Sort file paths
-  progressCallback('Sorting files...');
-  const allFilePaths = searchResultsByDir.flatMap(({ filePaths }) => filePaths);
-  const sortedFilePaths = deps.sortPaths(allFilePaths);
-
-  // Regroup sorted file paths by rootDir using Set for O(1) membership checks
-  const filePathSetByDir = new Map(searchResultsByDir.map(({ rootDir, filePaths }) => [rootDir, new Set(filePaths)]));
-  const sortedFilePathsByDir = rootDirs.map((rootDir) => ({
-    rootDir,
-    filePaths: sortedFilePaths.filter((filePath) => filePathSetByDir.get(rootDir)?.has(filePath) ?? false),
-  }));
-
-  // Pre-initialize metrics worker pool to overlap gpt-tokenizer loading with subsequent pipeline stages
-  // (security check, file processing, output generation).
+  // Pre-initialize the metrics worker pool BEFORE searchFiles so that
+  // gpt-tokenizer's ~200-285ms-per-worker BPE table parse overlaps the
+  // search + collect + security + process pipeline rather than only the
+  // post-search stages. Pool size is now decoupled from the file count
+  // (see METRICS_PREWARM_THREAD_CAP in calculateMetrics.ts) so it can be
+  // created without waiting on searchFiles to resolve.
+  //
+  // The pool is created OUTSIDE the try block so a synchronous throw from
+  // createMetricsTaskRunner does not leave us with no `finally` to clean it
+  // up; the matching `finally` below handles the post-construction case.
   const { taskRunner: metricsTaskRunner, warmupPromise: metricsWarmupPromise } = deps.createMetricsTaskRunner(
-    allFilePaths.length,
     config.tokenCount.encoding,
   );
 
   try {
+    progressCallback('Searching for files...');
+    const searchResultsByDir = await withMemoryLogging('Search Files', async () =>
+      Promise.all(
+        rootDirs.map(async (rootDir) => {
+          const result = await deps.searchFiles(rootDir, config, explicitFiles);
+          return { rootDir, filePaths: result.filePaths, emptyDirPaths: result.emptyDirPaths };
+        }),
+      ),
+    );
+
+    // Deduplicate and sort empty directory paths for reuse during output generation,
+    // avoiding a redundant searchFiles call in buildOutputGeneratorContext.
+    const emptyDirPaths = config.output.includeEmptyDirectories
+      ? [...new Set(searchResultsByDir.flatMap((r) => r.emptyDirPaths))].sort()
+      : undefined;
+
+    // Sort file paths
+    progressCallback('Sorting files...');
+    const allFilePaths = searchResultsByDir.flatMap(({ filePaths }) => filePaths);
+    const sortedFilePaths = deps.sortPaths(allFilePaths);
+
+    // Regroup sorted file paths by rootDir using Set for O(1) membership checks
+    const filePathSetByDir = new Map(searchResultsByDir.map(({ rootDir, filePaths }) => [rootDir, new Set(filePaths)]));
+    const sortedFilePathsByDir = rootDirs.map((rootDir) => ({
+      rootDir,
+      filePaths: sortedFilePaths.filter((filePath) => filePathSetByDir.get(rootDir)?.has(filePath) ?? false),
+    }));
+
     // Run file collection and git operations in parallel since they are independent:
     // - collectFiles reads file contents from disk
     // - getGitDiffs/getGitLogs spawn git subprocesses
@@ -213,16 +227,12 @@ export const pack = async (
       files: filePaths,
     }));
 
-    // Ensure warm-up task completes before metrics calculation
-    await metricsWarmupPromise;
-    // Ensure the token-count cache is loaded before calculateFileMetrics reads
-    // from it. The load was started at the very beginning of pack() and is
-    // typically already resolved; this await is a safety net for fast machines.
-    await tokenCacheLoadPromise;
-
     // Generate and write output, overlapping with metrics calculation.
     // File and git metrics don't depend on the output, so they start immediately
-    // while output generation runs concurrently.
+    // while output generation runs concurrently. The metrics warm-up and
+    // token-count cache load are awaited INSIDE the metrics branch only —
+    // produceOutput has no dependency on either, so blocking the whole pipeline
+    // on them would idle the main thread while workers are still spinning up.
     const outputPromise = deps.produceOutput(
       rootDirs,
       config,
@@ -239,8 +249,13 @@ export const pack = async (
 
     const [{ outputFiles }, metrics] = await Promise.all([
       outputPromise,
-      withMemoryLogging('Calculate Metrics', () =>
-        deps.calculateMetrics(
+      withMemoryLogging('Calculate Metrics', async () => {
+        // Ensure warm-up is done and the token cache is loaded before
+        // calculateMetrics tasks fire. Both promises were kicked off at the
+        // very start of pack(); these awaits are typically already-resolved
+        // by the time we get here.
+        await Promise.all([metricsWarmupPromise, tokenCacheLoadPromise]);
+        return deps.calculateMetrics(
           processedFiles,
           outputForMetricsPromise,
           progressCallback,
@@ -250,8 +265,8 @@ export const pack = async (
           {
             taskRunner: metricsTaskRunner,
           },
-        ),
-      ),
+        );
+      }),
     ]);
 
     // Create a result object that includes metrics and security results

--- a/tests/core/metrics/calculateMetrics.test.ts
+++ b/tests/core/metrics/calculateMetrics.test.ts
@@ -246,7 +246,7 @@ describe('calculateMetrics fast/slow path equivalence', () => {
 
 describe('createMetricsTaskRunner', () => {
   it('should return a taskRunner and warmupPromise', async () => {
-    const result = createMetricsTaskRunner(100, 'o200k_base');
+    const result = createMetricsTaskRunner('o200k_base');
 
     expect(result).toHaveProperty('taskRunner');
     expect(result).toHaveProperty('warmupPromise');
@@ -258,7 +258,7 @@ describe('createMetricsTaskRunner', () => {
   });
 
   it('should fire a warmup task with empty content', async () => {
-    const result = createMetricsTaskRunner(50, 'cl100k_base');
+    const result = createMetricsTaskRunner('cl100k_base');
 
     await result.warmupPromise;
 
@@ -272,7 +272,7 @@ describe('createMetricsTaskRunner', () => {
       cleanup: vi.fn(),
     });
 
-    const result = createMetricsTaskRunner(10, 'o200k_base');
+    const result = createMetricsTaskRunner('o200k_base');
 
     // warmupPromise should resolve (errors swallowed by .catch on each task)
     const resolved = await result.warmupPromise;

--- a/tests/core/packager.test.ts
+++ b/tests/core/packager.test.ts
@@ -185,6 +185,20 @@ describe('packager', () => {
       };
     };
 
+    test('cleans up the metrics worker pool when searchFiles rejects', async () => {
+      // Regression: the metrics pool is now created BEFORE searchFiles so the
+      // gpt-tokenizer warm-up overlaps the search phase. If searchFiles throws
+      // (e.g. a glob pattern collides with an unreadable directory), the
+      // surrounding try/finally must still tear the pool down — otherwise the
+      // Tinypool workers leak and Node.js keeps the process alive.
+      const { cleanup, deps } = baseDeps();
+      deps.searchFiles = vi.fn().mockRejectedValue(new Error('search failed'));
+
+      await expect(pack(['root'], createMockConfig(), vi.fn(), deps)).rejects.toThrow('search failed');
+
+      expect(cleanup).toHaveBeenCalled();
+    });
+
     test('cleans up the metrics worker pool when validateFileSafety rejects', async () => {
       const { cleanup, deps } = baseDeps();
       deps.validateFileSafety = vi.fn().mockRejectedValue(new Error('security check failed'));


### PR DESCRIPTION
## Summary

CI-bench bisect to identify which change in PR #1576 is doing the actual work. This branch keeps **#1 (early init), #2 (cap = 3), and #4 (drop blocking awaits)** but **drops #3 (lazy-import of `produceOutput`)**.

| | PR #1577 (#1+#4) | **This PR (#1+#2+#4)** | PR #1576 (all four) |
|---|---|---|---|
| Early init | ✅ | ✅ | ✅ |
| Cap = 3 | ❌ | ✅ | ✅ |
| Lazy `produceOutput` | ❌ | ❌ | ✅ |
| Drop blocking awaits | ✅ | ✅ | ✅ |
| Ubuntu | −0.6% | **TBD** | −9.1% |
| macOS | +1.4% | **TBD** | −2.0% |
| Windows | +2.6% | **TBD** | −4.6% |

## Expected outcomes (codex review)

- If CI numbers **match PR #1576** → #3 (lazy-import) is dead weight; merge this branch as the minimal scope.
- If CI numbers **fall short of PR #1576** → #3 contributes too; merge PR #1576 as the full bundle.

Codex's prediction: #2 (cap = 3) is the dominant contributor based on PR #1577's Windows regression evidence (uncapped early prewarm caused contention with `searchFiles`). #3 likely adds at most 25-50ms of module-load overlap on top.

## Checklist

- [x] Run `npm run test` — 1305 passing
- [x] Run `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)