### PR TITLE
Add watch mode for local rebuilds

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,12 @@ using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pat
 repomix --include "src/**/*.ts,**/*.md"
 ```
 
+To rebuild the output automatically when local files change:
+
+```bash
+repomix --watch
+```
+
 To exclude specific files or directories:
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@repomix/tree-sitter-wasms": "^0.1.17",
         "@secretlint/core": "^13.0.2",
         "@secretlint/secretlint-rule-preset-recommend": "^13.0.2",
+        "chokidar": "^5.0.0",
         "commander": "^15.0.0",
         "fast-xml-builder": "^1.2.0",
         "git-url-parse": "^16.1.0",
@@ -2554,6 +2555,21 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -4536,6 +4552,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/require-from-string": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@repomix/tree-sitter-wasms": "^0.1.17",
     "@secretlint/core": "^13.0.2",
     "@secretlint/secretlint-rule-preset-recommend": "^13.0.2",
+    "chokidar": "^5.0.0",
     "commander": "^15.0.0",
     "fast-xml-builder": "^1.2.0",
     "git-url-parse": "^16.1.0",

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -139,7 +139,10 @@ export const runDefaultAction = async (
   }
 
   // Report results
-  reportResults(cwd, packResult, config, cliOptions);
+  reportResults(cwd, packResult, config, {
+    skillDir: cliOptions.skillDir,
+    watchMode: cliOptions.watch,
+  });
 
   // Enforce the token budget as the last step. The output has already been
   // produced (and written) by this point, so this is a guard that fails the

--- a/src/cli/actions/watchAction.ts
+++ b/src/cli/actions/watchAction.ts
@@ -1,0 +1,251 @@
+import path from 'node:path';
+import process from 'node:process';
+import type { ChokidarOptions } from 'chokidar';
+import pc from 'picocolors';
+import type { RepomixConfigMerged } from '../../config/configSchema.js';
+import { RepomixError } from '../../shared/errorHandle.js';
+import { logger } from '../../shared/logger.js';
+import type { CliOptions } from '../types.js';
+import { type DefaultActionRunnerResult, runDefaultAction as runDefaultActionDefault } from './defaultAction.js';
+
+const DEFAULT_DEBOUNCE_MS = 300;
+
+const defaultConfigFileNames = [
+  'repomix.config.ts',
+  'repomix.config.mts',
+  'repomix.config.cts',
+  'repomix.config.js',
+  'repomix.config.mjs',
+  'repomix.config.cjs',
+  'repomix.config.json5',
+  'repomix.config.jsonc',
+  'repomix.config.json',
+];
+
+interface WatcherLike {
+  add(paths: string | string[]): unknown;
+  close(): Promise<unknown>;
+  on(event: 'all', listener: (eventName: string, filePath: string) => void): this;
+  on(event: 'error', listener: (error: Error) => void): this;
+}
+
+interface WatchTrigger {
+  eventName: string;
+  filePath: string;
+}
+
+interface WatchDeps {
+  runDefaultAction: typeof runDefaultActionDefault;
+  createWatcher: (paths: string[], options: ChokidarOptions) => WatcherLike | Promise<WatcherLike>;
+  waitForStop: (watcher: WatcherLike) => Promise<void>;
+  debounceMs: number;
+}
+
+const createDefaultWatcher: WatchDeps['createWatcher'] = async (paths, options) => {
+  const { watch } = await import('chokidar');
+  return watch(paths, options);
+};
+
+const waitForSignal: WatchDeps['waitForStop'] = async () => {
+  await new Promise<void>((resolve) => {
+    const finish = () => {
+      process.off('SIGINT', finish);
+      process.off('SIGTERM', finish);
+      resolve();
+    };
+    process.once('SIGINT', finish);
+    process.once('SIGTERM', finish);
+  });
+};
+
+const defaultDeps: WatchDeps = {
+  runDefaultAction: runDefaultActionDefault,
+  createWatcher: createDefaultWatcher,
+  waitForStop: waitForSignal,
+  debounceMs: DEFAULT_DEBOUNCE_MS,
+};
+
+const formatError = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+};
+
+const toAbsolutePath = (cwd: string, filePath: string): string => path.resolve(cwd, filePath);
+
+const uniquePaths = (paths: string[]): string[] => Array.from(new Set(paths));
+
+const pathSegments = (filePath: string): string[] => path.resolve(filePath).split(path.sep).filter(Boolean);
+
+const isInsideIgnoredDirectory = (filePath: string): boolean => {
+  const segments = pathSegments(filePath);
+  return segments.includes('.git') || segments.includes('node_modules');
+};
+
+const getConfigWatchPaths = (cwd: string, cliOptions: CliOptions): string[] => {
+  if (cliOptions.config) {
+    return [toAbsolutePath(cwd, cliOptions.config)];
+  }
+
+  return defaultConfigFileNames.map((fileName) => path.resolve(cwd, fileName));
+};
+
+const getInstructionWatchPath = (cwd: string, config?: RepomixConfigMerged): string[] => {
+  if (!config?.output.instructionFilePath) {
+    return [];
+  }
+  return [toAbsolutePath(cwd, config.output.instructionFilePath)];
+};
+
+const buildWatchPaths = (
+  directories: string[],
+  cwd: string,
+  cliOptions: CliOptions,
+  config?: RepomixConfigMerged,
+): string[] => {
+  const targetPaths = directories.map((directory) => toAbsolutePath(cwd, directory));
+  const configPaths = getConfigWatchPaths(cwd, cliOptions);
+  const instructionPaths = getInstructionWatchPath(cwd, config);
+  return uniquePaths([...targetPaths, ...configPaths, ...instructionPaths]);
+};
+
+const getOutputPaths = (cwd: string, result: DefaultActionRunnerResult): string[] => {
+  const outputPaths = new Set<string>();
+  outputPaths.add(toAbsolutePath(cwd, result.config.output.filePath));
+  for (const outputFile of result.packResult.outputFiles ?? []) {
+    outputPaths.add(toAbsolutePath(cwd, outputFile));
+  }
+  return Array.from(outputPaths);
+};
+
+const validateWatchOptions = (cliOptions: CliOptions): void => {
+  const conflicts: Array<[boolean, string]> = [
+    [Boolean(cliOptions.stdin), '--stdin'],
+    [Boolean(cliOptions.stdout || cliOptions.output === '-'), '--stdout'],
+    [Boolean(cliOptions.copy), '--copy'],
+    [cliOptions.skillGenerate !== undefined, '--skill-generate'],
+  ];
+
+  const conflict = conflicts.find(([enabled]) => enabled);
+  if (conflict) {
+    throw new RepomixError(`--watch cannot be used with ${conflict[1]}.`);
+  }
+};
+
+const displayWatchPath = (cwd: string, filePath: string): string => {
+  const relativePath = path.relative(cwd, filePath);
+  return relativePath && !relativePath.startsWith('..') && !path.isAbsolute(relativePath) ? relativePath : filePath;
+};
+
+export const runWatchAction = async (
+  directories: string[],
+  cwd: string,
+  cliOptions: CliOptions,
+  overrideDeps: Partial<WatchDeps> = {},
+): Promise<void> => {
+  validateWatchOptions(cliOptions);
+
+  const deps = { ...defaultDeps, ...overrideDeps };
+  const optionsForBuild = { ...cliOptions, watch: true };
+  let outputPaths = new Set<string>();
+  let latestConfig: RepomixConfigMerged | undefined;
+  let watcher: WatcherLike | undefined;
+  let watchedPaths = new Set<string>();
+  let debounceTimer: NodeJS.Timeout | undefined;
+  let isRebuilding = false;
+  let rebuildQueued = false;
+
+  const runRebuild = async (trigger?: WatchTrigger): Promise<void> => {
+    if (isRebuilding) {
+      rebuildQueued = true;
+      return;
+    }
+
+    isRebuilding = true;
+    try {
+      if (trigger) {
+        logger.log(
+          pc.dim(
+            `\nChange detected (${trigger.eventName}: ${displayWatchPath(cwd, trigger.filePath)}). Rebuilding...\n`,
+          ),
+        );
+      }
+
+      const result = await deps.runDefaultAction(directories, cwd, optionsForBuild);
+      latestConfig = result.config;
+      outputPaths = new Set(getOutputPaths(cwd, result));
+
+      if (watcher) {
+        const nextWatchPaths = buildWatchPaths(directories, cwd, cliOptions, latestConfig);
+        const newPaths = nextWatchPaths.filter((watchPath) => !watchedPaths.has(watchPath));
+        if (newPaths.length > 0) {
+          watcher.add(newPaths);
+          watchedPaths = new Set([...watchedPaths, ...newPaths]);
+        }
+      }
+    } catch (error) {
+      logger.error(pc.red(`Watch rebuild failed: ${formatError(error)}`));
+      logger.trace('Watch rebuild error:', error);
+    } finally {
+      isRebuilding = false;
+      if (rebuildQueued) {
+        rebuildQueued = false;
+        await runRebuild();
+      }
+    }
+  };
+
+  const scheduleRebuild = (trigger: WatchTrigger) => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+    debounceTimer = setTimeout(() => {
+      debounceTimer = undefined;
+      void runRebuild(trigger);
+    }, deps.debounceMs);
+  };
+
+  const isIgnored = (filePath: string): boolean => {
+    const absolutePath = path.resolve(filePath);
+    return isInsideIgnoredDirectory(absolutePath) || outputPaths.has(absolutePath);
+  };
+
+  await runRebuild();
+
+  const watchPaths = buildWatchPaths(directories, cwd, cliOptions, latestConfig);
+  watchedPaths = new Set(watchPaths);
+  watcher = await deps.createWatcher(watchPaths, {
+    persistent: true,
+    ignoreInitial: true,
+    atomic: true,
+    awaitWriteFinish: {
+      stabilityThreshold: 200,
+      pollInterval: 50,
+    },
+    ignored: isIgnored,
+  });
+
+  watcher
+    .on('all', (eventName, filePath) => {
+      if (isIgnored(filePath)) {
+        return;
+      }
+      scheduleRebuild({ eventName, filePath });
+    })
+    .on('error', (error) => {
+      logger.error(pc.red(`Watch error: ${formatError(error)}`));
+      logger.trace('Watch error:', error);
+    });
+
+  logger.log(pc.dim('Watching for changes. Press Ctrl+C to stop.'));
+
+  try {
+    await deps.waitForStop(watcher);
+  } finally {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+    await watcher.close();
+  }
+};

--- a/src/cli/actions/watchAction.ts
+++ b/src/cli/actions/watchAction.ts
@@ -38,6 +38,7 @@ interface WatchDeps {
   runDefaultAction: typeof runDefaultActionDefault;
   createWatcher: (paths: string[], options: ChokidarOptions) => WatcherLike | Promise<WatcherLike>;
   waitForStop: (watcher: WatcherLike) => Promise<void>;
+  exit: (code: number) => never | undefined;
   debounceMs: number;
 }
 
@@ -62,6 +63,7 @@ const defaultDeps: WatchDeps = {
   runDefaultAction: runDefaultActionDefault,
   createWatcher: createDefaultWatcher,
   waitForStop: waitForSignal,
+  exit: (code) => process.exit(code),
   debounceMs: DEFAULT_DEBOUNCE_MS,
 };
 
@@ -247,5 +249,6 @@ export const runWatchAction = async (
       clearTimeout(debounceTimer);
     }
     await watcher.close();
+    deps.exit(0);
   }
 };

--- a/src/cli/actions/watchAction.ts
+++ b/src/cli/actions/watchAction.ts
@@ -76,10 +76,10 @@ const toAbsolutePath = (cwd: string, filePath: string): string => path.resolve(c
 
 const uniquePaths = (paths: string[]): string[] => Array.from(new Set(paths));
 
-const pathSegments = (filePath: string): string[] => path.resolve(filePath).split(path.sep).filter(Boolean);
-
-const isInsideIgnoredDirectory = (filePath: string): boolean => {
-  const segments = pathSegments(filePath);
+const isInsideIgnoredDirectory = (cwd: string, filePath: string): boolean => {
+  const absolutePath = path.isAbsolute(filePath) ? filePath : path.resolve(cwd, filePath);
+  const relativePath = path.relative(cwd, absolutePath);
+  const segments = relativePath.split(path.sep).filter(Boolean);
   return segments.includes('.git') || segments.includes('node_modules');
 };
 
@@ -207,8 +207,8 @@ export const runWatchAction = async (
   };
 
   const isIgnored = (filePath: string): boolean => {
-    const absolutePath = path.resolve(filePath);
-    return isInsideIgnoredDirectory(absolutePath) || outputPaths.has(absolutePath);
+    const absolutePath = path.isAbsolute(filePath) ? filePath : path.resolve(cwd, filePath);
+    return isInsideIgnoredDirectory(cwd, absolutePath) || outputPaths.has(absolutePath);
   };
 
   await runRebuild();

--- a/src/cli/actions/watchAction.ts
+++ b/src/cli/actions/watchAction.ts
@@ -126,7 +126,7 @@ const validateWatchOptions = (cliOptions: CliOptions): void => {
     [Boolean(cliOptions.stdin), '--stdin'],
     [Boolean(cliOptions.stdout || cliOptions.output === '-'), '--stdout'],
     [Boolean(cliOptions.copy), '--copy'],
-    [cliOptions.skillGenerate !== undefined, '--skill-generate'],
+    [Boolean(cliOptions.skillGenerate), '--skill-generate'],
   ];
 
   const conflict = conflicts.find(([enabled]) => enabled);

--- a/src/cli/cliReport.ts
+++ b/src/cli/cliReport.ts
@@ -16,6 +16,7 @@ export const getDisplayPath = (absolutePath: string, cwd: string): string => {
 
 export interface ReportOptions {
   skillDir?: string;
+  watchMode?: boolean;
 }
 
 /**
@@ -59,7 +60,7 @@ export const reportResults = (
   reportSummary(cwd, packResult, config, options);
   logger.log('');
 
-  reportCompletion();
+  reportCompletion(options);
 };
 
 export const reportSummary = (
@@ -237,9 +238,13 @@ export const reportSkippedFiles = (_rootDir: string, skippedFiles: SkippedFileIn
   logger.log(pc.yellow('Please review these files if you expected them to contain text content.'));
 };
 
-export const reportCompletion = () => {
+export const reportCompletion = (options: ReportOptions = {}) => {
   logger.log(pc.green('🎉 All Done!'));
   logger.log('Your repository has been successfully packed.');
+
+  if (options.watchMode) {
+    return;
+  }
 
   logger.log('');
   logger.log(`💡 Repomix is now available in your browser! Try it at ${pc.underline('https://repomix.com')}`);

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -71,6 +71,7 @@ export const run = async () => {
       )
       .option('--stdin', 'Read file paths from stdin, one per line (specified files are processed directly)')
       .option('--copy', 'Copy the generated output to system clipboard after processing')
+      .option('--watch', 'Watch local files and rebuild the output when changes are detected')
       .option(
         '--token-count-tree [threshold]',
         'Show file tree with token counts; optional threshold to show only files with ≥N tokens (e.g., --token-count-tree 100)',
@@ -284,6 +285,20 @@ export const runCli = async (directories: string[], cwd: string, options: CliOpt
     const { runInitAction } = await import('./actions/initAction.js');
     await runInitAction(cwd, options.global || false);
     return;
+  }
+
+  if (options.watch) {
+    if (options.remote) {
+      throw new RepomixError('--watch cannot be used with --remote. Watch mode only supports local directories.');
+    }
+    if (directories.length === 1 && isExplicitRemoteUrl(directories[0])) {
+      throw new RepomixError(
+        '--watch only supports local directories. Clone the repository locally before watching it.',
+      );
+    }
+
+    const { runWatchAction } = await import('./actions/watchAction.js');
+    return await runWatchAction(directories, cwd, options);
   }
 
   if (options.remote) {

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -73,4 +73,5 @@ export interface CliOptions extends OptionValues {
   topFilesLen?: number;
   verbose?: boolean;
   quiet?: boolean;
+  watch?: boolean;
 }

--- a/tests/cli/actions/watchAction.test.ts
+++ b/tests/cli/actions/watchAction.test.ts
@@ -182,6 +182,38 @@ describe('watchAction', () => {
     await runPromise;
   });
 
+  it('does not ignore watched files because the workspace parent path contains node_modules', async () => {
+    const cwd = path.resolve('/repo/node_modules/my-project');
+    const fakeWatcher = new FakeWatcher();
+    let stopWatching!: () => void;
+    const stopPromise = new Promise<void>((resolve) => {
+      stopWatching = resolve;
+    });
+    const createWatcher = vi.fn((_paths: string[], _options: ChokidarOptions) => fakeWatcher);
+
+    const runPromise = runWatchAction(
+      ['src'],
+      cwd,
+      { watch: true },
+      {
+        runDefaultAction: vi.fn(async () => createResult()),
+        createWatcher,
+        waitForStop: async () => stopPromise,
+        debounceMs: 300,
+      },
+    );
+    await flushPromises();
+
+    const options = createWatcher.mock.calls[0][1];
+    const ignored = options.ignored as (filePath: string) => boolean;
+
+    expect(ignored(path.join(cwd, 'src/index.ts'))).toBe(false);
+    expect(ignored(path.join(cwd, 'node_modules/pkg/index.js'))).toBe(true);
+
+    stopWatching();
+    await runPromise;
+  });
+
   it('watches instruction file paths from the active config', async () => {
     const runDefaultAction = vi.fn(async () =>
       createResult({

--- a/tests/cli/actions/watchAction.test.ts
+++ b/tests/cli/actions/watchAction.test.ts
@@ -116,6 +116,7 @@ describe('watchAction', () => {
       stopWatching = resolve;
     });
     const createWatcher = vi.fn((_paths: string[], _options: ChokidarOptions) => fakeWatcher);
+    const exit = vi.fn();
 
     const runPromise = runWatchAction(
       ['src'],
@@ -125,11 +126,12 @@ describe('watchAction', () => {
         runDefaultAction,
         createWatcher,
         waitForStop: async () => stopPromise,
+        exit,
         debounceMs: 300,
       },
     );
 
-    return { fakeWatcher, stopWatching, runPromise, runDefaultAction, createWatcher };
+    return { fakeWatcher, stopWatching, runPromise, runDefaultAction, createWatcher, exit };
   };
 
   it('runs an initial build and starts watching local directories', async () => {
@@ -190,6 +192,7 @@ describe('watchAction', () => {
       stopWatching = resolve;
     });
     const createWatcher = vi.fn((_paths: string[], _options: ChokidarOptions) => fakeWatcher);
+    const exit = vi.fn();
 
     const runPromise = runWatchAction(
       ['src'],
@@ -199,6 +202,7 @@ describe('watchAction', () => {
         runDefaultAction: vi.fn(async () => createResult()),
         createWatcher,
         waitForStop: async () => stopPromise,
+        exit,
         debounceMs: 300,
       },
     );
@@ -259,6 +263,7 @@ describe('watchAction', () => {
         runDefaultAction,
         createWatcher: vi.fn(() => fakeWatcher),
         waitForStop: async () => stopPromise,
+        exit: vi.fn(),
         debounceMs: 300,
       },
     );
@@ -301,6 +306,7 @@ describe('watchAction', () => {
         runDefaultAction,
         createWatcher: vi.fn(() => fakeWatcher),
         waitForStop: async () => stopPromise,
+        exit: vi.fn(),
         debounceMs: 300,
       },
     );
@@ -314,6 +320,17 @@ describe('watchAction', () => {
 
     stopWatching();
     await runPromise;
+  });
+
+  it('closes the watcher and exits when stop is requested', async () => {
+    const { fakeWatcher, stopWatching, runPromise, exit } = setup();
+    await flushPromises();
+
+    stopWatching();
+    await runPromise;
+
+    expect(fakeWatcher.close).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(0);
   });
 
   it.each([
@@ -332,6 +349,7 @@ describe('watchAction', () => {
           runDefaultAction: vi.fn(),
           createWatcher: vi.fn(),
           waitForStop: vi.fn(),
+          exit: vi.fn(),
           debounceMs: 300,
         },
       ),

--- a/tests/cli/actions/watchAction.test.ts
+++ b/tests/cli/actions/watchAction.test.ts
@@ -1,0 +1,308 @@
+import path from 'node:path';
+import type { ChokidarOptions } from 'chokidar';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DefaultActionRunnerResult } from '../../../src/cli/actions/defaultAction.js';
+import { runWatchAction } from '../../../src/cli/actions/watchAction.js';
+import type { CliOptions } from '../../../src/cli/types.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+vi.mock('../../../src/shared/logger', () => ({
+  logger: {
+    log: vi.fn(),
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+type FakeWatcherListener = ((eventName: string, filePath: string) => void) | ((error: Error) => void);
+
+class FakeWatcher {
+  private listeners = new Map<'all' | 'error', FakeWatcherListener[]>();
+  add = vi.fn();
+  close = vi.fn(async () => {});
+
+  on(eventName: 'all', listener: (eventName: string, filePath: string) => void): this;
+  on(eventName: 'error', listener: (error: Error) => void): this;
+  on(eventName: 'all' | 'error', listener: FakeWatcherListener): this {
+    const eventListeners = this.listeners.get(eventName) ?? [];
+    eventListeners.push(listener);
+    this.listeners.set(eventName, eventListeners);
+    return this;
+  }
+
+  emit(eventName: 'all', event: string, filePath: string): boolean;
+  emit(eventName: 'error', error: Error): boolean;
+  emit(eventName: 'all' | 'error', ...args: [string, string] | [Error]): boolean {
+    const eventListeners = this.listeners.get(eventName) ?? [];
+    for (const listener of eventListeners) {
+      if (eventName === 'all') {
+        (listener as (event: string, filePath: string) => void)(args[0] as string, args[1] as string);
+      } else {
+        (listener as (error: Error) => void)(args[0] as Error);
+      }
+    }
+    return eventListeners.length > 0;
+  }
+}
+
+const flushPromises = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const createResult = (overrides: Parameters<typeof createMockConfig>[0] = {}): DefaultActionRunnerResult => {
+  const config = createMockConfig({
+    cwd: '/repo',
+    output: {
+      filePath: 'repomix-output.xml',
+      style: 'xml',
+      parsableStyle: false,
+      fileSummary: true,
+      directoryStructure: true,
+      topFilesLength: 5,
+      showLineNumbers: false,
+      removeComments: false,
+      removeEmptyLines: false,
+      compress: false,
+      copyToClipboard: false,
+      files: true,
+      git: {
+        sortByChanges: true,
+        sortByChangesMaxCommits: 100,
+        includeDiffs: false,
+      },
+    },
+    ...overrides,
+  });
+
+  return {
+    config,
+    packResult: {
+      totalFiles: 1,
+      totalCharacters: 10,
+      totalTokens: 5,
+      fileCharCounts: {},
+      fileTokenCounts: {},
+      gitDiffTokenCount: 0,
+      gitLogTokenCount: 0,
+      outputFiles: ['repomix-output.xml'],
+      suspiciousFilesResults: [],
+      suspiciousGitDiffResults: [],
+      suspiciousGitLogResults: [],
+      processedFiles: [],
+      safeFilePaths: [],
+      skippedFiles: [],
+    },
+  };
+};
+
+describe('watchAction', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  const setup = (options: CliOptions = {}, runDefaultAction = vi.fn(async () => createResult())) => {
+    const fakeWatcher = new FakeWatcher();
+    let stopWatching!: () => void;
+    const stopPromise = new Promise<void>((resolve) => {
+      stopWatching = resolve;
+    });
+    const createWatcher = vi.fn((_paths: string[], _options: ChokidarOptions) => fakeWatcher);
+
+    const runPromise = runWatchAction(
+      ['src'],
+      '/repo',
+      { watch: true, ...options },
+      {
+        runDefaultAction,
+        createWatcher,
+        waitForStop: async () => stopPromise,
+        debounceMs: 300,
+      },
+    );
+
+    return { fakeWatcher, stopWatching, runPromise, runDefaultAction, createWatcher };
+  };
+
+  it('runs an initial build and starts watching local directories', async () => {
+    const { runDefaultAction, createWatcher, stopWatching, runPromise } = setup();
+
+    await flushPromises();
+
+    expect(runDefaultAction).toHaveBeenCalledTimes(1);
+    expect(runDefaultAction).toHaveBeenCalledWith(['src'], '/repo', expect.objectContaining({ watch: true }));
+    expect(createWatcher).toHaveBeenCalledWith(
+      expect.arrayContaining([path.resolve('/repo', 'src')]),
+      expect.objectContaining({
+        ignoreInitial: true,
+        persistent: true,
+      }),
+    );
+
+    stopWatching();
+    await runPromise;
+  });
+
+  it('debounces file changes before rebuilding', async () => {
+    const { fakeWatcher, runDefaultAction, stopWatching, runPromise } = setup();
+    await flushPromises();
+
+    fakeWatcher.emit('all', 'change', path.resolve('/repo/src/index.ts'));
+    await vi.advanceTimersByTimeAsync(299);
+    expect(runDefaultAction).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(runDefaultAction).toHaveBeenCalledTimes(2);
+
+    stopWatching();
+    await runPromise;
+  });
+
+  it('ignores generated output files and noisy dependency directories', async () => {
+    const { createWatcher, stopWatching, runPromise } = setup();
+    await flushPromises();
+
+    const options = createWatcher.mock.calls[0][1];
+    const ignored = options.ignored as (filePath: string) => boolean;
+
+    expect(ignored(path.resolve('/repo/repomix-output.xml'))).toBe(true);
+    expect(ignored(path.resolve('/repo/node_modules/pkg/index.js'))).toBe(true);
+    expect(ignored(path.resolve('/repo/src/index.ts'))).toBe(false);
+
+    stopWatching();
+    await runPromise;
+  });
+
+  it('watches instruction file paths from the active config', async () => {
+    const runDefaultAction = vi.fn(async () =>
+      createResult({
+        output: {
+          instructionFilePath: 'docs/instructions.md',
+        },
+      }),
+    );
+
+    const { createWatcher, stopWatching, runPromise } = setup({}, runDefaultAction);
+    await flushPromises();
+
+    expect(createWatcher).toHaveBeenCalledWith(
+      expect.arrayContaining([path.resolve('/repo/docs/instructions.md')]),
+      expect.any(Object),
+    );
+
+    stopWatching();
+    await runPromise;
+  });
+
+  it('coalesces changes that arrive while a rebuild is running', async () => {
+    const fakeWatcher = new FakeWatcher();
+    let stopWatching!: () => void;
+    const stopPromise = new Promise<void>((resolve) => {
+      stopWatching = resolve;
+    });
+    let finishSecondBuild!: () => void;
+    const secondBuild = new Promise<DefaultActionRunnerResult>((resolve) => {
+      finishSecondBuild = () => resolve(createResult());
+    });
+    const runDefaultAction = vi
+      .fn()
+      .mockResolvedValueOnce(createResult())
+      .mockReturnValueOnce(secondBuild)
+      .mockResolvedValue(createResult());
+
+    const runPromise = runWatchAction(
+      ['src'],
+      '/repo',
+      { watch: true },
+      {
+        runDefaultAction,
+        createWatcher: vi.fn(() => fakeWatcher),
+        waitForStop: async () => stopPromise,
+        debounceMs: 300,
+      },
+    );
+
+    await flushPromises();
+    fakeWatcher.emit('all', 'change', path.resolve('/repo/src/first.ts'));
+    await vi.advanceTimersByTimeAsync(300);
+    await flushPromises();
+    expect(runDefaultAction).toHaveBeenCalledTimes(2);
+
+    fakeWatcher.emit('all', 'change', path.resolve('/repo/src/second.ts'));
+    await vi.advanceTimersByTimeAsync(300);
+    await flushPromises();
+    expect(runDefaultAction).toHaveBeenCalledTimes(2);
+
+    finishSecondBuild();
+    await flushPromises();
+    expect(runDefaultAction).toHaveBeenCalledTimes(3);
+
+    stopWatching();
+    await runPromise;
+  });
+
+  it('keeps watching after a rebuild fails', async () => {
+    const fakeWatcher = new FakeWatcher();
+    let stopWatching!: () => void;
+    const stopPromise = new Promise<void>((resolve) => {
+      stopWatching = resolve;
+    });
+    const runDefaultAction = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('first build failed'))
+      .mockResolvedValue(createResult());
+
+    const runPromise = runWatchAction(
+      ['src'],
+      '/repo',
+      { watch: true },
+      {
+        runDefaultAction,
+        createWatcher: vi.fn(() => fakeWatcher),
+        waitForStop: async () => stopPromise,
+        debounceMs: 300,
+      },
+    );
+
+    await flushPromises();
+    fakeWatcher.emit('all', 'change', path.resolve('/repo/src/index.ts'));
+    await vi.advanceTimersByTimeAsync(300);
+    await flushPromises();
+
+    expect(runDefaultAction).toHaveBeenCalledTimes(2);
+
+    stopWatching();
+    await runPromise;
+  });
+
+  it.each([
+    [{ stdin: true }, '--watch cannot be used with --stdin'],
+    [{ stdout: true }, '--watch cannot be used with --stdout'],
+    [{ output: '-' }, '--watch cannot be used with --stdout'],
+    [{ copy: true }, '--watch cannot be used with --copy'],
+    [{ skillGenerate: true }, '--watch cannot be used with --skill-generate'],
+  ] as const)('rejects unsupported option combination %j', async (options, expectedMessage) => {
+    await expect(
+      runWatchAction(
+        ['.'],
+        '/repo',
+        { watch: true, ...options },
+        {
+          runDefaultAction: vi.fn(),
+          createWatcher: vi.fn(),
+          waitForStop: vi.fn(),
+          debounceMs: 300,
+        },
+      ),
+    ).rejects.toThrow(expectedMessage);
+  });
+});

--- a/tests/cli/actions/watchAction.test.ts
+++ b/tests/cli/actions/watchAction.test.ts
@@ -333,6 +333,16 @@ describe('watchAction', () => {
     expect(exit).toHaveBeenCalledWith(0);
   });
 
+  it('allows watch mode when skill generation is explicitly disabled', async () => {
+    const { runDefaultAction, stopWatching, runPromise } = setup({ skillGenerate: false });
+    await flushPromises();
+
+    expect(runDefaultAction).toHaveBeenCalledTimes(1);
+
+    stopWatching();
+    await runPromise;
+  });
+
   it.each([
     [{ stdin: true }, '--watch cannot be used with --stdin'],
     [{ stdout: true }, '--watch cannot be used with --stdout'],

--- a/tests/cli/cliReport.test.ts
+++ b/tests/cli/cliReport.test.ts
@@ -398,6 +398,15 @@ describe('cliReport', () => {
 
       expect(logger.log).toHaveBeenCalledWith('GREEN:🎉 All Done!');
       expect(logger.log).toHaveBeenCalledWith('Your repository has been successfully packed.');
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('https://repomix.com'));
+    });
+
+    test('should skip browser prompt in watch mode', () => {
+      reportCompletion({ watchMode: true });
+
+      expect(logger.log).toHaveBeenCalledWith('GREEN:🎉 All Done!');
+      expect(logger.log).toHaveBeenCalledWith('Your repository has been successfully packed.');
+      expect(logger.log).not.toHaveBeenCalledWith(expect.stringContaining('https://repomix.com'));
     });
   });
 });

--- a/tests/cli/cliRun.test.ts
+++ b/tests/cli/cliRun.test.ts
@@ -5,6 +5,7 @@ import * as defaultAction from '../../src/cli/actions/defaultAction.js';
 import * as initAction from '../../src/cli/actions/initAction.js';
 import * as remoteAction from '../../src/cli/actions/remoteAction.js';
 import * as versionAction from '../../src/cli/actions/versionAction.js';
+import * as watchAction from '../../src/cli/actions/watchAction.js';
 import { run, runCli } from '../../src/cli/cliRun.js';
 import type { CliOptions } from '../../src/cli/types.js';
 import * as gitRemoteHandle from '../../src/core/git/gitRemoteHandle.js';
@@ -42,6 +43,7 @@ vi.mock('../../src/shared/logger', () => ({
 vi.mock('../../src/cli/actions/defaultAction');
 vi.mock('../../src/cli/actions/initAction');
 vi.mock('../../src/cli/actions/remoteAction');
+vi.mock('../../src/cli/actions/watchAction');
 vi.mock('../../src/core/git/gitRemoteHandle');
 vi.mock('../../src/cli/actions/versionAction');
 
@@ -174,6 +176,7 @@ describe('cliRun', () => {
       } satisfies PackResult,
     });
     vi.mocked(versionAction.runVersionAction).mockResolvedValue();
+    vi.mocked(watchAction.runWatchAction).mockResolvedValue(undefined);
   });
 
   test('should call process.exit(1) on error', async () => {
@@ -323,6 +326,48 @@ describe('cliRun', () => {
       });
 
       expect(remoteAction.runRemoteAction).toHaveBeenCalledWith('yamadashy/repomix', expect.any(Object));
+    });
+
+    test('should execute watch action for local directories when watch option is true', async () => {
+      await runCli(['src'], process.cwd(), { watch: true });
+
+      expect(watchAction.runWatchAction).toHaveBeenCalledWith(
+        ['src'],
+        process.cwd(),
+        expect.objectContaining({ watch: true }),
+      );
+      expect(defaultAction.runDefaultAction).not.toHaveBeenCalled();
+      expect(remoteAction.runRemoteAction).not.toHaveBeenCalled();
+    });
+
+    test('should reject --watch with explicit --remote', async () => {
+      await expect(runCli(['.'], process.cwd(), { watch: true, remote: 'yamadashy/repomix' })).rejects.toThrow(
+        '--watch cannot be used with --remote',
+      );
+
+      expect(watchAction.runWatchAction).not.toHaveBeenCalled();
+      expect(remoteAction.runRemoteAction).not.toHaveBeenCalled();
+    });
+
+    test('should reject --watch with explicit remote URL positional argument', async () => {
+      await expect(runCli(['https://github.com/user/repo'], process.cwd(), { watch: true })).rejects.toThrow(
+        '--watch only supports local directories',
+      );
+
+      expect(watchAction.runWatchAction).not.toHaveBeenCalled();
+      expect(remoteAction.runRemoteAction).not.toHaveBeenCalled();
+    });
+
+    test('should not probe GitHub shorthand in watch mode', async () => {
+      await runCli(['user/repo'], process.cwd(), { watch: true });
+
+      expect(gitRemoteHandle.checkRemoteRepoExists).not.toHaveBeenCalled();
+      expect(watchAction.runWatchAction).toHaveBeenCalledWith(
+        ['user/repo'],
+        process.cwd(),
+        expect.objectContaining({ watch: true }),
+      );
+      expect(remoteAction.runRemoteAction).not.toHaveBeenCalled();
     });
   });
 

--- a/website/client/src/en/guide/command-line-options.md
+++ b/website/client/src/en/guide/command-line-options.md
@@ -17,6 +17,7 @@ description: Reference every Repomix CLI option for input, output, file selectio
 | `--stdout` | Write packed output directly to stdout instead of a file (suppresses all logging) |
 | `--stdin` | Read file paths from stdin, one per line (specified files are processed directly) |
 | `--copy` | Copy the generated output to system clipboard after processing |
+| `--watch` | Watch local files and rebuild the output when changes are detected |
 | `--token-count-tree [threshold]` | Show file tree with token counts; optional threshold to show only files with ≥N tokens (e.g., `--token-count-tree 100`) |
 | `--top-files-len <number>` | Number of largest files to show in summary (default: `5`) |
 
@@ -114,6 +115,10 @@ repomix --stdout | llm "Please explain what this code does."
 
 # Custom output with compression
 repomix --compress
+
+# Watch local files and rebuild automatically
+repomix --watch
+repomix src --watch --include "src/**/*.ts"
 
 # Split output into multiple files (max size per part)
 repomix --split-output 20mb


### PR DESCRIPTION
Closes #1429.

## Summary

This adds a local `--watch` mode for rebuilding Repomix output after file changes, so the CLI does not need to be restarted during edit loops.

The watcher runs an initial pack, then debounces change events before running the normal pack flow again. It also avoids self-triggering on generated output files and skips the browser prompt while watch mode is still running.

A few modes are rejected up front because they do not fit a long-lived rebuild loop: remote repositories, stdin, stdout, clipboard copy, and skill generation.

## Testing

- `npm run lint`
- `npm run build`
- `npm test -- --run`
- manual watch smoke test: started `repomix --watch`, edited a local file, and confirmed the output was rebuilt