### PR TITLE
chore(renovate): Ignore @clack/prompts major update

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -96,6 +96,7 @@
     "node",
     "isbinaryfile", // v6+ requires Node.js >= 24
     "iconv-lite", // v0.7.1 has broken ESM types: https://github.com/pillarjs/iconv-lite/issues/363
+    "@clack/prompts", // v1 changes text() validate arg to `string | undefined`, breaks initAction.ts (TS18048)
   ],
   "minimumReleaseAge": "7 days"
 }


### PR DESCRIPTION
## Summary

Adds `@clack/prompts` to the renovate `ignoreDeps` list to defer its v1 major update.

### Why
The root major dependencies update ([#1607](https://github.com/yamadashy/repomix/pull/1607)) is fully red. The cause is `@clack/prompts` v1:

- v1 changed the `text()` `validate` callback argument from `string` to `string | undefined`.
- `src/cli/actions/initAction.ts:97` calls `value.length` directly, which now fails type-checking:
  ```
  src/cli/actions/initAction.ts(97,33): error TS18048: 'value' is possibly 'undefined'.
  ```
- Because `build` (`tsc`) runs via the `prepare` lifecycle hook, every `npm ci` fails — so **all** CI jobs (lint, test, build, bundle, benchmark, …) cascade-fail at the install step.

Deferring the major bump keeps `main` green. The v1 migration (making the `validate` callback null-safe, plus reviewing other clack v1 behavioral changes) can be done in a dedicated follow-up.

### Scope
Only `@clack/prompts` is ignored. `typescript` 6.0 and `@secretlint/*` 13 stay in the major group so CI can evaluate them on their own once clack is out of the batch.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`