### PR TITLE
fix(core): Match file extensions case-insensitively in getFileManipulator

### DIFF
--- a/src/core/file/fileManipulate.ts
+++ b/src/core/file/fileManipulate.ts
@@ -101,6 +101,10 @@ const manipulators: Record<string, FileManipulator> = {
 };
 
 export const getFileManipulator = (filePath: string): FileManipulator | null => {
-  const ext = path.extname(filePath);
+  // Match extensions case-insensitively so files with uppercase extensions
+  // (e.g. `Main.JS`, `style.CSS`, `App.PY`) still get their comments and empty
+  // lines stripped. This mirrors the lowercasing already done for tree-sitter
+  // language detection in languageParser.ts.
+  const ext = path.extname(filePath).toLowerCase();
   return manipulators[ext] || null;
 };

--- a/tests/core/file/fileManipulate.test.ts
+++ b/tests/core/file/fileManipulate.test.ts
@@ -1038,6 +1038,33 @@ r2 := '\\\\'`,
     expect(manipulator).toBeNull();
   });
 
+  describe('case-insensitive extension matching', () => {
+    // Extensions are matched case-insensitively, so files with uppercase or
+    // mixed-case extensions still resolve to a manipulator. Without this,
+    // removeComments and removeEmptyLines silently no-op on such files.
+    test.each([
+      '.JS',
+      '.Js',
+      '.PY',
+      '.CSS',
+      '.C',
+      '.HTML',
+      '.Vue',
+    ])('resolves a manipulator for uppercase extension %s', (ext) => {
+      expect(getFileManipulator(`test${ext}`)).not.toBeNull();
+    });
+
+    test('strips comments from a file with an uppercase extension', () => {
+      const manipulator = getFileManipulator('Main.JS');
+      const input = 'const a = 1; // inline\n/* block */\nconst b = 2;';
+      expect(manipulator?.removeComments(input)).toBe('const a = 1;\n\nconst b = 2;');
+    });
+
+    test('still returns null for unsupported uppercase extensions', () => {
+      expect(getFileManipulator('test.UNSUPPORTED')).toBeNull();
+    });
+  });
+
   describe('removeEmptyLines', () => {
     // BaseManipulator.removeEmptyLines is inherited by every concrete manipulator.
     // It runs after comment stripping in fileProcess to clean up the blanks left behind.


### PR DESCRIPTION
## Summary

`getFileManipulator` (`src/core/file/fileManipulate.ts`) looks up the manipulator using the raw extension from `path.extname(filePath)` against a map whose keys are all lowercase (`.js`, `.css`, `.py`, …). Files whose extension contains any uppercase letter — `Main.JS`, `style.CSS`, `App.PY`, `legacy.C` — therefore resolve to `null`.

Because both transforms are gated on a non-null manipulator:

- `fileProcessContent.ts` — `if (manipulator && config.output.removeComments)`
- `fileProcess.ts` — `if (manipulator) { content = manipulator.removeEmptyLines(content); }`

`--remove-comments` **and** `--remove-empty-lines` silently no-op on any file with an uppercase extension. No error, no warning — the comments and blank lines just pass through untouched.

## Reproduction

Two identical files differing only in extension case:

```bash
printf 'const a = 1; // inline\n\n\n/* block */\nconst b = 2;\n' > lower.js
printf 'const a = 1; // inline\n\n\n/* block */\nconst b = 2;\n' > UPPER.JS
repomix . --remove-comments --remove-empty-lines --stdout
```

Before this change, `lower.js` is stripped to `const a = 1;\nconst b = 2;` while `UPPER.JS` keeps every comment and blank line. After the change both produce identical stripped output.

## Fix

Lowercase the extension before the lookup. This mirrors what the codebase already does for tree-sitter language detection in `languageParser.ts` (`path.extname(filePath).toLowerCase()`), so the two extension-matching paths are now consistent.

## Why this approach

The map keys are canonical lowercase extensions; normalizing the input extension is the minimal, side-effect-free fix. No public behavior changes for already-supported (lowercase) extensions — unsupported extensions still return `null`, including uppercase ones like `.UNSUPPORTED`.

## Testing

- New unit tests in `tests/core/file/fileManipulate.test.ts` cover uppercase/mixed-case extensions resolving a manipulator, actual comment stripping on `Main.JS`, and that unsupported uppercase extensions still return `null`.
- `npm run test` — full `fileManipulate` suite passes (63 tests).
- `npm run lint` — clean.
- Verified end-to-end with the built CLI using the reproduction above.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`