### PR TITLE
fix(file): keep ignored .gitignore rules active

### DIFF
--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -112,7 +112,14 @@ const filterDeferredIgnoredFiles = (filePaths: string[], deferredIgnorePatterns:
   const posixPatterns = deferredIgnorePatterns.map(toPosixIgnorePattern);
   return filePaths.filter((filePath) => {
     const normalizedPath = toPosixPath(filePath);
-    return !posixPatterns.some((pattern) => minimatch(normalizedPath, pattern, { dot: true }));
+    // Match the control file itself, and — for the pathological case of a
+    // directory literally named `.gitignore` — its descendants too. globby
+    // previously normalized `**/.gitignore` to `**/.gitignore/**` (which excludes
+    // both), so matching `${pattern}/**` here preserves that behavior.
+    return !posixPatterns.some(
+      (pattern) =>
+        minimatch(normalizedPath, pattern, { dot: true }) || minimatch(normalizedPath, `${pattern}/**`, { dot: true }),
+    );
   });
 };
 

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -2,6 +2,7 @@ import type { Stats } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { type Options as GlobbyOptions, type GlobEntry, globby } from 'globby';
+import { minimatch } from 'minimatch';
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { defaultIgnoreList } from '../../config/defaultIgnore.js';
 import { mapWithConcurrency } from '../../shared/asyncMap.js';
@@ -20,6 +21,7 @@ export interface FileSearchResult {
 // than awaiting serially. The cap protects very large repos from EMFILE / file
 // descriptor exhaustion that unbounded `Promise.all` could cause.
 const EMPTY_DIR_CHECK_CONCURRENCY = 20;
+const IGNORE_CONTROL_FILE_NAMES = new Set(['.gitignore', '.ignore', '.repomixignore']);
 
 // No per-directory ignore-pattern check is needed here. The `directories` array
 // comes from globby with the same `ignore` patterns (e.g. `dist/**`), which
@@ -86,6 +88,27 @@ export const normalizeGlobPattern = (pattern: string): string => {
   return pattern;
 };
 
+const toPosixPath = (value: string): string => value.replace(/\\/g, '/');
+
+const isIgnoreControlFilePattern = (pattern: string): boolean => {
+  const normalizedPattern = toPosixPath(pattern).replace(/\/+$/, '');
+  if (normalizedPattern.startsWith('!')) {
+    return false;
+  }
+  return IGNORE_CONTROL_FILE_NAMES.has(path.posix.basename(normalizedPattern));
+};
+
+const filterDeferredIgnoredFiles = (filePaths: string[], deferredIgnorePatterns: string[]): string[] => {
+  if (deferredIgnorePatterns.length === 0) {
+    return filePaths;
+  }
+  const posixPatterns = deferredIgnorePatterns.map((pattern) => toPosixPath(pattern));
+  return filePaths.filter((filePath) => {
+    const normalizedPath = toPosixPath(filePath);
+    return !posixPatterns.some((pattern) => minimatch(normalizedPath, pattern, { dot: true }));
+  });
+};
+
 // Get all file paths considering the config
 export const searchFiles = async (
   rootDir: string,
@@ -140,10 +163,14 @@ export const searchFiles = async (
   }
 
   try {
-    const { adjustedIgnorePatterns, ignoreFilePatterns } = await prepareIgnoreContext(rootDir, config);
+    const { adjustedIgnorePatterns, ignoreFilePatterns, deferredIgnorePatterns } = await prepareIgnoreContext(
+      rootDir,
+      config,
+    );
 
     logger.trace('Ignore patterns:', adjustedIgnorePatterns);
     logger.trace('Ignore file patterns:', ignoreFilePatterns);
+    logger.trace('Deferred ignore patterns:', deferredIgnorePatterns);
 
     // Start with configured include patterns
     let includePatterns = config.include.map((pattern) => escapeGlobPattern(pattern));
@@ -221,7 +248,7 @@ export const searchFiles = async (
           directories.push(entry.path);
         }
       }
-      filePaths = files;
+      filePaths = filterDeferredIgnoredFiles(files, deferredIgnorePatterns);
 
       const globbyElapsedTime = Date.now() - globbyStartTime;
       logger.debug(
@@ -233,10 +260,13 @@ export const searchFiles = async (
       const filterTime = Date.now() - filterStartTime;
       logger.debug(`[empty dirs] Filtered to ${emptyDirPaths.length} empty directories in ${filterTime}ms`);
     } else {
-      filePaths = await globby(includePatterns, {
-        ...createBaseGlobbyOptions(rootDir, config, adjustedIgnorePatterns, ignoreFilePatterns),
-        onlyFiles: true,
-      }).catch(handleGlobbyError);
+      filePaths = filterDeferredIgnoredFiles(
+        await globby(includePatterns, {
+          ...createBaseGlobbyOptions(rootDir, config, adjustedIgnorePatterns, ignoreFilePatterns),
+          onlyFiles: true,
+        }).catch(handleGlobbyError),
+        deferredIgnorePatterns,
+      );
 
       const globbyElapsedTime = Date.now() - globbyStartTime;
       logger.debug(`[globby] Completed in ${globbyElapsedTime}ms, found ${filePaths.length} files`);
@@ -288,14 +318,25 @@ export const parseIgnoreContent = (content: string): string[] => {
 const prepareIgnoreContext = async (
   rootDir: string,
   config: RepomixConfigMerged,
-): Promise<{ adjustedIgnorePatterns: string[]; ignoreFilePatterns: string[] }> => {
+): Promise<{ adjustedIgnorePatterns: string[]; ignoreFilePatterns: string[]; deferredIgnorePatterns: string[] }> => {
   const [ignorePatterns, ignoreFilePatterns] = await Promise.all([
     getIgnorePatterns(rootDir, config),
     getIgnoreFilePatterns(config),
   ]);
 
+  // Keep ignore-control files visible to globby so their rules are loaded, then filter them from final file lists.
+  const deferredIgnorePatterns: string[] = [];
+  const globbyIgnorePatterns: string[] = [];
+  for (const pattern of ignorePatterns) {
+    if (isIgnoreControlFilePattern(pattern)) {
+      deferredIgnorePatterns.push(pattern);
+    } else {
+      globbyIgnorePatterns.push(pattern);
+    }
+  }
+
   // Normalize ignore patterns to handle trailing slashes consistently
-  const normalizedIgnorePatterns = ignorePatterns.map(normalizeGlobPattern);
+  const normalizedIgnorePatterns = globbyIgnorePatterns.map(normalizeGlobPattern);
 
   // Check if .git is a worktree reference
   const gitPath = path.join(rootDir, '.git');
@@ -312,7 +353,7 @@ const prepareIgnoreContext = async (
     }
   }
 
-  return { adjustedIgnorePatterns, ignoreFilePatterns };
+  return { adjustedIgnorePatterns, ignoreFilePatterns, deferredIgnorePatterns };
 };
 
 /**
@@ -433,12 +474,15 @@ export const listDirectories = async (rootDir: string, config: RepomixConfigMerg
  * @returns Array of file paths relative to rootDir
  */
 export const listFiles = async (rootDir: string, config: RepomixConfigMerged): Promise<string[]> => {
-  const { adjustedIgnorePatterns, ignoreFilePatterns } = await prepareIgnoreContext(rootDir, config);
+  const { adjustedIgnorePatterns, ignoreFilePatterns, deferredIgnorePatterns } = await prepareIgnoreContext(
+    rootDir,
+    config,
+  );
 
   const files = await globby(['**/*'], {
     ...createBaseGlobbyOptions(rootDir, config, adjustedIgnorePatterns, ignoreFilePatterns),
     onlyFiles: true,
   });
 
-  return sortPaths(files);
+  return sortPaths(filterDeferredIgnoredFiles(files, deferredIgnorePatterns));
 };

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -90,8 +90,15 @@ export const normalizeGlobPattern = (pattern: string): string => {
 
 const toPosixPath = (value: string): string => value.replace(/\\/g, '/');
 
+// Canonical posix form of a deferred ignore pattern: forward slashes and no
+// trailing slash. Detection (isIgnoreControlFilePattern) and post-filtering
+// (filterDeferredIgnoredFiles) must share this so a pattern that is deferred is
+// also matched by the filter. Otherwise e.g. `**/.gitignore/` would be deferred
+// (dropped from globby's ignore) yet never matched here, leaking the file.
+const toPosixIgnorePattern = (pattern: string): string => toPosixPath(pattern).replace(/\/+$/, '');
+
 const isIgnoreControlFilePattern = (pattern: string): boolean => {
-  const normalizedPattern = toPosixPath(pattern).replace(/\/+$/, '');
+  const normalizedPattern = toPosixIgnorePattern(pattern);
   if (normalizedPattern.startsWith('!')) {
     return false;
   }
@@ -102,7 +109,7 @@ const filterDeferredIgnoredFiles = (filePaths: string[], deferredIgnorePatterns:
   if (deferredIgnorePatterns.length === 0) {
     return filePaths;
   }
-  const posixPatterns = deferredIgnorePatterns.map((pattern) => toPosixPath(pattern));
+  const posixPatterns = deferredIgnorePatterns.map(toPosixIgnorePattern);
   return filePaths.filter((filePath) => {
     const normalizedPath = toPosixPath(filePath);
     return !posixPatterns.some((pattern) => minimatch(normalizedPath, pattern, { dot: true }));

--- a/tests/core/file/dotIgnoreSpec.test.ts
+++ b/tests/core/file/dotIgnoreSpec.test.ts
@@ -62,6 +62,32 @@ describe('repomix dot-ignore spec', () => {
     expect(filePaths).not.toContain('pkg/generated/bundle.data');
   });
 
+  it.each([
+    { fileName: '.ignore', ignorePattern: '**/.ignore' },
+    { fileName: '.repomixignore', ignorePattern: '**/.repomixignore' },
+  ])('still applies nested $fileName rules when the file itself is ignored', async ({ fileName, ignorePattern }) => {
+    await writeFixture(tmpDir, {
+      [`pkg/${fileName}`]: 'generated.data\n',
+      'pkg/src.ts': 'export {};\n',
+      'pkg/generated.data': 'generated\n',
+    });
+
+    const { filePaths } = await searchFiles(
+      tmpDir,
+      createMockConfig({
+        include: ['pkg/**'],
+        ignore: {
+          useDefaultPatterns: false,
+          customPatterns: [ignorePattern],
+        },
+      }),
+    );
+
+    expect(filePaths).toContain('pkg/src.ts');
+    expect(filePaths).not.toContain(`pkg/${fileName}`);
+    expect(filePaths).not.toContain('pkg/generated.data');
+  });
+
   it('honors .ignore files when `useDotIgnore` is on (the default)', async () => {
     await writeFixture(tmpDir, {
       '.ignore': '*.draft\n',

--- a/tests/core/file/fileSearch.gitignoreSpec.test.ts
+++ b/tests/core/file/fileSearch.gitignoreSpec.test.ts
@@ -57,6 +57,10 @@ describe('fileSearch gitignore spec', () => {
   it.each([
     'browser/.gitignore',
     '**/.gitignore',
+    // A trailing slash must behave identically: the pattern is still deferred so
+    // globby loads the rules, and the post-filter (sharing the same normalization)
+    // still removes the file rather than leaking it.
+    '**/.gitignore/',
   ])('still applies nested .gitignore rules when the nested .gitignore file itself is ignored by `%s`', async (ignorePattern) => {
     await writeFixture(tmpDir, {
       'browser/.gitignore': '*.draft\n',

--- a/tests/core/file/fileSearch.gitignoreSpec.test.ts
+++ b/tests/core/file/fileSearch.gitignoreSpec.test.ts
@@ -115,6 +115,31 @@ describe('fileSearch gitignore spec', () => {
     expect(emptyDirPaths).toContain('empty');
   });
 
+  it('excludes the contents of a directory literally named `.gitignore` when ignored by `**/.gitignore`', async () => {
+    // Pathological but valid: `.gitignore` as a directory name. The old globby
+    // behavior (where `**/.gitignore` normalized to `**/.gitignore/**`) excluded
+    // its contents, so the post-filter must drop descendants too, not just a
+    // file named `.gitignore`.
+    await writeFixture(tmpDir, {
+      'proj/.gitignore/inside.txt': 'x\n',
+      'proj/keep.txt': 'x\n',
+    });
+
+    const { filePaths } = await searchFiles(
+      tmpDir,
+      createMockConfig({
+        include: ['proj/**'],
+        ignore: {
+          useDefaultPatterns: false,
+          customPatterns: ['**/.gitignore'],
+        },
+      }),
+    );
+
+    expect(filePaths).toContain('proj/keep.txt');
+    expect(filePaths).not.toContain('proj/.gitignore/inside.txt');
+  });
+
   it('applies slash-less patterns recursively to all subdirectories', async () => {
     await writeFixture(tmpDir, {
       '.gitignore': '*.draft\nsecret.data\n',

--- a/tests/core/file/fileSearch.gitignoreSpec.test.ts
+++ b/tests/core/file/fileSearch.gitignoreSpec.test.ts
@@ -54,6 +54,63 @@ describe('fileSearch gitignore spec', () => {
     expect(filePaths).not.toContain('noisy.draft');
   });
 
+  it.each([
+    'browser/.gitignore',
+    '**/.gitignore',
+  ])('still applies nested .gitignore rules when the nested .gitignore file itself is ignored by `%s`', async (ignorePattern) => {
+    await writeFixture(tmpDir, {
+      'browser/.gitignore': '*.draft\n',
+      'browser/src/index.ts': 'export {};\n',
+      'browser/noisy.draft': 'noisy\n',
+    });
+
+    const { filePaths } = await searchFiles(
+      tmpDir,
+      createMockConfig({
+        include: ['browser/**'],
+        ignore: {
+          useDefaultPatterns: false,
+          customPatterns: [ignorePattern],
+        },
+      }),
+    );
+
+    expect(filePaths).toContain('browser/src/index.ts');
+    expect(filePaths).not.toContain('browser/.gitignore');
+    expect(filePaths).not.toContain('browser/noisy.draft');
+  });
+
+  it('filters root and nested .gitignore files matched by `**/.gitignore` while still applying their rules', async () => {
+    await writeFixture(tmpDir, {
+      '.gitignore': 'root-noisy.draft\n',
+      'keep.ts': 'export {};\n',
+      'root-noisy.draft': 'noisy\n',
+      'src/.gitignore': 'generated.ts\n',
+      'src/keep.ts': 'export {};\n',
+      'src/generated.ts': 'generated\n',
+    });
+    await fs.mkdir(path.join(tmpDir, 'empty'), { recursive: true });
+
+    const { filePaths, emptyDirPaths } = await searchFiles(
+      tmpDir,
+      createMockConfig({
+        output: { includeEmptyDirectories: true },
+        ignore: {
+          useDefaultPatterns: false,
+          customPatterns: ['**/.gitignore'],
+        },
+      }),
+    );
+
+    expect(filePaths).toContain('keep.ts');
+    expect(filePaths).toContain('src/keep.ts');
+    expect(filePaths).not.toContain('.gitignore');
+    expect(filePaths).not.toContain('src/.gitignore');
+    expect(filePaths).not.toContain('root-noisy.draft');
+    expect(filePaths).not.toContain('src/generated.ts');
+    expect(emptyDirPaths).toContain('empty');
+  });
+
   it('applies slash-less patterns recursively to all subdirectories', async () => {
     await writeFixture(tmpDir, {
       '.gitignore': '*.draft\nsecret.data\n',


### PR DESCRIPTION
## Summary

Fixes #624.

This PR fixes a conflict where ignore-control files such as `.gitignore`, `.ignore`, and `.repomixignore` can be ignored before globby has a chance to load their rules.

The fix keeps these control files visible during traversal so their rules are applied, then filters the control files out of the final file list.

## Why

If users configure custom ignore patterns such as `**/.gitignore`, the `.gitignore` file itself should not appear in Repomix output. However, hiding it too early can also prevent its rules from being respected.

Expected behavior:

- `.gitignore` / `.ignore` / `.repomixignore` are not included in output
- rules inside those files are still applied
- existing custom/default ignore behavior is preserved

## Tests

- [x] `npm test tests/core/file/fileSearch.gitignoreSpec.test.ts`
- [x] `npm test tests/core/file/dotIgnoreSpec.test.ts`
- [x] `npm test tests/core/file/fileSearch.test.ts`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`

Note: `npm run lint` exits 0, but upstream main still reports 3 existing warnings unrelated to this change.