### PR TITLE
fix(website): Improve accessibility of tabs and file upload widgets

### DIFF
--- a/website/client/components/Home/TryIt.vue
+++ b/website/client/components/Home/TryIt.vue
@@ -2,9 +2,12 @@
   <div class="container">
     <form class="try-it-container" @submit.prevent="handleSubmit($event)">
       <div class="input-row">
-        <div class="tab-container">
+        <div class="tab-container" role="tablist" aria-label="Repository input source">
           <button
             type="button"
+            role="tab"
+            aria-label="Remote repository URL"
+            :aria-selected="mode === 'url'"
             :class="{ active: mode === 'url' }"
             @click="setMode('url')"
           >
@@ -12,6 +15,9 @@
           </button>
           <button
             type="button"
+            role="tab"
+            aria-label="Upload local folder"
+            :aria-selected="mode === 'folder'"
             :class="{ active: mode === 'folder' }"
             @click="setMode('folder')"
           >
@@ -19,6 +25,9 @@
           </button>
           <button
             type="button"
+            role="tab"
+            aria-label="Upload ZIP archive"
+            :aria-selected="mode === 'file'"
             :class="{ active: mode === 'file' }"
             @click="setMode('file')"
           >

--- a/website/client/components/Home/TryIt.vue
+++ b/website/client/components/Home/TryIt.vue
@@ -4,9 +4,11 @@
       <div class="input-row">
         <div class="tab-container" role="tablist" aria-label="Repository input source">
           <button
+            id="tab-url"
             type="button"
             role="tab"
             aria-label="Remote repository URL"
+            aria-controls="tabpanel-input"
             :aria-selected="mode === 'url'"
             :class="{ active: mode === 'url' }"
             @click="setMode('url')"
@@ -14,9 +16,11 @@
             <Link2 size="20" class="icon" />
           </button>
           <button
+            id="tab-folder"
             type="button"
             role="tab"
             aria-label="Upload local folder"
+            aria-controls="tabpanel-input"
             :aria-selected="mode === 'folder'"
             :class="{ active: mode === 'folder' }"
             @click="setMode('folder')"
@@ -24,9 +28,11 @@
             <FolderOpen size="20" class="icon" />
           </button>
           <button
+            id="tab-file"
             type="button"
             role="tab"
             aria-label="Upload ZIP archive"
+            aria-controls="tabpanel-input"
             :aria-selected="mode === 'file'"
             :class="{ active: mode === 'file' }"
             @click="setMode('file')"
@@ -35,7 +41,12 @@
           </button>
         </div>
 
-        <div class="input-field">
+        <div
+          id="tabpanel-input"
+          class="input-field"
+          role="tabpanel"
+          :aria-labelledby="`tab-${mode}`"
+        >
           <TryItFileUpload
             v-if="mode === 'file'"
             @upload="handleFileUpload"
@@ -352,6 +363,12 @@ onMounted(() => {
 .tab-container button.active {
   background: var(--vp-c-brand-1);
   color: white;
+}
+
+.tab-container button:focus-visible {
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: -2px;
+  z-index: 1;
 }
 
 .tab-container button.active::before {

--- a/website/client/components/Home/TryItFileUpload.vue
+++ b/website/client/components/Home/TryItFileUpload.vue
@@ -66,10 +66,15 @@ function clearFile() {
     <div
       class="upload-container"
       :class="{ 'drag-active': dragActive, 'has-error': hasError }"
+      role="button"
+      tabindex="0"
+      aria-label="Upload ZIP file"
       @dragover.prevent="handleDragOver"
       @dragleave="handleDragLeave"
       @drop.prevent="onDrop"
       @click="triggerFileInput"
+      @keydown.enter.prevent="triggerFileInput"
+      @keydown.space.prevent="triggerFileInput"
     >
       <input
         ref="fileInput"
@@ -88,7 +93,12 @@ function clearFile() {
           </p>
           <p v-else-if="selectedFile" class="selected-file">
             Selected: {{ selectedFile }}
-            <button class="clear-button" @click.stop="clearFile">×</button>
+            <button
+              type="button"
+              class="clear-button"
+              aria-label="Clear selected file"
+              @click.stop="clearFile"
+            >×</button>
           </p>
           <template v-else>
             <p>Drop your ZIP file here or click to browse (max 10MB)</p>

--- a/website/client/components/Home/TryItFileUpload.vue
+++ b/website/client/components/Home/TryItFileUpload.vue
@@ -73,8 +73,8 @@ function clearFile() {
       @dragleave="handleDragLeave"
       @drop.prevent="onDrop"
       @click="triggerFileInput"
-      @keydown.enter.prevent="triggerFileInput"
-      @keydown.space.prevent="triggerFileInput"
+      @keydown.enter.self.prevent="triggerFileInput"
+      @keydown.space.self.prevent="triggerFileInput"
     >
       <input
         ref="fileInput"
@@ -137,6 +137,11 @@ function clearFile() {
 .upload-container:hover {
   border-color: var(--vp-c-brand-1);
   background-color: var(--vp-c-bg-soft);
+}
+
+.upload-container:focus-visible {
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: 2px;
 }
 
 .drag-active {

--- a/website/client/components/Home/TryItFolderUpload.vue
+++ b/website/client/components/Home/TryItFolderUpload.vue
@@ -76,10 +76,15 @@ function clearFolder() {
     <div
       class="upload-container"
       :class="{ 'drag-active': dragActive, 'has-error': hasError }"
+      role="button"
+      tabindex="0"
+      aria-label="Upload folder"
       @dragover.prevent="handleDragOver"
       @dragleave="handleDragLeave"
       @drop.prevent="onDrop"
       @click="triggerFileInput"
+      @keydown.enter.prevent="triggerFileInput"
+      @keydown.space.prevent="triggerFileInput"
     >
       <input
         ref="fileInput"
@@ -98,7 +103,12 @@ function clearFolder() {
           </p>
           <p v-else-if="selectedFolder" class="selected-file">
             Selected: {{ selectedFolder }}
-            <button class="clear-button" @click.stop="clearFolder">×</button>
+            <button
+              type="button"
+              class="clear-button"
+              aria-label="Clear selected folder"
+              @click.stop="clearFolder"
+            >×</button>
           </p>
           <template v-else>
             <p>Drop your folder here or click to browse (max 10MB)</p>

--- a/website/client/components/Home/TryItFolderUpload.vue
+++ b/website/client/components/Home/TryItFolderUpload.vue
@@ -83,8 +83,8 @@ function clearFolder() {
       @dragleave="handleDragLeave"
       @drop.prevent="onDrop"
       @click="triggerFileInput"
-      @keydown.enter.prevent="triggerFileInput"
-      @keydown.space.prevent="triggerFileInput"
+      @keydown.enter.self.prevent="triggerFileInput"
+      @keydown.space.self.prevent="triggerFileInput"
     >
       <input
         ref="fileInput"
@@ -150,6 +150,11 @@ function clearFolder() {
 .upload-container:hover {
   border-color: var(--vp-c-brand-1);
   background-color: var(--vp-c-bg-soft);
+}
+
+.upload-container:focus-visible {
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: 2px;
 }
 
 .drag-active {

--- a/website/client/components/Home/TryItResult.vue
+++ b/website/client/components/Home/TryItResult.vue
@@ -65,17 +65,25 @@ const handleRepack = (selectedFiles: FileInfo[]) => {
     />
     <div v-else-if="result" class="result-content">
       <!-- Tab Navigation -->
-      <div v-if="hasFileSelection" class="tab-navigation">
-        <button 
+      <div v-if="hasFileSelection" class="tab-navigation" role="tablist" aria-label="Pack result view">
+        <button
+          id="tab-result"
           type="button"
+          role="tab"
+          aria-controls="tabpanel-result"
+          :aria-selected="activeTab === 'result'"
           class="tab-button"
           :class="{ active: activeTab === 'result' }"
           @click="handleTabClick('result')"
         >
           Result
         </button>
-        <button 
+        <button
+          id="tab-files"
           type="button"
+          role="tab"
+          aria-controls="tabpanel-files"
+          :aria-selected="activeTab === 'files'"
           class="tab-button"
           :class="{ active: activeTab === 'files' }"
           @click="handleTabClick('files')"
@@ -85,10 +93,20 @@ const handleRepack = (selectedFiles: FileInfo[]) => {
       </div>
 
       <!-- Tab Content -->
-      <div v-show="activeTab === 'result' || !hasFileSelection">
+      <div
+        id="tabpanel-result"
+        role="tabpanel"
+        aria-labelledby="tab-result"
+        v-show="activeTab === 'result' || !hasFileSelection"
+      >
         <TryItResultContent :result="result" :pack-options="packOptions" />
       </div>
-      <div v-show="activeTab === 'files' && hasFileSelection">
+      <div
+        id="tabpanel-files"
+        role="tabpanel"
+        aria-labelledby="tab-files"
+        v-show="activeTab === 'files' && hasFileSelection"
+      >
         <TryItFileSelection
           v-if="hasFileSelection"
           :all-files="result.metadata!.allFiles!"

--- a/website/client/components/Home/TryItResult.vue
+++ b/website/client/components/Home/TryItResult.vue
@@ -155,6 +155,11 @@ const handleRepack = (selectedFiles: FileInfo[]) => {
   color: var(--vp-c-text-1);
 }
 
+.tab-button:focus-visible {
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: -2px;
+}
+
 .tab-button.active {
   color: var(--vp-c-brand-1);
   border-bottom-color: var(--vp-c-brand-1);


### PR DESCRIPTION
## Summary

- Add `role="tablist"` / `role="tab"` / `aria-selected` to the URL/Folder/ZIP mode tabs in `TryIt.vue` and the Result/File Selection tabs in `TryItResult.vue`.
- Give each tab panel `role="tabpanel"` + `aria-labelledby` so assistive tech can pair the active tab with its content.
- Make file and folder upload drop zones focusable: `role="button"`, `tabindex="0"`, Enter/Space activation, and an `aria-label`.
- Add an `aria-label` to the inline clear (×) button for the selected file/folder.

## Why

Tab triggers had no role or selected-state hints, so screen reader users could not tell which view was active. The upload drop zones were a `div` over a `display:none` input, which made the picker unreachable by keyboard and invisible to screen readers.

## Checklist

- [x] Run `node --run lint` (website/client)
- [x] Run `node --run docs:build` (website/client)