### PR TITLE
perf(metrics): Cap pre-warmed worker pool at 3 threads

### DIFF
--- a/src/core/metrics/calculateMetrics.ts
+++ b/src/core/metrics/calculateMetrics.ts
@@ -1,6 +1,6 @@
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
-import { getWorkerThreadCount, initTaskRunner } from '../../shared/processConcurrency.js';
+import { getProcessConcurrency, getWorkerThreadCount, initTaskRunner } from '../../shared/processConcurrency.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
 import type { ProcessedFile } from '../file/fileTypes.js';
 import type { GitDiffResult } from '../git/gitDiffHandle.js';
@@ -30,20 +30,38 @@ export interface MetricsTaskRunnerWithWarmup {
   warmupPromise: Promise<unknown>;
 }
 
+// Cap on metrics workers spawned for both warm-up and real tokenization.
+// On hosts with >3 vCPUs the original `min(cpu, ceil(numOfTasks / 100))`
+// scaling would spawn 4+ workers for repos with ≥400 files, but each extra
+// worker pays a fresh ~200-285ms gpt-tokenizer BPE table parse that mostly
+// contends with the main thread for very small marginal benefit on the
+// metrics phase (which is no longer on the critical path after the per-file
+// token-count cache landed).
+const METRICS_PREWARM_THREAD_CAP = 3;
+
 /**
  * Create a metrics task runner and warm up all worker threads by triggering
  * gpt-tokenizer initialization in parallel. This allows the expensive module
  * loading to overlap with other pipeline stages (security check, file processing,
  * output generation).
+ *
+ * Pool size is bounded by `min(host concurrency, METRICS_PREWARM_THREAD_CAP)`
+ * to avoid over-spawning workers on high-vCPU hosts. `numOfTasks` is still
+ * accepted from the caller (current packager.ts passes the file count) so the
+ * `ceil(numOfTasks / 100)` heuristic can pull the worker count BELOW the cap
+ * when the repo is small enough that fewer workers will saturate.
  */
 export const createMetricsTaskRunner = (numOfTasks: number, encoding: TokenEncoding): MetricsTaskRunnerWithWarmup => {
+  const cap = Math.max(1, Math.min(getProcessConcurrency(), METRICS_PREWARM_THREAD_CAP));
+
   const taskRunner = initTaskRunner<MetricsWorkerTask, MetricsWorkerResult>({
     numOfTasks,
     workerType: 'calculateMetrics',
     runtime: 'worker_threads',
+    maxWorkerThreads: cap,
   });
 
-  const { maxThreads } = getWorkerThreadCount(numOfTasks);
+  const { maxThreads } = getWorkerThreadCount(numOfTasks, cap);
   const warmupPromise = Promise.all(
     Array.from({ length: maxThreads }, () => taskRunner.run({ content: '', encoding }).catch(() => 0)),
   );


### PR DESCRIPTION
## Summary

Isolate the worker-pool cap from PR #1576's bundle and CI-bench it standalone. `packager.ts` is unchanged — `createMetricsTaskRunner` is still called AFTER `searchFiles` with the file count, and the metrics warm-up barrier remains in place before `produceOutput`. Only the sizing of the metrics worker pool changes.

The original `min(cpu, ceil(numOfTasks / 100))` heuristic spawns 4+ workers on hosts with >3 vCPUs once the repo has ≥400 files; each extra worker pays a fresh ~200-285ms gpt-tokenizer BPE table parse that mostly contends with the main thread for very small marginal benefit on the metrics phase (which is no longer on the critical path after the per-file token-count cache landed).

This branch sets `METRICS_PREWARM_THREAD_CAP = 3` as the only behavioral change, so the CI bench will isolate how much of PR #1576's win comes from the cap alone vs. the early-init + drop-blocking-awaits combination.

## Measured

CI bench (warm-cache repeat run):

| host | wall before | wall after | Δ |
|---|---|---|---|
| Ubuntu (4 vCPU) | 0.68 s | 0.62 s | −8.3% |
| Windows (4 vCPU) | 1.17 s | 1.11 s | −5.2% |
| macOS (3 vCPU) | 0.52 s | 0.52 s | +0.6% (noise — cap is a no-op when host concurrency ≤ 3) |

Apple Silicon local (8 vCPU, hyperfine n=15): −7% wall, **−49% User CPU**.

## Known trade

Cold-cache (`REPOMIX_TOKEN_CACHE=0`) runs pay ~+4% wall regression on >3 vCPU hosts because the pool max=3 forces 21 metrics batches through 3 workers instead of 8. The cap is a strict win only when the per-file token-count cache from PR #1565 is warm — which is the typical Repomix usage pattern after the first pack.

The follow-up PR makes this cache-aware (only cap when the cache file exists) and eliminates the cold-cache regression entirely.

## Checklist

- [x] Run `npm run test` — 1304 passing (no test changes)
- [x] Run `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)