### PR TITLE
feat(website): Enable auto-pack when repo URL parameter is present

### DIFF
--- a/website/client/components/Home/TryIt.vue
+++ b/website/client/components/Home/TryIt.vue
@@ -283,16 +283,16 @@ onMounted(() => {
   // If repository parameter exists and is valid, trigger packing automatically
   // Skip auto-execution for bots/crawlers to prevent unintended API calls
   // (e.g., Applebot executing JS on permalink URLs causes mass pack requests)
-  // if (urlParams.repo && isValidRemoteValue(urlParams.repo.trim()) && !isBot()) {
-  //   // Use nextTick to ensure all reactive values are properly initialized
-  //   nextTick(async () => {
-  //     try {
-  //       await handleSubmit();
-  //     } catch (error) {
-  //       console.error('Auto-execution failed:', error);
-  //     }
-  //   });
-  // }
+  if (urlParams.repo && isValidRemoteValue(urlParams.repo.trim()) && !isBot()) {
+    // Use nextTick to ensure all reactive values are properly initialized
+    nextTick(async () => {
+      try {
+        await handleSubmit();
+      } catch (error) {
+        console.error('Auto-execution failed:', error);
+      }
+    });
+  }
 });
 </script>
 


### PR DESCRIPTION
## Summary

Re-enables automatic packing on the website when a repository is provided via the `?repo=` URL parameter. This logic was previously commented out in `website/client/components/Home/TryIt.vue` to prevent crawler-driven mass pack requests, but with the Cloudflare bot defense (Bot Fight Mode + invisible Turnstile) now reliably in place, it is safe to turn back on.

### Details
- Uncomments the auto-execution block inside `onMounted()` in `TryIt.vue`.
- All supporting code (URL param parsing, `isValidRemoteValue`, `isBot`, `nextTick`, `handleSubmit`) was already imported/defined — only the commented block was activated.
- Keeps the `!isBot()` guard as defense-in-depth: auto-execution was originally disabled because crawlers (e.g. Applebot) executing JS on permalink URLs caused mass API calls. Cloudflare is now the primary layer, with `isBot()` as a secondary safeguard.

### Verification
- `website/client` typecheck (`tsgo --noEmit`) — passes
- `npm run docs:build` (VitePress / Vue SFC compile) — passes

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`