### PR TITLE
perf(core): Automated performance tuning by Claude

### DIFF
--- a/src/core/output/outputGenerate.ts
+++ b/src/core/output/outputGenerate.ts
@@ -76,6 +76,22 @@ const calculateFileLineCounts = (processedFiles: ProcessedFile[]): Record<string
 };
 
 export const createRenderContext = (outputGeneratorContext: OutputGeneratorContext): RenderContext => {
+  const { config, processedFiles } = outputGeneratorContext;
+
+  // `fileLineCounts` is only consumed by the skill-generation path
+  // (skillSectionGenerators / skillStatistics). For the standard xml/markdown/plain
+  // output templates it is never referenced, so skip the full-content newline scan
+  // over every file unless skill generation is active.
+  const skillGenerateActive = config.skillGenerate !== undefined;
+  const fileLineCounts = skillGenerateActive ? calculateFileLineCounts(processedFiles) : {};
+
+  // `markdownCodeBlockDelimiter` is only referenced by the Markdown template and the
+  // skill sections (which also render Markdown-style code fences). For xml/plain output
+  // it is unused, so skip scanning every file for backtick runs and fall back to the
+  // default fence.
+  const markdownCodeBlockDelimiter =
+    config.output.style === 'markdown' || skillGenerateActive ? calculateMarkdownDelimiter(processedFiles) : '```';
+
   return {
     generationHeader: generateHeader(outputGeneratorContext.config, outputGeneratorContext.generationDate),
     summaryPurpose: generateSummaryPurpose(outputGeneratorContext.config),
@@ -89,12 +105,12 @@ export const createRenderContext = (outputGeneratorContext: OutputGeneratorConte
     instruction: outputGeneratorContext.instruction,
     treeString: outputGeneratorContext.treeString,
     processedFiles: outputGeneratorContext.processedFiles,
-    fileLineCounts: calculateFileLineCounts(outputGeneratorContext.processedFiles),
+    fileLineCounts,
     fileSummaryEnabled: outputGeneratorContext.config.output.fileSummary,
     directoryStructureEnabled: outputGeneratorContext.config.output.directoryStructure,
     filesEnabled: outputGeneratorContext.config.output.files,
     escapeFileContent: outputGeneratorContext.config.output.parsableStyle,
-    markdownCodeBlockDelimiter: calculateMarkdownDelimiter(outputGeneratorContext.processedFiles),
+    markdownCodeBlockDelimiter,
     gitDiffEnabled: outputGeneratorContext.config.output.git?.includeDiffs,
     gitDiffWorkTree: outputGeneratorContext.gitDiffResult?.workTreeDiffContent,
     gitDiffStaged: outputGeneratorContext.gitDiffResult?.stagedDiffContent,


### PR DESCRIPTION
Skip two full-content scans in `createRenderContext` (`src/core/output/outputGenerate.ts`) that are computed on every run but only consumed by output paths that aren't active in the default run.

## Summary

`createRenderContext` unconditionally computed two values by scanning the **entire content of every file**:

- **`calculateFileLineCounts`** — a `/\n/g` regex over every file. Only ever read by the **skill-generation path** (`skillSectionGenerators` / `skillStatistics`). The xml / markdown / plain / json output templates never reference it.
- **`calculateMarkdownDelimiter`** — a backtick-run regex over every file. Only read by the **Markdown** template and the skill sections (which render Markdown-style code fences). For xml / plain / json it is unused.

This PR gates both behind the paths that actually consume them:

```ts
const skillGenerateActive = config.skillGenerate !== undefined;
const fileLineCounts = skillGenerateActive ? calculateFileLineCounts(processedFiles) : {};
const markdownCodeBlockDelimiter =
  config.output.style === 'markdown' || skillGenerateActive
    ? calculateMarkdownDelimiter(processedFiles)
    : '```';
```

In warm-cache runs the output branch (`produceOutput`) is the wall-clock critical path — it overlaps with the much cheaper metrics branch — so eliminating these two scans maps almost 1:1 to wall-clock time.

## Behavior preservation

This is a pure performance change; output is unchanged.

- The skill path always has `config.skillGenerate !== undefined` in production (guarded at `packager.ts` before `packSkill`, and set by the MCP `generateSkillTool`), so `fileLineCounts` is still fully computed wherever it's consumed.
- The Markdown template still always receives the real delimiter (`style === 'markdown'`). For xml/plain/json — which never read the field — the default `'```'` fence is substituted (and equals what `calculateMarkdownDelimiter` returns for zero-backtick content anyway).
- Output verified **byte-identical** across xml / markdown / plain (the only diff observed was the edited source file itself appearing in repomix's self-pack).
- json and parsable-xml paths confirmed to reference neither field.
- Reviewed by two independent agents for edge cases (empty repo, multi-root, `--style json`, parsable variants, MCP) — no production behavior change.

## Benchmark

repomix self-pack, warm token-count cache, paired interleaved A/B (base vs changed `lib`, alternating order to cancel drift), `node` process spawn measuring full CLI wall-clock, 60 pairs:

| metric | value |
| --- | --- |
| base mean | 1242.3 ms |
| **paired delta** | **23.8 ms = 1.91%** |
| 95% CI | [0.94%, 2.88%] (i.e. [11.7, 35.8] ms) |
| changed faster in | 43 / 60 pairs |

The point estimate lands just under the 2% target and within measurement noise of it (the container is shared/noisy; per-sample SD ≈ 47 ms). The win is a genuine ~24 ms of eliminated dead work with zero behavioral risk, so it's offered here as a safe, low-risk improvement for review.

> Note: this branch is `claude/optimistic-goodall-z9N2O` (the session's mandated working branch) rather than `perf/auto-perf-tuning`.

## Checklist

- [x] Run `npm run test` — 1320/1320 passing
- [x] Run `npm run lint` — biome / oxlint / tsgo clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01HDSv3o5qcHNjogZViLZ5WD)_