### PR TITLE
fix(website): remove invalid Turnstile size 'invisible', hide container via CSS

### DIFF
--- a/website/client/components/Home/TryIt.vue
+++ b/website/client/components/Home/TryIt.vue
@@ -478,4 +478,16 @@ onMounted(() => {
   border-color: #333 transparent transparent transparent;
 }
 
+/* The Turnstile widget is executed programmatically via execution: 'execute'.
+   The container must remain in the DOM (removing it prevents widget rendering)
+   but should not affect page layout or be visible. */
+.turnstile-container {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  visibility: hidden;
+  pointer-events: none;
+}
+
 </style>

--- a/website/client/composables/useTurnstile.ts
+++ b/website/client/composables/useTurnstile.ts
@@ -87,7 +87,6 @@ export function useTurnstile() {
       if (!widgetId.value) {
         widgetId.value = turnstile.render(el, {
           sitekey: siteKey,
-          size: 'invisible',
           action: 'pack',
           execution: 'execute',
           callback: (token: string) => {

--- a/website/client/composables/useTurnstileScript.ts
+++ b/website/client/composables/useTurnstileScript.ts
@@ -18,7 +18,7 @@ export interface TurnstileGlobal {
 
 export interface TurnstileRenderOptions {
   sitekey: string;
-  size?: 'normal' | 'compact' | 'invisible';
+  size?: 'normal' | 'compact' | 'flexible';
   // `action` is bound into the issued token and verified server-side, so a
   // token minted for /api/pack can't be replayed at a future endpoint that
   // expects a different action.


### PR DESCRIPTION
## Problem

Cloudflare Turnstile throws a `TurnstileError` when `size: 'invisible'` is passed to `render()`:

```
Uncaught TurnstileError: [Cloudflare Turnstile] Invalid value for parameter "size",
expected "compact", "flexible", or "normal", got "invisible".
```

This breaks the Pack form on repomix.com for affected users (reported in #1551).

The valid values for the `size` parameter are `'normal'`, `'compact'`, and `'flexible'`. The value `'invisible'` was never a documented Turnstile option and is rejected by recent Turnstile script versions.

## Solution

1. **`useTurnstile.ts`** — remove `size: 'invisible'` from the `render()` options. The non-interactive behaviour is already provided by `execution: 'execute'`, which defers the challenge until `mintToken()` is called.

2. **`useTurnstileScript.ts`** — update the `TurnstileRenderOptions.size` type to match the actual API (`'normal' | 'compact' | 'flexible'`).

3. **`TryIt.vue`** — add a `.turnstile-container` CSS rule (`position: absolute; width/height: 0; overflow: hidden; visibility: hidden`) so the widget does not consume layout space or appear visually when rendered without a size.

## Testing

- `npm run lint` — no errors
- `npm run test` — all 1312 tests pass
- Verified the render options no longer include `size: 'invisible'`

Fixes #1551