### PR TITLE
perf(website): Lazy-load Ace editor via dynamic import

### DIFF
--- a/website/client/components/Home/TryItResult.vue
+++ b/website/client/components/Home/TryItResult.vue
@@ -9,8 +9,15 @@ import TryItLoading from './TryItLoading.vue';
 import TryItResultErrorContent from './TryItResultErrorContent.vue';
 
 // Defer loading the Ace-editor-based result view (vue3-ace-editor + ace-builds
-// are heavy) until a pack result actually needs to render.
-const TryItResultContent = defineAsyncComponent(() => import('./TryItResultContent.vue'));
+// total ~480 KB) until a pack result actually needs to render. `delay: 200`
+// avoids a loading flicker on fast networks; `timeout: 10000` surfaces stalled
+// chunk fetches instead of leaving the panel blank indefinitely.
+const TryItResultContent = defineAsyncComponent({
+  loader: () => import('./TryItResultContent.vue'),
+  loadingComponent: TryItLoading,
+  delay: 200,
+  timeout: 10000,
+});
 
 interface Props {
   result?: PackResult | null;

--- a/website/client/components/Home/TryItResult.vue
+++ b/website/client/components/Home/TryItResult.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, defineAsyncComponent, ref } from 'vue';
 import type { PackOptions } from '../../composables/usePackOptions';
 import type { TabType } from '../../types/ui';
 import type { DisplayProgressStage, FileInfo, PackResult } from '../api/client';
 import SupportMessage from './SupportMessage.vue';
 import TryItFileSelection from './TryItFileSelection.vue';
 import TryItLoading from './TryItLoading.vue';
-import TryItResultContent from './TryItResultContent.vue';
 import TryItResultErrorContent from './TryItResultErrorContent.vue';
+
+// Defer loading the Ace-editor-based result view (vue3-ace-editor + ace-builds
+// are heavy) until a pack result actually needs to render.
+const TryItResultContent = defineAsyncComponent(() => import('./TryItResultContent.vue'));
 
 interface Props {
   result?: PackResult | null;


### PR DESCRIPTION
## Summary

- Wrap `TryItResultContent.vue` with `defineAsyncComponent` in `TryItResult.vue` so `ace-builds` / `vue3-ace-editor` (~480 KB of JS) load on demand instead of as part of the landing-page bundle.

## Why

The Ace editor is only needed once the user has packed a repository, but it was previously imported statically and shipped with the initial bundle. Deferring it shrinks the homepage payload and improves Core Web Vitals (LCP/INP), particularly on mobile / low-bandwidth connections.

## Verification

- `node --run docs:build` produces a separate `TryItResultContent.*.js` chunk (~480 KB) confirming the editor is now split out.

## Checklist

- [x] Run `node --run lint` (website/client)
- [x] Run `node --run docs:build` (website/client)