### PR TITLE
ci(website): Add docs:build step to website client job

### DIFF
--- a/.github/workflows/ci-website.yml
+++ b/.github/workflows/ci-website.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Lint website client
         working-directory: website/client
         run: node --run lint
+      - name: Build website client
+        working-directory: website/client
+        run: node --run docs:build
 
   lint-website-server:
     name: Lint Website Server


### PR DESCRIPTION
## Summary

- Append `node --run docs:build` after `node --run lint` in the `lint-website-client` workflow.
- The existing `tsgo --noEmit` lint does not fully typecheck Vue SFCs and composables, so regressions there only surface on the next deploy. Running the VitePress build catches them at PR time.

## Verification

- Local `node --run docs:build` completes in ~33s on the current `main`.

## Checklist

- [x] Run `node --run lint` (website/client)
- [x] Run `node --run docs:build` (website/client) — passes locally