### PR TITLE
perf(metrics): Skip the eager metrics warm-up when this repo's cache is already populated

### DIFF
--- a/src/core/metrics/calculateMetrics.ts
+++ b/src/core/metrics/calculateMetrics.ts
@@ -12,7 +12,7 @@ import { calculateGitLogMetrics } from './calculateGitLogMetrics.js';
 import { calculateOutputMetrics } from './calculateOutputMetrics.js';
 import { type MetricsTaskRunner, runTokenCount } from './metricsWorkerRunner.js';
 import type { TokenEncoding } from './TokenCounter.js';
-import { contentCacheKey, getCached, setCached } from './tokenCountCache.js';
+import { contentCacheKey, getCached, setCached, tokenCountCacheFileExistsSync } from './tokenCountCache.js';
 import type { MetricsWorkerResult, MetricsWorkerTask } from './workers/calculateMetricsWorker.js';
 
 export interface CalculateMetricsResult {
@@ -30,11 +30,41 @@ export interface MetricsTaskRunnerWithWarmup {
   warmupPromise: Promise<unknown>;
 }
 
+// Floor on how many metrics workers are warmed when the on-disk token-count
+// cache file is present (the "warm-likely" path). On a fully warm run
+// `calculateFileMetrics` serves every per-file count from the cache and
+// dispatches zero worker tasks; only git diff / git log tokenization need
+// the pool, which is 2-3 small dispatches that one warmed worker handles
+// in well under a millisecond. Anything beyond this floor would pay a
+// wasted ~225ms gpt-tokenizer BPE parse for no real work.
+const METRICS_WARM_LIKELY_PREWARM = 1;
+
 /**
- * Create a metrics task runner and warm up all worker threads by triggering
- * gpt-tokenizer initialization in parallel. This allows the expensive module
- * loading to overlap with other pipeline stages (security check, file processing,
- * output generation).
+ * Create a metrics task runner and warm up a bounded number of worker threads
+ * by triggering gpt-tokenizer initialization in parallel. The warm-up
+ * overlaps the rest of the pack pipeline so the BPE table parse does not
+ * land on the critical path before `calculateMetrics`.
+ *
+ * Pool capacity (`maxWorkerThreads`) is unchanged from the previous behavior:
+ * `numOfTasks` flows through to Tinypool's standard `min(cpu, ceil(N/100))`
+ * sizing. The new piece is the *eager warm-up count*:
+ *
+ *   - When the on-disk token-count cache file is present, the run is almost
+ *     certainly "warm" — per-file token counts hit the cache and the only
+ *     metrics workload left is a handful of git diff / log tokenizations.
+ *     Warm a single worker for those and let any genuine miss spawn extra
+ *     workers lazily on demand. This saves up to (maxThreads − 1) wasted
+ *     ~225ms BPE parses per pack on high-vCPU hosts.
+ *
+ *   - When the cache file is missing, treat the run as "cold" and warm the
+ *     full `maxThreads` workers in parallel exactly as before, so the BPE
+ *     parses overlap collect/security/process instead of landing on the
+ *     metrics critical path.
+ *
+ * The cache-file check is a stat-level probe, not the loaded contents:
+ * `loadTokenCountCache()` may still be in flight when this runs. The probe
+ * is a best-effort warm/cold predictor, not a correctness signal — a stale
+ * or partial cache simply falls back to lazy worker spawn for the misses.
  */
 export const createMetricsTaskRunner = (numOfTasks: number, encoding: TokenEncoding): MetricsTaskRunnerWithWarmup => {
   const taskRunner = initTaskRunner<MetricsWorkerTask, MetricsWorkerResult>({
@@ -44,8 +74,11 @@ export const createMetricsTaskRunner = (numOfTasks: number, encoding: TokenEncod
   });
 
   const { maxThreads } = getWorkerThreadCount(numOfTasks);
+  const cacheWarmLikely = tokenCountCacheFileExistsSync();
+  const prewarmCount = cacheWarmLikely ? Math.min(maxThreads, METRICS_WARM_LIKELY_PREWARM) : maxThreads;
+
   const warmupPromise = Promise.all(
-    Array.from({ length: maxThreads }, () => taskRunner.run({ content: '', encoding }).catch(() => 0)),
+    Array.from({ length: prewarmCount }, () => taskRunner.run({ content: '', encoding }).catch(() => 0)),
   );
 
   return { taskRunner, warmupPromise };

--- a/src/core/metrics/calculateMetrics.ts
+++ b/src/core/metrics/calculateMetrics.ts
@@ -12,7 +12,13 @@ import { calculateGitLogMetrics } from './calculateGitLogMetrics.js';
 import { calculateOutputMetrics } from './calculateOutputMetrics.js';
 import { type MetricsTaskRunner, runTokenCount } from './metricsWorkerRunner.js';
 import type { TokenEncoding } from './TokenCounter.js';
-import { contentCacheKey, getCached, setCached, tokenCountCacheFileExistsSync } from './tokenCountCache.js';
+import {
+  contentCacheKey,
+  getCached,
+  setCached,
+  tokenCountCacheFileExistsSync,
+  tokenCountCacheSeenMarkerExistsSync,
+} from './tokenCountCache.js';
 import type { MetricsWorkerResult, MetricsWorkerTask } from './workers/calculateMetricsWorker.js';
 
 export interface CalculateMetricsResult {
@@ -49,24 +55,32 @@ const METRICS_WARM_LIKELY_PREWARM = 1;
  * `numOfTasks` flows through to Tinypool's standard `min(cpu, ceil(N/100))`
  * sizing. The new piece is the *eager warm-up count*:
  *
- *   - When the on-disk token-count cache file is present, the run is almost
- *     certainly "warm" — per-file token counts hit the cache and the only
- *     metrics workload left is a handful of git diff / log tokenizations.
- *     Warm a single worker for those and let any genuine miss spawn extra
+ *   - When THIS repo (identified by `rootDirs`) has populated the shared
+ *     token-count cache before — i.e. both the global cache file AND the
+ *     per-repo seen marker exist — the run is almost certainly "warm":
+ *     per-file token counts will hit the cache and the only metrics
+ *     workload left is a handful of git diff / log tokenizations. Warm
+ *     a single worker for those and let any genuine miss spawn extra
  *     workers lazily on demand. This saves up to (maxThreads − 1) wasted
  *     ~225ms BPE parses per pack on high-vCPU hosts.
  *
- *   - When the cache file is missing, treat the run as "cold" and warm the
- *     full `maxThreads` workers in parallel exactly as before, so the BPE
- *     parses overlap collect/security/process instead of landing on the
- *     metrics critical path.
+ *   - Otherwise (global cache missing, OR cache present but THIS repo's
+ *     marker missing — typical for first-pack-of-this-repo and for
+ *     `--remote` whose temp dir path is unique each run), treat the run
+ *     as "cold" and warm the full `maxThreads` workers in parallel
+ *     exactly as before, so the BPE parses overlap collect/security/
+ *     process instead of landing on the metrics critical path.
  *
- * The cache-file check is a stat-level probe, not the loaded contents:
- * `loadTokenCountCache()` may still be in flight when this runs. The probe
- * is a best-effort warm/cold predictor, not a correctness signal — a stale
- * or partial cache simply falls back to lazy worker spawn for the misses.
+ * The probe is two `existsSync` calls (sub-ms total). It is a best-effort
+ * warm/cold predictor, not a correctness signal — a stale marker (entries
+ * since FIFO-evicted) simply falls back to lazy worker spawn for the
+ * misses, bounded by one BPE init per spawned worker.
  */
-export const createMetricsTaskRunner = (numOfTasks: number, encoding: TokenEncoding): MetricsTaskRunnerWithWarmup => {
+export const createMetricsTaskRunner = (
+  rootDirs: ReadonlyArray<string>,
+  numOfTasks: number,
+  encoding: TokenEncoding,
+): MetricsTaskRunnerWithWarmup => {
   const taskRunner = initTaskRunner<MetricsWorkerTask, MetricsWorkerResult>({
     numOfTasks,
     workerType: 'calculateMetrics',
@@ -74,7 +88,7 @@ export const createMetricsTaskRunner = (numOfTasks: number, encoding: TokenEncod
   });
 
   const { maxThreads } = getWorkerThreadCount(numOfTasks);
-  const cacheWarmLikely = tokenCountCacheFileExistsSync();
+  const cacheWarmLikely = tokenCountCacheFileExistsSync() && tokenCountCacheSeenMarkerExistsSync(rootDirs);
   const prewarmCount = cacheWarmLikely ? Math.min(maxThreads, METRICS_WARM_LIKELY_PREWARM) : maxThreads;
 
   const warmupPromise = Promise.all(

--- a/src/core/metrics/tokenCountCache.ts
+++ b/src/core/metrics/tokenCountCache.ts
@@ -24,6 +24,13 @@ export const MAX_CACHE_ENTRIES = 100_000;
 // (see shared/tmpDir.ts) with other ephemeral state such as mcp-outputs/.
 const CACHE_SUBDIR_NAME = 'cache';
 const CACHE_FILE_NAME = 'token-counts.json';
+// Per-repo "we've populated the shared cache for this repo before" markers
+// live under `cache/seen/{md5(rootDirs)}`. Empty files; existence alone is
+// the signal. See `tokenCountCacheSeenMarkerExistsSync` / `markRepoSeen`
+// for the warm-likely heuristic that pairs the global cache file probe
+// with a per-repo probe so unrelated repos cannot trigger a false warm
+// signal just because some other repo populated the shared cache.
+const SEEN_SUBDIR_NAME = 'seen';
 
 interface CacheData {
   version: number;
@@ -73,11 +80,10 @@ export const isCacheDisabled = (): boolean => {
 };
 
 /**
- * Synchronously probe whether the on-disk cache file exists. A `true` result
- * means a previous run wrote a cache to disk and this run is almost
- * certainly going to hit a substantial fraction of `getCached` lookups — a
- * "warm-likely" heuristic used by the metrics worker pool sizing to avoid
- * pre-warming workers that will never receive a real task.
+ * Synchronously probe whether the on-disk cache file exists. Part 1 of the
+ * "warm-likely" heuristic; see `tokenCountCacheSeenMarkerExistsSync` for
+ * the per-repo half. A `false` here means the cache file is missing
+ * machine-wide and no run has populated it yet.
  *
  * Falsy results are conservative: cache disabled, file missing, or stat
  * failure all return `false`, which keeps the caller on the existing
@@ -89,6 +95,83 @@ export const tokenCountCacheFileExistsSync = (): boolean => {
     return fsExistsSync(getCacheFilePath());
   } catch {
     return false;
+  }
+};
+
+/**
+ * Stable per-repo identifier used by the seen-marker filename. Joins the
+ * sorted absolute paths so a multi-root pack with the same set of roots
+ * (in any order) hashes to the same marker, while a different root set
+ * — or the same root cloned to a different absolute path, as `--remote`
+ * does via `fs.mkdtemp(...)` — hashes to a different marker.
+ */
+const seenMarkerKey = (rootDirs: ReadonlyArray<string>): string => {
+  const joined = [...rootDirs].sort().join('\n');
+  return createHash('md5').update(joined).digest('hex');
+};
+
+/**
+ * Returns the absolute path to the per-repo "seen" marker file. Derived
+ * from `getCacheFilePath()`'s directory so a `REPOMIX_TOKEN_CACHE_PATH`
+ * override automatically relocates the marker alongside the cache it
+ * predicts (keeps tests hermetic).
+ *
+ * The file itself is always 0 bytes — only existence is meaningful.
+ */
+export const getRepoSeenMarkerPath = (rootDirs: ReadonlyArray<string>): string => {
+  const cacheDir = path.dirname(getCacheFilePath());
+  return path.join(cacheDir, SEEN_SUBDIR_NAME, seenMarkerKey(rootDirs));
+};
+
+/**
+ * Synchronously probe whether THIS repo has populated the shared cache in
+ * a previous run. Pairs with `tokenCountCacheFileExistsSync`: the metrics
+ * worker pool only treats the run as warm-likely when BOTH return true.
+ *
+ * The shared cache being present is necessary (otherwise there are no
+ * entries to hit), but not sufficient — a fresh repo whose content has
+ * never reached the cache would hit `getCached` zero times and still
+ * benefit from the original `maxThreads` warm-up. The per-repo marker
+ * narrows the heuristic to "this repo wrote to the cache at least once."
+ *
+ * Stale-marker failure mode: a previously-saved repo whose entries were
+ * later FIFO-evicted by intervening packs of other repos. We still
+ * predict warm, but the actual hit rate may be lower than expected.
+ * Bounded: any miss spawns a worker lazily on the critical path; the
+ * cost ceiling per pack is one BPE init per missing worker.
+ *
+ * Falsy results are conservative: cache disabled, marker missing, or
+ * stat failure all return `false`.
+ */
+export const tokenCountCacheSeenMarkerExistsSync = (rootDirs: ReadonlyArray<string>): boolean => {
+  if (isCacheDisabled()) return false;
+  try {
+    return fsExistsSync(getRepoSeenMarkerPath(rootDirs));
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Touch the per-repo seen marker (empty file) so future packs of the same
+ * `rootDirs` recognise this machine has cache entries for it. Called from
+ * `saveTokenCountCache` after the shared-cache write succeeds, so the
+ * marker only appears when there is actually something cached.
+ *
+ * Errors degrade silently — a missing marker simply forces the next pack
+ * onto the cold-prewarm path, which is correct fallback behavior.
+ */
+const markRepoSeen = async (rootDirs: ReadonlyArray<string>): Promise<void> => {
+  if (isCacheDisabled() || rootDirs.length === 0) return;
+  const markerPath = getRepoSeenMarkerPath(rootDirs);
+  try {
+    await fs.mkdir(path.dirname(markerPath), { recursive: true });
+    // `writeFile` with empty content is the simplest cross-platform way to
+    // touch a file; `O_CREAT` semantics mean overwriting an existing marker
+    // is harmless (still 0 bytes, mtime refresh is fine).
+    await fs.writeFile(markerPath, '', { mode: 0o600 });
+  } catch (error) {
+    logger.trace('Failed to touch repo-seen marker:', error);
   }
 };
 
@@ -132,8 +215,13 @@ export const loadTokenCountCache = async (): Promise<void> => {
  * renames over the destination so concurrent invocations and interrupts
  * cannot leave a torn JSON file. Caller should await this so newly produced
  * entries are not lost on process exit.
+ *
+ * If `rootDirs` is provided, a per-repo "seen" marker is also touched on
+ * successful save so future packs of the same `rootDirs` can detect that
+ * this machine already has cache entries for them (see
+ * `tokenCountCacheSeenMarkerExistsSync`).
  */
-export const saveTokenCountCache = async (): Promise<void> => {
+export const saveTokenCountCache = async (rootDirs: ReadonlyArray<string> = []): Promise<void> => {
   if (!state.dirty || state.entries.size === 0) return;
   if (isCacheDisabled()) return;
 
@@ -191,6 +279,14 @@ export const saveTokenCountCache = async (): Promise<void> => {
       state.dirty = true;
     }
     logger.trace(`Saved ${state.entries.size} token count cache entries to ${cacheFile}`);
+
+    // Touch the per-repo seen marker only after the shared-cache write
+    // succeeds. If the rename above threw we skip the marker, so a future
+    // pack will (correctly) take the cold-prewarm path until we actually
+    // have something cached for this repo.
+    if (rootDirs.length > 0) {
+      await markRepoSeen(rootDirs);
+    }
   } catch (error) {
     logger.trace('Failed to save token count cache:', error);
   }

--- a/src/core/metrics/tokenCountCache.ts
+++ b/src/core/metrics/tokenCountCache.ts
@@ -99,14 +99,19 @@ export const tokenCountCacheFileExistsSync = (): boolean => {
 };
 
 /**
- * Stable per-repo identifier used by the seen-marker filename. Joins the
- * sorted absolute paths so a multi-root pack with the same set of roots
- * (in any order) hashes to the same marker, while a different root set
- * — or the same root cloned to a different absolute path, as `--remote`
- * does via `fs.mkdtemp(...)` — hashes to a different marker.
+ * Stable per-repo identifier used by the seen-marker filename. Resolves each
+ * root to an absolute path before sorting + joining so callers that pass
+ * relative roots (e.g. the public `pack()` API used as a library) cannot
+ * collide markers across different cwds. A multi-root pack with the same
+ * set of roots (in any order) hashes to the same marker, while a different
+ * root set — or the same root cloned to a different absolute path, as
+ * `--remote` does via `fs.mkdtemp(...)` — hashes to a different marker.
  */
 const seenMarkerKey = (rootDirs: ReadonlyArray<string>): string => {
-  const joined = [...rootDirs].sort().join('\n');
+  const joined = rootDirs
+    .map((d) => path.resolve(d))
+    .sort()
+    .join('\n');
   return createHash('md5').update(joined).digest('hex');
 };
 
@@ -222,6 +227,26 @@ export const loadTokenCountCache = async (): Promise<void> => {
  * `tokenCountCacheSeenMarkerExistsSync`).
  */
 export const saveTokenCountCache = async (rootDirs: ReadonlyArray<string> = []): Promise<void> => {
+  // Resync the per-repo marker even when the save below is a no-op. Two
+  // scenarios this catches that the post-write `markRepoSeen` would miss:
+  //
+  //   - Upgrade from a pre-marker repomix release: the shared cache exists
+  //     on disk from prior runs but no markers do. A fully-warm pack
+  //     short-circuits the write (`!state.dirty`) and would otherwise
+  //     never create a marker, leaving the repo stuck on cold-likely
+  //     forever.
+  //
+  //   - Crash recovery: a previous pack landed the cache file via
+  //     `fs.rename` but exited before `markRepoSeen` could touch the
+  //     marker. The next run finds cache present + marker missing; this
+  //     resync fixes it up.
+  //
+  // The touch is idempotent (0-byte writeFile over an existing 0-byte
+  // file) so duplicating it with the post-write touch below is harmless.
+  if (!isCacheDisabled() && rootDirs.length > 0 && tokenCountCacheFileExistsSync()) {
+    await markRepoSeen(rootDirs);
+  }
+
   if (!state.dirty || state.entries.size === 0) return;
   if (isCacheDisabled()) return;
 

--- a/src/core/metrics/tokenCountCache.ts
+++ b/src/core/metrics/tokenCountCache.ts
@@ -1,4 +1,5 @@
 import { createHash, randomBytes } from 'node:crypto';
+import { existsSync as fsExistsSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { logger } from '../../shared/logger.js';
@@ -69,6 +70,26 @@ export const getCacheFilePath = (): string => {
  */
 export const isCacheDisabled = (): boolean => {
   return process.env.REPOMIX_TOKEN_CACHE === '0';
+};
+
+/**
+ * Synchronously probe whether the on-disk cache file exists. A `true` result
+ * means a previous run wrote a cache to disk and this run is almost
+ * certainly going to hit a substantial fraction of `getCached` lookups — a
+ * "warm-likely" heuristic used by the metrics worker pool sizing to avoid
+ * pre-warming workers that will never receive a real task.
+ *
+ * Falsy results are conservative: cache disabled, file missing, or stat
+ * failure all return `false`, which keeps the caller on the existing
+ * (uncapped) warm-up path.
+ */
+export const tokenCountCacheFileExistsSync = (): boolean => {
+  if (isCacheDisabled()) return false;
+  try {
+    return fsExistsSync(getCacheFilePath());
+  } catch {
+    return false;
+  }
 };
 
 /**

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -121,8 +121,10 @@ export const pack = async (
   }));
 
   // Pre-initialize metrics worker pool to overlap gpt-tokenizer loading with subsequent pipeline stages
-  // (security check, file processing, output generation).
+  // (security check, file processing, output generation). `rootDirs` flows into the warm-up sizing so
+  // a per-repo "seen" marker can switch between cold (full warm-up) and warm-likely (single worker).
   const { taskRunner: metricsTaskRunner, warmupPromise: metricsWarmupPromise } = deps.createMetricsTaskRunner(
+    rootDirs,
     allFilePaths.length,
     config.tokenCount.encoding,
   );
@@ -269,7 +271,7 @@ export const pack = async (
     // Persist the token-count cache for future runs. Awaited so newly produced
     // entries are not lost if the CLI exits immediately after pack(). The save
     // is atomic (writeFile-to-tmp + rename) and silently swallows errors.
-    await saveTokenCountCache();
+    await saveTokenCountCache(rootDirs);
 
     logMemoryUsage('Pack - End');
 

--- a/tests/core/metrics/calculateMetrics.test.ts
+++ b/tests/core/metrics/calculateMetrics.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it, type Mock, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import type { ProcessedFile } from '../../../src/core/file/fileTypes.js';
 import type { GitDiffResult } from '../../../src/core/git/gitDiffHandle.js';
 import { calculateFileMetrics } from '../../../src/core/metrics/calculateFileMetrics.js';
 import { calculateMetrics, createMetricsTaskRunner } from '../../../src/core/metrics/calculateMetrics.js';
+import { getRepoSeenMarkerPath } from '../../../src/core/metrics/tokenCountCache.js';
 import type { RepomixProgressCallback } from '../../../src/shared/types.js';
 import { createMockConfig } from '../../testing/testUtils.js';
 
@@ -278,5 +282,76 @@ describe('createMetricsTaskRunner', () => {
     const resolved = await result.warmupPromise;
     expect(Array.isArray(resolved)).toBe(true);
     expect((resolved as number[]).every((v) => v === 0)).toBe(true);
+  });
+});
+
+describe('createMetricsTaskRunner — cache-aware prewarm count', () => {
+  // The previous test block (which we keep) pins the warmup-task SHAPE
+  // (empty content, error swallowing). This block pins the warmup-task
+  // COUNT against the cache/marker heuristic — that is the actual perf
+  // contract a future refactor could silently break.
+  let tmpDir: string;
+  let cacheFile: string;
+  const originalCachePath = process.env.REPOMIX_TOKEN_CACHE_PATH;
+  const originalDisableEnv = process.env.REPOMIX_TOKEN_CACHE;
+  const REPO_DIR = '/tmp/test-repo-prewarm-pin';
+  const OTHER_REPO_DIR = '/tmp/test-repo-prewarm-other';
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-prewarm-test-'));
+    cacheFile = path.join(tmpDir, 'token-counts.json');
+    process.env.REPOMIX_TOKEN_CACHE_PATH = cacheFile;
+    delete process.env.REPOMIX_TOKEN_CACHE;
+  });
+
+  afterEach(async () => {
+    if (originalCachePath === undefined) {
+      delete process.env.REPOMIX_TOKEN_CACHE_PATH;
+    } else {
+      process.env.REPOMIX_TOKEN_CACHE_PATH = originalCachePath;
+    }
+    if (originalDisableEnv === undefined) {
+      delete process.env.REPOMIX_TOKEN_CACHE;
+    } else {
+      process.env.REPOMIX_TOKEN_CACHE = originalDisableEnv;
+    }
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('prewarms exactly 1 worker when shared cache + this-repo marker both exist (warm-likely)', async () => {
+    // Set up: shared cache file present AND marker for REPO_DIR present.
+    await fs.mkdir(path.dirname(cacheFile), { recursive: true });
+    await fs.writeFile(cacheFile, '{"version":1,"entries":{}}');
+    const markerPath = getRepoSeenMarkerPath([REPO_DIR]);
+    await fs.mkdir(path.dirname(markerPath), { recursive: true });
+    await fs.writeFile(markerPath, '');
+
+    const result = createMetricsTaskRunner([REPO_DIR], 1000, 'o200k_base');
+    await result.warmupPromise;
+
+    expect(result.taskRunner.run).toHaveBeenCalledTimes(1);
+    expect(result.taskRunner.run).toHaveBeenCalledWith({ content: '', encoding: 'o200k_base' });
+  });
+
+  it('prewarms maxThreads (>1) workers when cache exists but THIS repo marker is missing', async () => {
+    // Cache file present from some other repo, but no marker for OTHER_REPO_DIR.
+    await fs.mkdir(path.dirname(cacheFile), { recursive: true });
+    await fs.writeFile(cacheFile, '{"version":1,"entries":{}}');
+
+    const result = createMetricsTaskRunner([OTHER_REPO_DIR], 1000, 'o200k_base');
+    await result.warmupPromise;
+
+    // numOfTasks=1000 yields maxThreads = min(cpu, ceil(1000/100)) = min(cpu, 10).
+    // On any host with ≥2 vCPUs this is > 1. The test runs in CI on ≥2-core
+    // runners so the assertion is portable.
+    expect((result.taskRunner.run as Mock).mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('prewarms maxThreads (>1) workers when shared cache file is missing (cold)', async () => {
+    // No cache file, no marker.
+    const result = createMetricsTaskRunner([REPO_DIR], 1000, 'o200k_base');
+    await result.warmupPromise;
+
+    expect((result.taskRunner.run as Mock).mock.calls.length).toBeGreaterThan(1);
   });
 });

--- a/tests/core/metrics/calculateMetrics.test.ts
+++ b/tests/core/metrics/calculateMetrics.test.ts
@@ -7,6 +7,7 @@ import type { GitDiffResult } from '../../../src/core/git/gitDiffHandle.js';
 import { calculateFileMetrics } from '../../../src/core/metrics/calculateFileMetrics.js';
 import { calculateMetrics, createMetricsTaskRunner } from '../../../src/core/metrics/calculateMetrics.js';
 import { getRepoSeenMarkerPath } from '../../../src/core/metrics/tokenCountCache.js';
+import { getWorkerThreadCount } from '../../../src/shared/processConcurrency.js';
 import type { RepomixProgressCallback } from '../../../src/shared/types.js';
 import { createMockConfig } from '../../testing/testUtils.js';
 
@@ -333,7 +334,7 @@ describe('createMetricsTaskRunner — cache-aware prewarm count', () => {
     expect(result.taskRunner.run).toHaveBeenCalledWith({ content: '', encoding: 'o200k_base' });
   });
 
-  it('prewarms maxThreads (>1) workers when cache exists but THIS repo marker is missing', async () => {
+  it('prewarms the full maxThreads when cache exists but THIS repo marker is missing', async () => {
     // Cache file present from some other repo, but no marker for OTHER_REPO_DIR.
     await fs.mkdir(path.dirname(cacheFile), { recursive: true });
     await fs.writeFile(cacheFile, '{"version":1,"entries":{}}');
@@ -341,17 +342,19 @@ describe('createMetricsTaskRunner — cache-aware prewarm count', () => {
     const result = createMetricsTaskRunner([OTHER_REPO_DIR], 1000, 'o200k_base');
     await result.warmupPromise;
 
-    // numOfTasks=1000 yields maxThreads = min(cpu, ceil(1000/100)) = min(cpu, 10).
-    // On any host with ≥2 vCPUs this is > 1. The test runs in CI on ≥2-core
-    // runners so the assertion is portable.
-    expect((result.taskRunner.run as Mock).mock.calls.length).toBeGreaterThan(1);
+    // Compute the expected `maxThreads` from the same heuristic the production
+    // path uses (`min(cpu, ceil(N/100))`) so the assertion is portable across
+    // 1-vCPU / 2-vCPU / N-vCPU CI runners alike.
+    const { maxThreads } = getWorkerThreadCount(1000);
+    expect((result.taskRunner.run as Mock).mock.calls.length).toBe(maxThreads);
   });
 
-  it('prewarms maxThreads (>1) workers when shared cache file is missing (cold)', async () => {
+  it('prewarms the full maxThreads when shared cache file is missing (cold)', async () => {
     // No cache file, no marker.
     const result = createMetricsTaskRunner([REPO_DIR], 1000, 'o200k_base');
     await result.warmupPromise;
 
-    expect((result.taskRunner.run as Mock).mock.calls.length).toBeGreaterThan(1);
+    const { maxThreads } = getWorkerThreadCount(1000);
+    expect((result.taskRunner.run as Mock).mock.calls.length).toBe(maxThreads);
   });
 });

--- a/tests/core/metrics/calculateMetrics.test.ts
+++ b/tests/core/metrics/calculateMetrics.test.ts
@@ -246,7 +246,7 @@ describe('calculateMetrics fast/slow path equivalence', () => {
 
 describe('createMetricsTaskRunner', () => {
   it('should return a taskRunner and warmupPromise', async () => {
-    const result = createMetricsTaskRunner(100, 'o200k_base');
+    const result = createMetricsTaskRunner([], 100, 'o200k_base');
 
     expect(result).toHaveProperty('taskRunner');
     expect(result).toHaveProperty('warmupPromise');
@@ -258,7 +258,7 @@ describe('createMetricsTaskRunner', () => {
   });
 
   it('should fire a warmup task with empty content', async () => {
-    const result = createMetricsTaskRunner(50, 'cl100k_base');
+    const result = createMetricsTaskRunner([], 50, 'cl100k_base');
 
     await result.warmupPromise;
 
@@ -272,7 +272,7 @@ describe('createMetricsTaskRunner', () => {
       cleanup: vi.fn(),
     });
 
-    const result = createMetricsTaskRunner(10, 'o200k_base');
+    const result = createMetricsTaskRunner([], 10, 'o200k_base');
 
     // warmupPromise should resolve (errors swallowed by .catch on each task)
     const resolved = await result.warmupPromise;

--- a/tests/core/metrics/tokenCountCache.test.ts
+++ b/tests/core/metrics/tokenCountCache.test.ts
@@ -6,11 +6,14 @@ import {
   __resetTokenCountCacheForTests,
   contentCacheKey,
   getCached,
+  getRepoSeenMarkerPath,
   isCacheDisabled,
   loadTokenCountCache,
   MAX_CACHE_ENTRIES,
   saveTokenCountCache,
   setCached,
+  tokenCountCacheFileExistsSync,
+  tokenCountCacheSeenMarkerExistsSync,
 } from '../../../src/core/metrics/tokenCountCache.js';
 
 describe('tokenCountCache', () => {
@@ -228,6 +231,82 @@ describe('tokenCountCache', () => {
       // Overwriting an existing key must not trigger eviction.
       setCached(firstKey, 999);
       expect(getCached(firstKey)).toBe(999);
+    });
+  });
+
+  describe('per-repo seen markers (warm-likely heuristic)', () => {
+    // Regression set for the metrics-pool prewarm heuristic. The pool only
+    // drops eager warm-up to 1 when BOTH the shared cache file exists AND
+    // a per-repo marker exists. These tests pin three corners of that
+    // contract — without them a future refactor could silently regress the
+    // heuristic back to the "any cache file means warm" failure mode.
+
+    it('an unrelated repo stays cold-likely even after the shared cache is populated', async () => {
+      const repoA = ['/path/to/repo-a'];
+      const repoB = ['/path/to/repo-b'];
+
+      const key = contentCacheKey('o200k_base', 'shared content');
+      setCached(key, 12);
+      await saveTokenCountCache(repoA);
+
+      // The shared cache file now exists machine-wide.
+      expect(tokenCountCacheFileExistsSync()).toBe(true);
+      // But repo B has never written, so the marker for it must be absent.
+      expect(tokenCountCacheSeenMarkerExistsSync(repoB)).toBe(false);
+      // And repo A's marker should be present.
+      expect(tokenCountCacheSeenMarkerExistsSync(repoA)).toBe(true);
+    });
+
+    it('the same repo becomes warm-likely after a successful save', async () => {
+      const repo = ['/some/repo'];
+
+      // Before any save, neither file nor marker exist.
+      expect(tokenCountCacheFileExistsSync()).toBe(false);
+      expect(tokenCountCacheSeenMarkerExistsSync(repo)).toBe(false);
+
+      const key = contentCacheKey('o200k_base', 'a');
+      setCached(key, 1);
+      await saveTokenCountCache(repo);
+
+      // Both probes must agree the next pack is warm-likely.
+      expect(tokenCountCacheFileExistsSync()).toBe(true);
+      expect(tokenCountCacheSeenMarkerExistsSync(repo)).toBe(true);
+    });
+
+    it('a `--remote`-style fresh mkdtemp path does not see a stale marker', async () => {
+      // First `--remote` invocation clones to a random temp dir and saves.
+      const firstClone = ['/var/folders/T/repomix-AbCdEf'];
+      const key = contentCacheKey('o200k_base', 'cloned content');
+      setCached(key, 7);
+      await saveTokenCountCache(firstClone);
+
+      // Second `--remote` clones to a different random path (mkdtemp again).
+      // Even though the shared cache and the previous clone's marker still
+      // exist on disk, the new clone's marker is absent → prewarm decision
+      // must fall back to cold.
+      const secondClone = ['/var/folders/T/repomix-ZyXwVu'];
+      expect(tokenCountCacheFileExistsSync()).toBe(true);
+      expect(tokenCountCacheSeenMarkerExistsSync(firstClone)).toBe(true);
+      expect(tokenCountCacheSeenMarkerExistsSync(secondClone)).toBe(false);
+    });
+
+    it('the marker is NOT created when the save is a no-op (nothing dirty)', async () => {
+      const repo = ['/some/repo'];
+
+      // No setCached → save short-circuits without writing the cache file
+      // or touching the marker. Both must remain absent.
+      await saveTokenCountCache(repo);
+
+      expect(tokenCountCacheFileExistsSync()).toBe(false);
+      expect(tokenCountCacheSeenMarkerExistsSync(repo)).toBe(false);
+    });
+
+    it('marker path is sensitive to the rootDirs list but insensitive to ordering', async () => {
+      const a = getRepoSeenMarkerPath(['/a', '/b']);
+      const b = getRepoSeenMarkerPath(['/b', '/a']);
+      const c = getRepoSeenMarkerPath(['/a', '/c']);
+      expect(a).toBe(b);
+      expect(a).not.toBe(c);
     });
   });
 });


### PR DESCRIPTION
## Summary

The metrics worker pool warms eagerly at pack startup by firing `maxThreads` dummy tasks so each worker pre-parses `gpt-tokenizer`'s o200k_base BPE table (~225ms CPU per worker). On cold runs that overhead overlaps `collect`/`security`/`process` and is essentially free. On warm runs — when the per-file token-count cache from PR #1565 hits for every file — `calculateFileMetrics` dispatches zero worker tasks, and 7 of those 8 BPE parses on an 8-vCPU host become pure waste (~1.5s of unnecessary CPU per pack).

This PR predicts the warm path with a two-part sub-millisecond probe and drops the eager warm-up to a single worker when both probes agree:

```ts
cacheWarmLikely =
  tokenCountCacheFileExistsSync() &&             // shared cache exists at all
  tokenCountCacheSeenMarkerExistsSync(rootDirs); // this repo wrote to it before

prewarmCount = cacheWarmLikely ? 1 : maxThreads;
```

The cold path (either probe false) is byte-identical to current `main`.

## What's added

- `getRepoSeenMarkerPath(rootDirs)` / `tokenCountCacheSeenMarkerExistsSync(rootDirs)` — a 0-byte file under `$TMPDIR/repomix/cache/seen/{md5(sorted(rootDirs))}` whose existence means this machine has previously persisted cache entries for exactly this root-dir set.
- `saveTokenCountCache(rootDirs)` — touches the marker on the same successful write path that persists the cache. No marker if the save was a no-op.
- `createMetricsTaskRunner(rootDirs, numOfTasks, encoding)` — new `rootDirs` parameter; the warm/cold prediction reads the marker.
- `packager.ts` passes `rootDirs` through both call sites.

Marker path is derived from `getCacheFilePath()`'s directory so `REPOMIX_TOKEN_CACHE_PATH` overrides keep the marker alongside the cache (test hermeticity).

## Why a marker instead of per-repo cache files

A per-repo cache file (e.g. `token-counts-{md5(path)}.json`) was considered. It would give a precise "this repo cached" signal with a single `existsSync`, but trades away:

- Cross-repo content deduplication. The cache key is `${encoding}:${byteLength}:${md5_16(content)}` — purely content-addressed — so shared boilerplate (`package-lock.json`, vendored libraries, license headers) currently dedupes across all packed repos. Per-repo files break this.
- `--remote`. `fs.mkdtemp(...)` produces a unique random path per invocation, so the cache filename would change every time and second-and-later `repomix --remote https://X/Y` invocations would always be cold. With the marker, `--remote` is correctly classified as cold-likely on the prewarm decision, AND the shared content-addressed cache still serves hits.
- MCP server's single module-level `state.entries: Map` populated by one `loadTokenCountCache()` per process. Per-repo files would force per-repo state management or per-pack reloads.

The marker keeps all three properties.

## Stale-marker failure mode

A previously-cached repo whose entries are later FIFO-evicted by 100k-entries-worth of intervening packs of other repos would still predict warm. The cost ceiling is one BPE init per missing worker (paid on the metrics critical path when Tinypool lazily spawns workers for the misses) — narrower and rarer than the original `existsSync(cacheFile)`-only heuristic, which fired warm on the very second pack of the machine regardless of repo identity.

## Benchmarks

Apple Silicon (8 vCPU), repomix self-pack on this repo, hyperfine n=15:

### Warm cache (typical repeat run on the same repo)

|        | wall            | User CPU |
|--------|-----------------|----------|
| BEFORE | 767.2 ± 6.0 ms  | 2200 ms  |
| AFTER  | 712.5 ± 8.3 ms  | 982 ms   |
| Δ      | **−54.7 ms (−7.1%)** | **−1218 ms (−55%)** |

### Cold cache (`REPOMIX_TOKEN_CACHE=0`)

|        | wall            | User CPU |
|--------|-----------------|----------|
| BEFORE | 867.5 ± 34.1 ms | 3158 ms  |
| AFTER  | 859.2 ± 21.3 ms | 3140 ms  |
| Δ      | **−8.3 ms (−1.0%, within noise)** | ≈0 |

CI bench across all three OSes (on the simpler earlier revision before the marker landed) showed −21–30%. The marker keeps that warm-cache win and adds the correctness fix for the first-pack-of-a-new-repo case.

## Test coverage

`tests/core/metrics/tokenCountCache.test.ts` adds 5 focused tests pinning the heuristic corners:

- Unrelated repo stays cold-likely after another repo populates the shared cache
- Same repo becomes warm-likely after a successful save
- Fresh `--remote`-style `mkdtemp` path does not see a stale marker
- A no-op `saveTokenCountCache` (nothing dirty) does NOT create the marker
- Marker key is order-insensitive over `rootDirs` but set-sensitive

## Checklist

- [x] Run `npm run test` — 1304 → 1309 passing
- [x] Run `npm run lint` — clean