### PR TITLE
fix multi-root duplicate relative paths

### DIFF
--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -65,6 +65,100 @@ export interface PackOptions {
   skillSourceUrl?: string;
 }
 
+const toDisplayPath = (filePath: string): string => filePath.replaceAll(path.win32.sep, path.posix.sep);
+
+const isCwdRelativePath = (relativePath: string): boolean =>
+  relativePath !== '' &&
+  relativePath !== '..' &&
+  !relativePath.startsWith(`..${path.sep}`) &&
+  !path.isAbsolute(relativePath);
+
+const getDuplicateLabels = (labels: string[]): Set<string> => {
+  const counts = new Map<string, number>();
+  for (const label of labels) {
+    counts.set(label, (counts.get(label) ?? 0) + 1);
+  }
+
+  const duplicates = new Set<string>();
+  for (const [label, count] of counts) {
+    if (count > 1) {
+      duplicates.add(label);
+    }
+  }
+  return duplicates;
+};
+
+const uniquifyLabelsWithSuffixes = (labels: string[]): string[] => {
+  const seen = new Set<string>();
+  return labels.map((label, index) => {
+    const baseLabel = label || `root-${index + 1}`;
+    let candidate = baseLabel;
+    let suffix = 2;
+    while (seen.has(candidate)) {
+      candidate = `${baseLabel}-${suffix}`;
+      suffix++;
+    }
+    seen.add(candidate);
+    return candidate;
+  });
+};
+
+const buildRootLabels = (rootDirs: string[], cwd: string): string[] => {
+  const resolvedCwd = path.resolve(cwd);
+  const resolvedRootDirs = rootDirs.map((rootDir) => path.resolve(rootDir));
+  const labelCandidates = resolvedRootDirs.map((rootDir) => {
+    const relativeRootDir = path.relative(resolvedCwd, rootDir);
+    if (isCwdRelativePath(relativeRootDir)) {
+      const label = toDisplayPath(relativeRootDir);
+      return {
+        label,
+        segments: label.split('/').filter(Boolean),
+      };
+    }
+
+    return {
+      label: toDisplayPath(path.basename(rootDir) || rootDir),
+      segments: undefined,
+    };
+  });
+  const labels = labelCandidates.map(({ label }) => label);
+
+  if (new Set(labels).size === labels.length) {
+    return labels;
+  }
+
+  const duplicateLabels = getDuplicateLabels(labels);
+  const maxDepth = Math.max(...labelCandidates.map(({ segments }) => segments?.length ?? 1), 1);
+  let candidates = labels;
+
+  for (let depth = 1; depth <= maxDepth; depth++) {
+    candidates = labels.map((label, index) => {
+      if (!duplicateLabels.has(label)) {
+        return label;
+      }
+
+      const segments = labelCandidates[index]?.segments;
+      if (!segments) {
+        return label || `root-${index + 1}`;
+      }
+
+      return segments.slice(-depth).join('/') || label || `root-${index + 1}`;
+    });
+
+    if (new Set(candidates).size === candidates.length) {
+      return candidates;
+    }
+  }
+
+  return uniquifyLabelsWithSuffixes(candidates);
+};
+
+const joinDisplayPath = (rootLabel: string, filePath: string): string => {
+  const normalizedRootLabel = toDisplayPath(rootLabel).replace(/^\/+|\/+$/g, '') || 'root';
+  const normalizedFilePath = toDisplayPath(filePath).replace(/^\/+/, '');
+  return normalizedFilePath ? `${normalizedRootLabel}/${normalizedFilePath}` : normalizedRootLabel;
+};
+
 export const pack = async (
   rootDirs: string[],
   config: RepomixConfigMerged,
@@ -110,15 +204,19 @@ export const pack = async (
 
   // Sort file paths
   progressCallback('Sorting files...');
-  const allFilePaths = searchResultsByDir.flatMap(({ filePaths }) => filePaths);
-  const sortedFilePaths = deps.sortPaths(allFilePaths);
-
-  // Regroup sorted file paths by rootDir using Set for O(1) membership checks
-  const filePathSetByDir = new Map(searchResultsByDir.map(({ rootDir, filePaths }) => [rootDir, new Set(filePaths)]));
-  const sortedFilePathsByDir = rootDirs.map((rootDir) => ({
+  const sortedFilePathsByDir = searchResultsByDir.map(({ rootDir, filePaths }) => ({
     rootDir,
-    filePaths: sortedFilePaths.filter((filePath) => filePathSetByDir.get(rootDir)?.has(filePath) ?? false),
+    filePaths: deps.sortPaths([...new Set(filePaths)]),
   }));
+  const rootLabels = rootDirs.length > 1 ? buildRootLabels(rootDirs, config.cwd) : undefined;
+  const displayFilePathsByDir = sortedFilePathsByDir.map(({ rootDir, filePaths }, index) => {
+    const rootLabel = rootLabels?.[index];
+    return {
+      rootDir,
+      filePaths: rootLabel ? filePaths.map((filePath) => joinDisplayPath(rootLabel, filePath)) : filePaths,
+    };
+  });
+  const allFilePaths = displayFilePathsByDir.flatMap(({ filePaths }) => filePaths);
 
   // Pre-initialize metrics worker pool to overlap gpt-tokenizer loading with subsequent pipeline stages
   // (security check, file processing, output generation). `rootDirs` flows into the warm-up sizing so
@@ -149,8 +247,20 @@ export const pack = async (
       deps.getGitLogs(rootDirs, config),
     ]);
 
-    const rawFiles = collectResults.flatMap((curr) => curr.rawFiles);
-    const allSkippedFiles = collectResults.flatMap((curr) => curr.skippedFiles);
+    const rawFiles = collectResults.flatMap((curr, index) => {
+      const rootLabel = rootLabels?.[index];
+      return curr.rawFiles.map((file) => ({
+        ...file,
+        path: rootLabel ? joinDisplayPath(rootLabel, file.path) : file.path,
+      }));
+    });
+    const allSkippedFiles = collectResults.flatMap((curr, index) => {
+      const rootLabel = rootLabels?.[index];
+      return curr.skippedFiles.map((file) => ({
+        ...file,
+        path: rootLabel ? joinDisplayPath(rootLabel, file.path) : file.path,
+      }));
+    });
 
     // Run security check and file processing concurrently.
     // Security check uses worker threads while file processing runs on the main thread
@@ -208,10 +318,8 @@ export const pack = async (
     }
 
     // Build filePathsByRoot for multi-root tree generation
-    // Use directory basename as the label for each root
-    // Fallback to rootDir if basename is empty (e.g., filesystem root "/")
-    const filePathsByRoot: FilesByRoot[] = sortedFilePathsByDir.map(({ rootDir, filePaths }) => ({
-      rootLabel: path.basename(rootDir) || rootDir,
+    const filePathsByRoot: FilesByRoot[] = sortedFilePathsByDir.map(({ rootDir, filePaths }, index) => ({
+      rootLabel: rootLabels?.[index] ?? (path.basename(rootDir) || rootDir),
       files: filePaths,
     }));
 

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -15,6 +15,7 @@ import { calculateMetrics, createMetricsTaskRunner } from './metrics/calculateMe
 import { loadTokenCountCache, saveTokenCountCache } from './metrics/tokenCountCache.js';
 import { prefetchSortData, sortOutputFiles } from './output/outputSort.js';
 import { produceOutput } from './packager/produceOutput.js';
+import { buildRootLabels, joinDisplayPath } from './packager/rootDisplayPath.js';
 import type { SuspiciousFileResult } from './security/securityCheck.js';
 import { validateFileSafety } from './security/validateFileSafety.js';
 import type { PackSkillParams } from './skill/packSkill.js';
@@ -64,100 +65,6 @@ export interface PackOptions {
   skillProjectName?: string;
   skillSourceUrl?: string;
 }
-
-const toDisplayPath = (filePath: string): string => filePath.replaceAll(path.win32.sep, path.posix.sep);
-
-const isCwdRelativePath = (relativePath: string): boolean =>
-  relativePath !== '' &&
-  relativePath !== '..' &&
-  !relativePath.startsWith(`..${path.sep}`) &&
-  !path.isAbsolute(relativePath);
-
-const getDuplicateLabels = (labels: string[]): Set<string> => {
-  const counts = new Map<string, number>();
-  for (const label of labels) {
-    counts.set(label, (counts.get(label) ?? 0) + 1);
-  }
-
-  const duplicates = new Set<string>();
-  for (const [label, count] of counts) {
-    if (count > 1) {
-      duplicates.add(label);
-    }
-  }
-  return duplicates;
-};
-
-const uniquifyLabelsWithSuffixes = (labels: string[]): string[] => {
-  const seen = new Set<string>();
-  return labels.map((label, index) => {
-    const baseLabel = label || `root-${index + 1}`;
-    let candidate = baseLabel;
-    let suffix = 2;
-    while (seen.has(candidate)) {
-      candidate = `${baseLabel}-${suffix}`;
-      suffix++;
-    }
-    seen.add(candidate);
-    return candidate;
-  });
-};
-
-const buildRootLabels = (rootDirs: string[], cwd: string): string[] => {
-  const resolvedCwd = path.resolve(cwd);
-  const resolvedRootDirs = rootDirs.map((rootDir) => path.resolve(rootDir));
-  const labelCandidates = resolvedRootDirs.map((rootDir) => {
-    const relativeRootDir = path.relative(resolvedCwd, rootDir);
-    if (isCwdRelativePath(relativeRootDir)) {
-      const label = toDisplayPath(relativeRootDir);
-      return {
-        label,
-        segments: label.split('/').filter(Boolean),
-      };
-    }
-
-    return {
-      label: toDisplayPath(path.basename(rootDir) || rootDir),
-      segments: undefined,
-    };
-  });
-  const labels = labelCandidates.map(({ label }) => label);
-
-  if (new Set(labels).size === labels.length) {
-    return labels;
-  }
-
-  const duplicateLabels = getDuplicateLabels(labels);
-  const maxDepth = Math.max(...labelCandidates.map(({ segments }) => segments?.length ?? 1), 1);
-  let candidates = labels;
-
-  for (let depth = 1; depth <= maxDepth; depth++) {
-    candidates = labels.map((label, index) => {
-      if (!duplicateLabels.has(label)) {
-        return label;
-      }
-
-      const segments = labelCandidates[index]?.segments;
-      if (!segments) {
-        return label || `root-${index + 1}`;
-      }
-
-      return segments.slice(-depth).join('/') || label || `root-${index + 1}`;
-    });
-
-    if (new Set(candidates).size === candidates.length) {
-      return candidates;
-    }
-  }
-
-  return uniquifyLabelsWithSuffixes(candidates);
-};
-
-const joinDisplayPath = (rootLabel: string, filePath: string): string => {
-  const normalizedRootLabel = toDisplayPath(rootLabel).replace(/^\/+|\/+$/g, '') || 'root';
-  const normalizedFilePath = toDisplayPath(filePath).replace(/^\/+/, '');
-  return normalizedFilePath ? `${normalizedRootLabel}/${normalizedFilePath}` : normalizedRootLabel;
-};
 
 export const pack = async (
   rootDirs: string[],

--- a/src/core/packager/rootDisplayPath.ts
+++ b/src/core/packager/rootDisplayPath.ts
@@ -15,21 +15,6 @@ const isCwdRelativePath = (relativePath: string): boolean =>
   !relativePath.startsWith(`..${path.sep}`) &&
   !path.isAbsolute(relativePath);
 
-const getDuplicateLabels = (labels: string[]): Set<string> => {
-  const counts = new Map<string, number>();
-  for (const label of labels) {
-    counts.set(label, (counts.get(label) ?? 0) + 1);
-  }
-
-  const duplicates = new Set<string>();
-  for (const [label, count] of counts) {
-    if (count > 1) {
-      duplicates.add(label);
-    }
-  }
-  return duplicates;
-};
-
 const uniquifyLabelsWithSuffixes = (labels: string[]): string[] => {
   const seen = new Set<string>();
   return labels.map((label, index) => {
@@ -57,52 +42,17 @@ const uniquifyLabelsWithSuffixes = (labels: string[]): string[] => {
  */
 export const buildRootLabels = (rootDirs: string[], cwd: string): string[] => {
   const resolvedCwd = path.resolve(cwd);
-  const resolvedRootDirs = rootDirs.map((rootDir) => path.resolve(rootDir));
-  const labelCandidates = resolvedRootDirs.map((rootDir) => {
-    const relativeRootDir = path.relative(resolvedCwd, rootDir);
-    if (isCwdRelativePath(relativeRootDir)) {
-      const label = toDisplayPath(relativeRootDir);
-      return {
-        label,
-        segments: label.split('/').filter(Boolean),
-      };
-    }
-
-    return {
-      label: toDisplayPath(path.basename(rootDir) || rootDir),
-      segments: undefined,
-    };
+  const labels = rootDirs.map((rootDir) => {
+    const resolvedRootDir = path.resolve(rootDir);
+    const relativeRootDir = path.relative(resolvedCwd, resolvedRootDir);
+    return isCwdRelativePath(relativeRootDir)
+      ? toDisplayPath(relativeRootDir)
+      : toDisplayPath(path.basename(resolvedRootDir) || resolvedRootDir);
   });
-  const labels = labelCandidates.map(({ label }) => label);
 
-  if (new Set(labels).size === labels.length) {
-    return labels;
-  }
-
-  const duplicateLabels = getDuplicateLabels(labels);
-  const maxDepth = Math.max(...labelCandidates.map(({ segments }) => segments?.length ?? 1), 1);
-  let candidates = labels;
-
-  for (let depth = 1; depth <= maxDepth; depth++) {
-    candidates = labels.map((label, index) => {
-      if (!duplicateLabels.has(label)) {
-        return label;
-      }
-
-      const segments = labelCandidates[index]?.segments;
-      if (!segments) {
-        return label || `root-${index + 1}`;
-      }
-
-      return segments.slice(-depth).join('/') || label || `root-${index + 1}`;
-    });
-
-    if (new Set(candidates).size === candidates.length) {
-      return candidates;
-    }
-  }
-
-  return uniquifyLabelsWithSuffixes(candidates);
+  // uniquifyLabelsWithSuffixes leaves already-unique labels untouched and only
+  // appends a numeric suffix to collisions, so it covers both cases.
+  return uniquifyLabelsWithSuffixes(labels);
 };
 
 /**

--- a/src/core/packager/rootDisplayPath.ts
+++ b/src/core/packager/rootDisplayPath.ts
@@ -1,0 +1,117 @@
+import path from 'node:path';
+
+/**
+ * Helpers for building stable, unique per-root display labels and display
+ * paths used when packing multiple roots. These keep files with the same
+ * relative path (e.g. `README.md` in two roots) distinguishable in the output
+ * and avoid key collisions in styles that key files by path (e.g. JSON).
+ */
+
+const toDisplayPath = (filePath: string): string => filePath.replaceAll(path.win32.sep, path.posix.sep);
+
+const isCwdRelativePath = (relativePath: string): boolean =>
+  relativePath !== '' &&
+  relativePath !== '..' &&
+  !relativePath.startsWith(`..${path.sep}`) &&
+  !path.isAbsolute(relativePath);
+
+const getDuplicateLabels = (labels: string[]): Set<string> => {
+  const counts = new Map<string, number>();
+  for (const label of labels) {
+    counts.set(label, (counts.get(label) ?? 0) + 1);
+  }
+
+  const duplicates = new Set<string>();
+  for (const [label, count] of counts) {
+    if (count > 1) {
+      duplicates.add(label);
+    }
+  }
+  return duplicates;
+};
+
+const uniquifyLabelsWithSuffixes = (labels: string[]): string[] => {
+  const seen = new Set<string>();
+  return labels.map((label, index) => {
+    const baseLabel = label || `root-${index + 1}`;
+    let candidate = baseLabel;
+    let suffix = 2;
+    while (seen.has(candidate)) {
+      candidate = `${baseLabel}-${suffix}`;
+      suffix++;
+    }
+    seen.add(candidate);
+    return candidate;
+  });
+};
+
+/**
+ * Compute a unique display label for each root directory.
+ *
+ * - Roots inside cwd use their cwd-relative path (e.g. `packages/a`).
+ * - Roots outside cwd use only their basename, to avoid leaking host/parent
+ *   directory names into the output.
+ * - On collision, labels fall back to a numeric suffix (`app`, `app-2`, ...).
+ *   - The suffixed label is a display path that does not exist on disk, but
+ *     collisions (same label across roots) are expected to be uncommon.
+ */
+export const buildRootLabels = (rootDirs: string[], cwd: string): string[] => {
+  const resolvedCwd = path.resolve(cwd);
+  const resolvedRootDirs = rootDirs.map((rootDir) => path.resolve(rootDir));
+  const labelCandidates = resolvedRootDirs.map((rootDir) => {
+    const relativeRootDir = path.relative(resolvedCwd, rootDir);
+    if (isCwdRelativePath(relativeRootDir)) {
+      const label = toDisplayPath(relativeRootDir);
+      return {
+        label,
+        segments: label.split('/').filter(Boolean),
+      };
+    }
+
+    return {
+      label: toDisplayPath(path.basename(rootDir) || rootDir),
+      segments: undefined,
+    };
+  });
+  const labels = labelCandidates.map(({ label }) => label);
+
+  if (new Set(labels).size === labels.length) {
+    return labels;
+  }
+
+  const duplicateLabels = getDuplicateLabels(labels);
+  const maxDepth = Math.max(...labelCandidates.map(({ segments }) => segments?.length ?? 1), 1);
+  let candidates = labels;
+
+  for (let depth = 1; depth <= maxDepth; depth++) {
+    candidates = labels.map((label, index) => {
+      if (!duplicateLabels.has(label)) {
+        return label;
+      }
+
+      const segments = labelCandidates[index]?.segments;
+      if (!segments) {
+        return label || `root-${index + 1}`;
+      }
+
+      return segments.slice(-depth).join('/') || label || `root-${index + 1}`;
+    });
+
+    if (new Set(candidates).size === candidates.length) {
+      return candidates;
+    }
+  }
+
+  return uniquifyLabelsWithSuffixes(candidates);
+};
+
+/**
+ * Join a root label and a file path into a single display path
+ * (e.g. `app` + `src/index.ts` -> `app/src/index.ts`), normalizing separators
+ * and trimming redundant slashes.
+ */
+export const joinDisplayPath = (rootLabel: string, filePath: string): string => {
+  const normalizedRootLabel = toDisplayPath(rootLabel).replace(/^\/+|\/+$/g, '') || 'root';
+  const normalizedFilePath = toDisplayPath(filePath).replace(/^\/+/, '');
+  return normalizedFilePath ? `${normalizedRootLabel}/${normalizedFilePath}` : normalizedRootLabel;
+};

--- a/tests/core/packager/multiRootSpec.test.ts
+++ b/tests/core/packager/multiRootSpec.test.ts
@@ -101,41 +101,39 @@ const countOccurrences = (haystack: string, needle: string): number => {
 };
 
 describe('multi-root pack spec', () => {
+  let rootAParent: string;
+  let rootBParent: string;
   let rootA: string;
   let rootB: string;
   let outputDir: string;
   let outputPath: string;
 
   beforeEach(async () => {
-    rootA = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-multiroot-a-'));
-    rootB = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-multiroot-b-'));
+    rootAParent = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-multiroot-parent-a-'));
+    rootBParent = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-multiroot-parent-b-'));
+    rootA = path.join(rootAParent, 'app');
+    rootB = path.join(rootBParent, 'app');
     outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-multiroot-out-'));
     outputPath = path.join(outputDir, 'output.xml');
 
-    // Same relative path in each root, but unique content so a collapsing
-    // implementation produces an obviously-wrong output.
+    // Same root basename and same relative paths, but unique content so a
+    // collapsing implementation produces an obviously-wrong output.
+    await fs.mkdir(rootA);
     await fs.writeFile(path.join(rootA, 'README.md'), '# Root A\nMARKER_FROM_ROOT_A\n');
     await fs.mkdir(path.join(rootA, 'src'));
     await fs.writeFile(path.join(rootA, 'src', 'index.ts'), 'export const fromA = "ROOT_A_SRC_MARKER";\n');
 
+    await fs.mkdir(rootB);
     await fs.writeFile(path.join(rootB, 'README.md'), '# Root B (totally different)\nMARKER_FROM_ROOT_B\n');
-    await fs.mkdir(path.join(rootB, 'lib'));
-    await fs.writeFile(path.join(rootB, 'lib', 'util.ts'), 'export const fromB = "ROOT_B_LIB_MARKER";\n');
+    await fs.mkdir(path.join(rootB, 'src'));
+    await fs.writeFile(path.join(rootB, 'src', 'index.ts'), 'export const fromB = "ROOT_B_SRC_MARKER";\n');
   });
 
   afterEach(async () => {
-    await fs.rm(rootA, { recursive: true, force: true });
-    await fs.rm(rootB, { recursive: true, force: true });
+    await fs.rm(rootAParent, { recursive: true, force: true });
+    await fs.rm(rootBParent, { recursive: true, force: true });
     await fs.rm(outputDir, { recursive: true, force: true });
   });
-
-  // Note on `totalFiles`: a separate pre-existing quirk in `sortedFilePathsByDir`
-  // means the same relative path appears in each root's collect input (e.g.
-  // `README.md` is filtered from the global sorted list per-root, so duplicates
-  // pass twice). That inflates `result.totalFiles` beyond 4. This spec is
-  // intentionally narrow: it verifies the *unique content* contract — both
-  // roots' real bytes reach the packed output — and does not assert on
-  // counts, which would couple it to that unrelated quirk.
 
   it('preserves both unique contents of a duplicate relative path when packing multiple roots (xml)', async () => {
     const config = buildMergedConfig(outputDir, outputPath, 'xml');
@@ -148,7 +146,7 @@ describe('multi-root pack spec', () => {
     expect(output).toContain('MARKER_FROM_ROOT_A');
     expect(output).toContain('MARKER_FROM_ROOT_B');
     expect(output).toContain('ROOT_A_SRC_MARKER');
-    expect(output).toContain('ROOT_B_LIB_MARKER');
+    expect(output).toContain('ROOT_B_SRC_MARKER');
   });
 
   it('preserves both unique contents in plain style too', async () => {
@@ -163,16 +161,50 @@ describe('multi-root pack spec', () => {
     expect(output).toContain('MARKER_FROM_ROOT_B');
   });
 
-  // Sanity check on the deduplication direction: each unique sentinel must
-  // appear at most twice (the pre-existing `sortedFilePathsByDir` quirk causes
-  // each root's bytes to be packed twice). If an over-eager perf change starts
-  // multiplying entries further, this catches it.
-  it('does not balloon a duplicated path beyond the existing 2x quirk', async () => {
-    const config = buildMergedConfig(outputDir, outputPath, 'xml');
+  it.each([
+    'xml',
+    'markdown',
+    'plain',
+  ] as const)('packs each duplicate-relative-path multi-root file exactly once in %s style', async (style) => {
+    const config = buildMergedConfig(outputDir, outputPath, style);
     await runPack([rootA, rootB], config);
 
     const output = await fs.readFile(outputPath, 'utf-8');
-    expect(countOccurrences(output, 'MARKER_FROM_ROOT_A')).toBeLessThanOrEqual(2);
-    expect(countOccurrences(output, 'MARKER_FROM_ROOT_B')).toBeLessThanOrEqual(2);
+    expect(countOccurrences(output, 'MARKER_FROM_ROOT_A')).toBe(1);
+    expect(countOccurrences(output, 'MARKER_FROM_ROOT_B')).toBe(1);
+    expect(countOccurrences(output, 'ROOT_A_SRC_MARKER')).toBe(1);
+    expect(countOccurrences(output, 'ROOT_B_SRC_MARKER')).toBe(1);
+  });
+
+  it('preserves duplicate relative paths in json output with unique keys', async () => {
+    const config = buildMergedConfig(outputDir, outputPath, 'json');
+    await runPack([rootA, rootB], config);
+
+    const output = await fs.readFile(outputPath, 'utf-8');
+    const parsed = JSON.parse(output) as { files: Record<string, string> };
+
+    expect(Object.keys(parsed.files).sort()).toEqual([
+      'app-2/README.md',
+      'app-2/src/index.ts',
+      'app/README.md',
+      'app/src/index.ts',
+    ]);
+    expect(Object.values(parsed.files)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('MARKER_FROM_ROOT_A'),
+        expect.stringContaining('MARKER_FROM_ROOT_B'),
+        expect.stringContaining('ROOT_A_SRC_MARKER'),
+        expect.stringContaining('ROOT_B_SRC_MARKER'),
+      ]),
+    );
+  });
+
+  it('reports the real file count for duplicate-relative-path multi-root inputs', async () => {
+    const config = buildMergedConfig(outputDir, outputPath, 'xml');
+    const result = await runPack([rootA, rootB], config);
+
+    expect(result.totalFiles).toBe(4);
+    expect(result.processedFiles).toHaveLength(4);
+    expect(Object.keys(result.fileCharCounts)).toHaveLength(4);
   });
 });

--- a/tests/core/packager/multiRootSpec.test.ts
+++ b/tests/core/packager/multiRootSpec.test.ts
@@ -189,14 +189,12 @@ describe('multi-root pack spec', () => {
       'app/README.md',
       'app/src/index.ts',
     ]);
-    expect(Object.values(parsed.files)).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining('MARKER_FROM_ROOT_A'),
-        expect.stringContaining('MARKER_FROM_ROOT_B'),
-        expect.stringContaining('ROOT_A_SRC_MARKER'),
-        expect.stringContaining('ROOT_B_SRC_MARKER'),
-      ]),
-    );
+    // Verify each disambiguated key maps to its own root's content (rootA -> app,
+    // rootB -> app-2), not just that all markers appear somewhere in the values.
+    expect(parsed.files['app/README.md']).toContain('MARKER_FROM_ROOT_A');
+    expect(parsed.files['app/src/index.ts']).toContain('ROOT_A_SRC_MARKER');
+    expect(parsed.files['app-2/README.md']).toContain('MARKER_FROM_ROOT_B');
+    expect(parsed.files['app-2/src/index.ts']).toContain('ROOT_B_SRC_MARKER');
   });
 
   it('reports the real file count for duplicate-relative-path multi-root inputs', async () => {

--- a/tests/core/packager/rootDisplayPath.test.ts
+++ b/tests/core/packager/rootDisplayPath.test.ts
@@ -1,0 +1,63 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { buildRootLabels, joinDisplayPath } from '../../../src/core/packager/rootDisplayPath.js';
+
+// Build absolute paths from a resolved virtual base so the tests stay
+// deterministic and cross-platform (buildRootLabels uses path.resolve/relative).
+const base = path.resolve('virtual-root-for-rootDisplayPath-test');
+const cwd = path.join(base, 'work');
+
+describe('rootDisplayPath', () => {
+  describe('buildRootLabels', () => {
+    it('uses basenames for distinct roots inside cwd', () => {
+      const roots = [path.join(cwd, 'frontend'), path.join(cwd, 'backend')];
+      expect(buildRootLabels(roots, cwd)).toEqual(['frontend', 'backend']);
+    });
+
+    it('uses the cwd-relative path for nested roots inside cwd', () => {
+      const roots = [path.join(cwd, 'packages', 'a'), path.join(cwd, 'packages', 'b')];
+      expect(buildRootLabels(roots, cwd)).toEqual(['packages/a', 'packages/b']);
+    });
+
+    it('uses only the basename for roots outside cwd (no parent leakage)', () => {
+      const roots = [path.join(base, 'other', 'foo'), path.join(base, 'other', 'bar')];
+      expect(buildRootLabels(roots, cwd)).toEqual(['foo', 'bar']);
+    });
+
+    it('falls back to a numeric suffix when outside-cwd basenames collide', () => {
+      const roots = [path.join(base, 'x', 'app'), path.join(base, 'y', 'app')];
+      expect(buildRootLabels(roots, cwd)).toEqual(['app', 'app-2']);
+    });
+
+    it('disambiguates a collision between an inside-cwd and an outside-cwd root', () => {
+      const roots = [path.join(cwd, 'app'), path.join(base, 'other', 'app')];
+      expect(buildRootLabels(roots, cwd)).toEqual(['app', 'app-2']);
+    });
+
+    it('returns the single label unchanged for one root', () => {
+      expect(buildRootLabels([path.join(cwd, 'frontend')], cwd)).toEqual(['frontend']);
+    });
+  });
+
+  describe('joinDisplayPath', () => {
+    it('joins a root label and file path with a posix separator', () => {
+      expect(joinDisplayPath('app', 'src/index.ts')).toBe('app/src/index.ts');
+    });
+
+    it('normalizes windows separators in the file path', () => {
+      expect(joinDisplayPath('app', `src${path.win32.sep}index.ts`)).toBe('app/src/index.ts');
+    });
+
+    it('trims redundant leading/trailing slashes', () => {
+      expect(joinDisplayPath('/app/', '/README.md')).toBe('app/README.md');
+    });
+
+    it('returns just the label when the file path is empty', () => {
+      expect(joinDisplayPath('app', '')).toBe('app');
+    });
+
+    it('falls back to "root" when the label is empty', () => {
+      expect(joinDisplayPath('', 'README.md')).toBe('root/README.md');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

  This fixes a multi-root edge case where files with the same relative path could be handled incorrectly.

  For example, if two roots both contain `README.md` or `src/index.ts`, the current packing flow can duplicate those files in XML/
  Markdown/plain output. In JSON output, the later file can overwrite the earlier one because both entries use the same key.

  The fix keeps each root's file list separate during collection, then disambiguates file paths for multi-root duplicate relative
  paths.

  ## Changes

  - Deduplicate and sort file paths per root instead of flattening everything first.
  - Use root-aware display paths for multi-root output, like `packages/a/README.md` and `packages/b/README.md`.
  - Keep the existing JSON shape as `files: Record<string, string>`.
  - Add regression tests for duplicate relative paths across multiple roots.

  ## Checklist

  - [x] Run `npm run test`
  - [x] Run `npm run lint`

  ## Test Plan

  - `npm test tests/core/packager/multiRootSpec.test.ts`
  - `npm test`
  - `npm run build`
  - `npm run lint` exits successfully; it reports three pre-existing warnings outside this PR's scope.