### PR TITLE
chore(skills): Sharpen repomix-explorer description

### DIFF
--- a/skills/repomix-explorer/SKILL.md
+++ b/skills/repomix-explorer/SKILL.md
@@ -1,6 +1,19 @@
 ---
 name: repomix-explorer
-description: "Use this skill when the user wants to analyze or explore a codebase (remote repository or local repository) using Repomix. Triggers on: 'analyze this repo', 'explore codebase', 'what's the structure', 'find patterns in repo', 'how many files/tokens'. Runs repomix CLI to pack repositories, then analyzes the output."
+description: |
+  Analyze or explore a codebase (remote or local repository) by packing it with the Repomix CLI, then reading and searching the generated output. Use when the user wants a high-level understanding of an unfamiliar or large repo, not a targeted edit.
+
+  Trigger for:
+  - Structure/overview: "analyze this repo", "what's the structure", "explain this codebase", "what's in vercel/next.js"
+  - Pattern discovery across many files: "find all auth code", "where are the API endpoints", "show me all React components"
+  - Metrics: "how many files/tokens", "largest files", "TypeScript vs JavaScript ratio"
+  - Remote repos: any github.com URL or "owner/repo" the user wants explored
+
+  DO NOT trigger for:
+  - Editing, refactoring, or writing code in the current project
+  - Reading or searching a known file/path (use Read or grep directly)
+  - Single-symbol lookups answerable with one grep
+  - Git operations, running tests, builds, or installs
 ---
 
 You are an expert code analyst specializing in repository exploration using Repomix CLI. Your role is to help users understand codebases by running repomix commands, then reading and analyzing the generated output files.

--- a/skills/repomix-explorer/SKILL.md
+++ b/skills/repomix-explorer/SKILL.md
@@ -11,8 +11,8 @@ description: |
 
   DO NOT trigger for:
   - Editing, refactoring, or writing code in the current project
-  - Reading or searching a known file/path (use Read or grep directly)
-  - Single-symbol lookups answerable with one grep
+  - Reading or searching a known file/path in the local project (use Read or grep directly)
+  - Single-symbol lookups in the local project answerable with one grep
   - Git operations, running tests, builds, or installs
 ---
 


### PR DESCRIPTION
## Summary

Rewrites the `repomix-explorer` skill description so it activates more precisely, modeled on the description style in [GoogleChrome/modern-web-guidance](https://github.com/GoogleChrome/modern-web-guidance/tree/main/skills/modern-web-guidance).

- Switch from a single-line string to a block scalar for readability.
- List **`Trigger for:`** cases by category (structure/overview, pattern discovery, metrics, remote repos) with concrete example phrasings.
- Add an explicit **`DO NOT trigger for:`** list (single-file edits, known-path greps, single-symbol lookups, git/test/build ops) to prevent over-triggering on targeted work.

Skill body is unchanged; this only refines the activation description.

## Checklist

- [ ] Run \`npm run test\`
- [ ] Run \`npm run lint\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)