### PR TITLE
fix(cli): copy split output files after remote packing

### DIFF
--- a/src/cli/actions/remoteAction.ts
+++ b/src/cli/actions/remoteAction.ts
@@ -152,7 +152,10 @@ export const runRemoteAction = async (
     // For skill generation, the skill is already written directly to the target directory
     // (either via --skill-output path or via promptSkillLocation which uses process.cwd())
     if (!cliOptions.stdout && result.config.skillGenerate === undefined) {
-      await copyOutputToCurrentDirectory(tempDirPath, process.cwd(), result.config.output.filePath);
+      const outputFiles = result.packResult.outputFiles ?? [result.config.output.filePath];
+      for (const outputFile of outputFiles) {
+        await copyOutputToCurrentDirectory(tempDirPath, process.cwd(), outputFile);
+      }
     }
 
     // Enforce the token budget now that the output has been delivered (copied

--- a/tests/cli/actions/remoteAction.test.ts
+++ b/tests/cli/actions/remoteAction.test.ts
@@ -113,6 +113,52 @@ describe('remoteAction functions', () => {
       expect(fs.copyFile).toHaveBeenCalled();
     });
 
+    test('copies all split-output files returned by remote packing', async () => {
+      const execGitShallowCloneMock = vi.fn(async (_url: string, directory: string) => {
+        await fs.writeFile(path.join(directory, 'README.md'), 'Hello, world!');
+      });
+      const base = createMockDefaultActionResult();
+      const runDefaultActionMock = vi.fn(async () => ({
+        packResult: {
+          ...base.packResult,
+          outputFiles: ['split-output.1.xml', 'split-output.2.xml'],
+        },
+        config: createMockConfig({ output: { filePath: 'split-output.xml', splitOutput: 1024 } }),
+      }));
+
+      vi.mocked(fs.copyFile).mockResolvedValue(undefined);
+      await runRemoteAction(
+        'https://gitlab.com/owner/repo.git',
+        {},
+        {
+          isGitInstalled: async () => Promise.resolve(true),
+          execGitShallowClone: execGitShallowCloneMock,
+          getRemoteRefs: async () => Promise.resolve(['main']),
+          runDefaultAction: runDefaultActionMock,
+          downloadGitHubArchive: vi.fn().mockRejectedValue(new Error('Archive download not implemented in test')),
+          isGitHubRepository: vi.fn().mockReturnValue(false),
+          parseGitHubRepoInfo: vi.fn().mockReturnValue(null),
+          isArchiveDownloadSupported: vi.fn().mockReturnValue(false),
+        },
+      );
+
+      expect(fs.copyFile).toHaveBeenCalledTimes(2);
+      expect(fs.copyFile).toHaveBeenNthCalledWith(
+        1,
+        expect.stringMatching(/split-output\.1\.xml$/),
+        path.resolve(process.cwd(), 'split-output.1.xml'),
+      );
+      expect(fs.copyFile).toHaveBeenNthCalledWith(
+        2,
+        expect.stringMatching(/split-output\.2\.xml$/),
+        path.resolve(process.cwd(), 'split-output.2.xml'),
+      );
+      expect(fs.copyFile).not.toHaveBeenCalledWith(
+        expect.stringMatching(/split-output\.xml$/),
+        path.resolve(process.cwd(), 'split-output.xml'),
+      );
+    });
+
     test('should download GitHub archive successfully without git installed', async () => {
       const downloadGitHubArchiveMock = vi.fn().mockResolvedValue(undefined);
       const execGitShallowCloneMock = vi.fn();


### PR DESCRIPTION
## Summary

I noticed that remote mode does not handle `--split-output` correctly right now.

When Repomix packs a remote repository, it works in a temporary directory first and then copies the generated output back to the current directory. That is fine for normal output, because there is only one output file.

With `--split-output`, the actual files are numbered files like:

- `repomix-output.1.xml`
- `repomix-output.2.xml`

The packer already returns those filenames in `packResult.outputFiles`, but `runRemoteAction` was still trying to copy only `config.output.filePath`. In split mode that base file may not exist, so the remote run can fail while the actual split files stay in the temporary directory.

This PR makes remote mode copy the returned `outputFiles` when they are present, and keeps the old single-file behavior as the fallback.

## Tests

- `npx vitest run tests/cli/actions/remoteAction.test.ts`
- `npx vitest run tests/cli/actions/remoteAction.test.ts tests/core/packager/splitOutput.test.ts tests/core/packager/produceOutput.test.ts`
- `npx biome check src/cli/actions/remoteAction.ts tests/cli/actions/remoteAction.test.ts`
- `npm run lint-ts`
