### PR TITLE
fix(website): Make pack button cancel work via keyboard

### DIFF
--- a/website/client/components/Home/PackButton.vue
+++ b/website/client/components/Home/PackButton.vue
@@ -4,7 +4,7 @@
     :class="{ 'pack-button--loading': loading }"
     :disabled="!isValid && !loading"
     :aria-label="loading ? 'Cancel processing' : 'Pack repository'"
-    type="submit"
+    :type="loading ? 'button' : 'submit'"
     @click="handleClick"
   >
     <span class="pack-button__text pack-button__text--normal">
@@ -28,8 +28,9 @@ const props = defineProps<{
 const emit = defineEmits<(e: 'cancel') => void>();
 
 function handleClick(event: MouseEvent) {
-  // Only handle cancel on actual mouse clicks, not on form submission (Enter key)
-  if (props.loading && event.detail > 0) {
+  // type=button while loading prevents form submission, so any click
+  // (mouse or keyboard) safely signals cancel.
+  if (props.loading) {
     event.preventDefault();
     event.stopPropagation();
     emit('cancel');


### PR DESCRIPTION
## Summary

- Switch the pack button's `type` to `button` while loading so the form does not submit on Enter/Space.
- Drop the `event.detail > 0` guard so any click event — mouse or keyboard — emits `cancel` while loading.

## Why

The previous handler only fired `cancel` when `event.detail > 0` (true for real mouse clicks). When the button was activated via the keyboard, the browser fires a click with `detail === 0`, so keyboard users could not cancel an in-flight pack request.

## Checklist

- [x] Run `node --run lint` (website/client)