### PR TITLE
ci(schema): Regenerate schema on main only, not on PR branches

### DIFF
--- a/.github/workflows/schema-update.yml
+++ b/.github/workflows/schema-update.yml
@@ -9,9 +9,10 @@ permissions:
   contents: write
 
 concurrency:
-  # Serialize runs that share the reused chore/schema-update branch so two
-  # near-simultaneous main pushes don't race on it.
-  group: schema-update-${{ github.ref }}
+  # Serialize all runs so concurrent triggers (a main push plus a
+  # workflow_dispatch, possibly from different refs) don't race on the shared,
+  # reused chore/schema-update branch. The group is intentionally ref-independent.
+  group: schema-update
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/schema-update.yml
+++ b/.github/workflows/schema-update.yml
@@ -3,8 +3,6 @@ name: Update Schema
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -23,10 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Same-repo PRs check out the PR head branch so the regenerated schema
-          # can be committed back to it. Fork PRs check out the merge ref so the
-          # schema is generated from the PR's code. Push / dispatch use main.
-          ref: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || github.ref) || 'main' }}
+          ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -35,33 +30,14 @@ jobs:
       - run: npm ci
       - run: node --run website-generate-schema
 
-      # On same-repo pull requests, commit the regenerated schema back into the
-      # PR branch so the schema change rides along with the PR that caused it.
-      - if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
-        with:
-          commit_message: 'chore(schema): Auto-generate schema'
-          commit_user_name: "github-actions[bot]"
-          commit_user_email: "github-actions[bot]@users.noreply.github.com"
-          commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
-
-      # Fork pull requests use a read-only token and cannot be committed to, so
-      # fail if the schema is out of date to surface the drift instead of
-      # silently merging it.
-      - if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-        run: |
-          if ! git diff --quiet; then
-            echo "::error::Generated schema is out of date. Run 'node --run website-generate-schema' and commit the result."
-            git --no-pager diff --stat
-            exit 1
-          fi
-
-      # On main (e.g. after a version bump), direct pushes are blocked by the
-      # branch ruleset (pull_request required), so deliver the regenerated
-      # schema as a PR instead. COMMITTER_TOKEN is used so the PR triggers CI
-      # and is mergeable.
-      - if: github.event_name != 'pull_request'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+      # The schema is regenerated only on main (after a merge) and delivered as a
+      # PR. Pull requests intentionally do NOT run this workflow: committing the
+      # schema back to a PR branch (the previous behavior) left the PR head on a
+      # GITHUB_TOKEN-authored commit, which does not trigger CI and blocked merge.
+      # Direct pushes to main are blocked by the branch ruleset, so the
+      # regenerated schema is delivered as this PR instead. COMMITTER_TOKEN is
+      # used so the PR triggers CI and is mergeable.
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.COMMITTER_TOKEN }}
           base: main


### PR DESCRIPTION
## Summary

Changes the `Update Schema` workflow so the configuration JSON schema is regenerated **only on `main`** (and `workflow_dispatch`), delivered as the existing `chore/schema-update` PR. Pull requests no longer run this workflow.

## Why

The previous behavior committed the regenerated schema back onto same-repo PR branches via `git-auto-commit-action` (`GITHUB_TOKEN`). Commits authored by `GITHUB_TOKEN` **do not trigger workflows**, so the PR head ended up on a commit with no CI runs — required checks were missing on the head and the PR was stuck in `BLOCKED` (observed on #1621).

## What changed

- Removed the `pull_request` trigger (PRs no longer run this workflow).
- Removed the same-repo auto-commit step and the fork drift-check step.
- Kept the `main` push → `chore/schema-update` PR path (via `COMMITTER_TOKEN`, so that PR triggers CI). Behavior on `main` pushes is unchanged.
- Simplified the checkout `ref` to `main`.

## Workflow after this change

- **Feature PR** changes `src/config/configSchema.ts` → no schema job runs; contributors never touch the generated JSON.
- **After merge to `main`** → the workflow regenerates the schema and opens `chore/schema-update` if it drifted.

## Checklist

- [x] YAML validated
- [ ] `actionlint` (runs in CI)