### PR TITLE
Add configurable file processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1403,6 +1403,7 @@ Here's an explanation of the configuration options:
 | `output.git.includeLogs`        | Whether to include git logs in the output (includes commit history with dates, messages, and file paths)                   | `false`                |
 | `output.git.includeLogsCount`   | Number of git log commits to include                                                                                         | `50`                   |
 | `include`                        | Patterns of files to include (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax))  | `[]`                   |
+| `fileProcessors`                 | Map of glob patterns to shell commands that transform matched file contents. Commands must include `{file}`; stdout becomes packed content. Local repositories only | `{}`                   |
 | `ignore.useGitignore`            | Whether to use patterns from the project's `.gitignore` file                                                                 | `true`                 |
 | `ignore.useDotIgnore`            | Whether to use patterns from the project's `.ignore` file                                                                    | `true`                 |
 | `ignore.useDefaultPatterns`      | Whether to use default ignore patterns                                                                                       | `true`                 |
@@ -1470,6 +1471,7 @@ Example configuration:
     }
   },
   "include": ["**/*"],
+  "fileProcessors": {},
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,
@@ -1546,6 +1548,29 @@ preventing the leakage of confidential information.
 Note: Binary files are not included in the packed output by default, but their paths are listed in the "Repository
 Structure" section of the output file. This provides a complete overview of the repository structure while keeping the
 packed file efficient and text-based.
+
+### File Processors
+
+`fileProcessors` lets you transform matched text files with an external command before Repomix packs them. Repomix
+writes the current file content to a temporary file, replaces `{file}` in the command with that temporary file path, and
+uses the command's stdout as the new file content.
+
+For example, to convert Jupyter notebooks to Python with `jupyter nbconvert`:
+
+```json5
+{
+  "fileProcessors": {
+    "**/*.ipynb": "jupyter nbconvert --to python --stdout {file}"
+  }
+}
+```
+
+Processor patterns use the same glob syntax as `include`. When multiple patterns match a file, the first matching entry
+in the configuration is used. Commands run from the repository root, and the transformed content is used by downstream
+packing steps, including security checks.
+
+This feature is opt-in and runs local commands, so only configure processors you trust. It is disabled for remote
+repository processing.
 
 ### Custom Instruction
 

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -52,6 +52,10 @@ export const runDefaultAction = async (
   const config: RepomixConfigMerged = mergeConfigs(cwd, fileConfig, cliConfig);
   logger.trace('Merged config:', config);
 
+  if (cliOptions.skipFileProcessors && Object.keys(config.fileProcessors).length > 0) {
+    throw new RepomixError('fileProcessors cannot be used in remote mode.');
+  }
+
   // Validate conflicting options
   validateConflictingOptions(config);
 

--- a/src/cli/actions/remoteAction.ts
+++ b/src/cli/actions/remoteAction.ts
@@ -139,6 +139,7 @@ export const runRemoteAction = async (
       skillProjectName,
       skillSourceUrl,
       skipLocalConfig: !trustRemoteConfig,
+      skipFileProcessors: true,
       // Defer the token-budget check so the output is copied out of the temp
       // dir below before the guard can throw; we run validateTokenBudget here
       // afterwards. Otherwise an over-budget remote run would throw inside

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -42,6 +42,7 @@ export interface CliOptions extends OptionValues {
   remoteBranch?: string;
   remoteTrustConfig?: boolean;
   skipLocalConfig?: boolean; // Internal flag: skip loading config files from the working directory (e.g., untrusted remote repos)
+  skipFileProcessors?: boolean; // Internal flag: disable local command processors for remote repository runs
   deferTokenBudgetCheck?: boolean; // Internal flag: skip the token-budget check inside runDefaultAction so the caller can enforce it after delivering output (e.g., remote runs copy out of the temp dir first)
 
   // Configuration Options

--- a/src/config/configLoad.ts
+++ b/src/config/configLoad.ts
@@ -257,6 +257,11 @@ export const mergeConfigs = (
       ...fileConfig.tokenCount,
       ...cliConfig.tokenCount,
     },
+    fileProcessors: {
+      ...baseConfig.fileProcessors,
+      ...fileConfig.fileProcessors,
+      ...cliConfig.fileProcessors,
+    },
     // Skill generation (CLI only)
     ...(cliConfig.skillGenerate !== undefined && { skillGenerate: cliConfig.skillGenerate }),
   };

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -74,6 +74,7 @@ export const repomixConfigBaseSchema = v.object({
       encoding: v.optional(v.string()),
     }),
   ),
+  fileProcessors: v.optional(v.record(v.string(), v.string())),
 });
 
 // Default config schema with default values
@@ -124,6 +125,7 @@ export const repomixConfigDefaultSchema = v.object({
   tokenCount: v.object({
     encoding: v.optional(v.picklist(TOKEN_ENCODINGS), 'o200k_base'),
   }),
+  fileProcessors: v.optional(v.record(v.string(), v.string()), () => ({})),
 });
 
 // File-specific schema. Add options for file path and style

--- a/src/core/file/fileCollect.ts
+++ b/src/core/file/fileCollect.ts
@@ -3,6 +3,7 @@ import pc from 'picocolors';
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
+import { applyFileProcessors as defaultApplyFileProcessors } from './fileProcessors.js';
 import { readRawFile as defaultReadRawFile, type FileSkipReason } from './fileRead.js';
 import type { RawFile } from './fileTypes.js';
 
@@ -18,6 +19,11 @@ export interface SkippedFileInfo {
 export interface FileCollectResults {
   rawFiles: RawFile[];
   skippedFiles: SkippedFileInfo[];
+}
+
+export interface CollectFilesDeps {
+  readRawFile?: typeof defaultReadRawFile;
+  applyFileProcessors?: typeof defaultApplyFileProcessors;
 }
 
 const promisePool = async <T, R>(items: T[], concurrency: number, fn: (item: T) => Promise<R>): Promise<R[]> => {
@@ -41,20 +47,20 @@ export const collectFiles = async (
   rootDir: string,
   config: RepomixConfigMerged,
   progressCallback: RepomixProgressCallback = () => {},
-  deps = {
-    readRawFile: defaultReadRawFile,
-  },
+  deps: CollectFilesDeps = {},
 ): Promise<FileCollectResults> => {
   const startTime = process.hrtime.bigint();
   logger.trace(`Starting file collection for ${filePaths.length} files`);
 
+  const readRawFile = deps.readRawFile ?? defaultReadRawFile;
+  const applyFileProcessors = deps.applyFileProcessors ?? defaultApplyFileProcessors;
   let completedTasks = 0;
   const totalTasks = filePaths.length;
   const maxFileSize = config.input.maxFileSize;
 
   const results = await promisePool(filePaths, FILE_COLLECT_CONCURRENCY, async (filePath) => {
     const fullPath = path.resolve(rootDir, filePath);
-    const result = await deps.readRawFile(fullPath, maxFileSize);
+    const result = await readRawFile(fullPath, maxFileSize);
 
     completedTasks++;
     progressCallback(`Collect file... (${completedTasks}/${totalTasks}) ${pc.dim(filePath)}`);
@@ -74,9 +80,11 @@ export const collectFiles = async (
     }
   }
 
+  const processedRawFiles = await applyFileProcessors(rawFiles, rootDir, config, progressCallback);
+
   const endTime = process.hrtime.bigint();
   const duration = Number(endTime - startTime) / 1e6;
   logger.trace(`File collection completed in ${duration.toFixed(2)}ms`);
 
-  return { rawFiles, skippedFiles };
+  return { rawFiles: processedRawFiles, skippedFiles };
 };

--- a/src/core/file/fileProcessors.ts
+++ b/src/core/file/fileProcessors.ts
@@ -1,0 +1,130 @@
+import { execFile } from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { minimatch } from 'minimatch';
+import pc from 'picocolors';
+import type { RepomixConfigMerged } from '../../config/configSchema.js';
+import { mapWithConcurrency } from '../../shared/asyncMap.js';
+import { RepomixError } from '../../shared/errorHandle.js';
+import type { RepomixProgressCallback } from '../../shared/types.js';
+import type { RawFile } from './fileTypes.js';
+
+const execFileAsync = promisify(execFile);
+const FILE_PROCESSOR_CONCURRENCY = 4;
+const FILE_PROCESSOR_TIMEOUT_MS = 30_000;
+const FILE_PROCESSOR_MAX_BUFFER = 10 * 1024 * 1024;
+
+export interface RunCommandOptions {
+  cwd: string;
+  timeout: number;
+  maxBuffer: number;
+}
+
+export interface FileProcessorDeps {
+  mkdtemp: (prefix: string) => Promise<string>;
+  writeFile: (file: string, data: string, encoding: BufferEncoding) => Promise<void>;
+  rm: (file: string, options: { force: boolean; recursive: boolean }) => Promise<void>;
+  runCommand: (command: string, options: RunCommandOptions) => Promise<{ stdout: string }>;
+}
+
+const runShellCommand = async (command: string, options: RunCommandOptions): Promise<{ stdout: string }> => {
+  const shell = process.platform === 'win32' ? (process.env.ComSpec ?? 'cmd.exe') : '/bin/sh';
+  const args = process.platform === 'win32' ? ['/d', '/s', '/c', command] : ['-c', command];
+  const result = await execFileAsync(shell, args, {
+    cwd: options.cwd,
+    encoding: 'utf8',
+    maxBuffer: options.maxBuffer,
+    timeout: options.timeout,
+    windowsHide: true,
+  });
+  return { stdout: String(result.stdout) };
+};
+
+const defaultDeps: FileProcessorDeps = {
+  mkdtemp: fs.mkdtemp,
+  writeFile: fs.writeFile,
+  rm: fs.rm,
+  runCommand: runShellCommand,
+};
+
+const normalizePathForGlob = (filePath: string): string => filePath.replace(/\\/g, '/');
+
+const findProcessorCommand = (filePath: string, fileProcessors: Record<string, string>): [string, string] | null => {
+  const normalizedPath = normalizePathForGlob(filePath);
+  return Object.entries(fileProcessors).find(([pattern]) => minimatch(normalizedPath, pattern, { dot: true })) ?? null;
+};
+
+const quoteForShell = (filePath: string): string => {
+  if (process.platform === 'win32') {
+    return `"${filePath.replace(/"/g, '""')}"`;
+  }
+  return `'${filePath.replace(/'/g, "'\\''")}'`;
+};
+
+const safeTempFileName = (filePath: string): string => {
+  const basename = path.basename(filePath);
+  return basename.replace(/[^a-zA-Z0-9._-]/g, '_') || 'input';
+};
+
+const formatError = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+};
+
+const processFile = async (
+  rawFile: RawFile,
+  rootDir: string,
+  pattern: string,
+  commandTemplate: string,
+  deps: FileProcessorDeps,
+): Promise<RawFile> => {
+  if (!commandTemplate.includes('{file}')) {
+    throw new RepomixError(`File processor for pattern "${pattern}" must include {file}.`);
+  }
+
+  const tempDir = await deps.mkdtemp(path.join(os.tmpdir(), 'repomix-file-processors-'));
+  try {
+    const tempFilePath = path.join(tempDir, safeTempFileName(rawFile.path));
+    await deps.writeFile(tempFilePath, rawFile.content, 'utf8');
+
+    const command = commandTemplate.replaceAll('{file}', quoteForShell(tempFilePath));
+    const { stdout } = await deps.runCommand(command, {
+      cwd: rootDir,
+      maxBuffer: FILE_PROCESSOR_MAX_BUFFER,
+      timeout: FILE_PROCESSOR_TIMEOUT_MS,
+    });
+    return { ...rawFile, content: stdout };
+  } catch (error) {
+    throw new RepomixError(`Failed to process ${rawFile.path} with file processor "${pattern}": ${formatError(error)}`);
+  } finally {
+    await deps.rm(tempDir, { force: true, recursive: true });
+  }
+};
+
+export const applyFileProcessors = async (
+  rawFiles: RawFile[],
+  rootDir: string,
+  config: RepomixConfigMerged,
+  progressCallback: RepomixProgressCallback = () => {},
+  deps: FileProcessorDeps = defaultDeps,
+): Promise<RawFile[]> => {
+  const fileProcessors = config.fileProcessors;
+  if (Object.keys(fileProcessors).length === 0) {
+    return rawFiles;
+  }
+
+  return await mapWithConcurrency(rawFiles, FILE_PROCESSOR_CONCURRENCY, async (rawFile, index) => {
+    const processor = findProcessorCommand(rawFile.path, fileProcessors);
+    if (!processor) {
+      return rawFile;
+    }
+
+    const [pattern, command] = processor;
+    progressCallback(`Processing file processor... (${index + 1}/${rawFiles.length}) ${pc.dim(rawFile.path)}`);
+    return await processFile(rawFile, rootDir, pattern, command, deps);
+  });
+};

--- a/src/core/file/fileProcessors.ts
+++ b/src/core/file/fileProcessors.ts
@@ -51,9 +51,11 @@ const defaultDeps: FileProcessorDeps = {
 
 const normalizePathForGlob = (filePath: string): string => filePath.replace(/\\/g, '/');
 
-const findProcessorCommand = (filePath: string, fileProcessors: Record<string, string>): [string, string] | null => {
+type ProcessorEntry = [string, string];
+
+const findProcessorCommand = (filePath: string, processorEntries: ProcessorEntry[]): ProcessorEntry | null => {
   const normalizedPath = normalizePathForGlob(filePath);
-  return Object.entries(fileProcessors).find(([pattern]) => minimatch(normalizedPath, pattern, { dot: true })) ?? null;
+  return processorEntries.find(([pattern]) => minimatch(normalizedPath, pattern, { dot: true })) ?? null;
 };
 
 const quoteForShell = (filePath: string): string => {
@@ -101,7 +103,11 @@ const processFile = async (
   } catch (error) {
     throw new RepomixError(`Failed to process ${rawFile.path} with file processor "${pattern}": ${formatError(error)}`);
   } finally {
-    await deps.rm(tempDir, { force: true, recursive: true });
+    try {
+      await deps.rm(tempDir, { force: true, recursive: true });
+    } catch {
+      // Cleanup is best-effort; keep the processor result or primary error intact.
+    }
   }
 };
 
@@ -112,13 +118,13 @@ export const applyFileProcessors = async (
   progressCallback: RepomixProgressCallback = () => {},
   deps: FileProcessorDeps = defaultDeps,
 ): Promise<RawFile[]> => {
-  const fileProcessors = config.fileProcessors;
-  if (Object.keys(fileProcessors).length === 0) {
+  const processorEntries = Object.entries(config.fileProcessors);
+  if (processorEntries.length === 0) {
     return rawFiles;
   }
 
   return await mapWithConcurrency(rawFiles, FILE_PROCESSOR_CONCURRENCY, async (rawFile, index) => {
-    const processor = findProcessorCommand(rawFile.path, fileProcessors);
+    const processor = findProcessorCommand(rawFile.path, processorEntries);
     if (!processor) {
       return rawFile;
     }

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -157,6 +157,21 @@ describe('defaultAction', () => {
     expect(mockSpinner.fail).toHaveBeenCalledWith('Error during packing');
   });
 
+  it('should reject fileProcessors when disabled by remote mode', async () => {
+    vi.mocked(configLoader.mergeConfigs).mockReturnValue(
+      createMockConfig({
+        fileProcessors: {
+          '**/*.ipynb': 'jupyter nbconvert --to python --stdout {file}',
+        },
+      }),
+    );
+
+    await expect(runDefaultAction(['.'], process.cwd(), { skipFileProcessors: true })).rejects.toThrow(
+      'fileProcessors cannot be used in remote mode',
+    );
+    expect(packager.pack).not.toHaveBeenCalled();
+  });
+
   describe('progressCallback', () => {
     it('should forward progress messages to the provided callback', async () => {
       // Configure pack mock to invoke its 3rd argument (progressCallback)

--- a/tests/cli/actions/remoteAction.test.ts
+++ b/tests/cli/actions/remoteAction.test.ts
@@ -70,7 +70,7 @@ describe('remoteAction functions', () => {
       expect(runDefaultActionMock).toHaveBeenCalledWith(
         expect.any(Array),
         expect.any(String),
-        expect.objectContaining({ skipLocalConfig: true }),
+        expect.objectContaining({ skipFileProcessors: true, skipLocalConfig: true }),
       );
     });
 
@@ -216,7 +216,7 @@ describe('remoteAction functions', () => {
       expect(runDefaultActionMock).toHaveBeenCalledWith(
         expect.any(Array),
         expect.any(String),
-        expect.objectContaining({ skipLocalConfig: true }),
+        expect.objectContaining({ skipFileProcessors: true, skipLocalConfig: true }),
       );
     });
 
@@ -244,7 +244,7 @@ describe('remoteAction functions', () => {
       expect(runDefaultActionMock).toHaveBeenCalledWith(
         expect.any(Array),
         expect.any(String),
-        expect.objectContaining({ skipLocalConfig: false }),
+        expect.objectContaining({ skipFileProcessors: true, skipLocalConfig: false }),
       );
     });
 

--- a/tests/config/configLoad.test.ts
+++ b/tests/config/configLoad.test.ts
@@ -374,6 +374,26 @@ describe('configLoad', () => {
       expect(merged.tokenCount.encoding).toBe('cl100k_base');
     });
 
+    test('should merge fileProcessors config correctly', () => {
+      const fileConfig: RepomixConfigFile = {
+        fileProcessors: {
+          '**/*.ipynb': 'jupyter nbconvert --to python --stdout {file}',
+        },
+      };
+      const cliConfig: RepomixConfigCli = {
+        fileProcessors: {
+          '**/*.json': 'node scripts/json-to-text.js {file}',
+        },
+      };
+
+      const merged = mergeConfigs(process.cwd(), fileConfig, cliConfig);
+
+      expect(merged.fileProcessors).toEqual({
+        '**/*.ipynb': 'jupyter nbconvert --to python --stdout {file}',
+        '**/*.json': 'node scripts/json-to-text.js {file}',
+      });
+    });
+
     test('should map default filename to style when only style is provided via CLI', () => {
       const merged = mergeConfigs(process.cwd(), {}, { output: { style: 'markdown' } });
       expect(merged.output.filePath).toBe('repomix-output.md');

--- a/tests/config/configSchema.test.ts
+++ b/tests/config/configSchema.test.ts
@@ -70,6 +70,9 @@ describe('configSchema', () => {
           useGitignore: true,
           customPatterns: ['node_modules'],
         },
+        fileProcessors: {
+          '**/*.ipynb': 'jupyter nbconvert --to python --stdout {file}',
+        },
         security: {
           enableSecurityCheck: true,
         },
@@ -136,6 +139,7 @@ describe('configSchema', () => {
         tokenCount: {
           encoding: 'o200k_base',
         },
+        fileProcessors: {},
       };
       expect(v.parse(repomixConfigDefaultSchema, validConfig)).toEqual(validConfig);
     });
@@ -190,6 +194,7 @@ describe('configSchema', () => {
         ignore: { useGitignore: true, useDotIgnore: true, useDefaultPatterns: true, customPatterns: [] as string[] },
         security: { enableSecurityCheck: true },
         tokenCount: { encoding: 'o200k_base' as const },
+        fileProcessors: {},
       };
 
       it('rejects non-integer maxFileSize', () => {
@@ -286,8 +291,21 @@ describe('configSchema', () => {
         ignore: {
           customPatterns: ['*.log'],
         },
+        fileProcessors: {
+          '**/*.json': 'node scripts/json-to-text.js {file}',
+        },
       };
       expect(v.parse(repomixConfigFileSchema, validConfig)).toEqual(validConfig);
+    });
+
+    it('should reject file processor commands that are not strings', () => {
+      const invalidConfig = {
+        fileProcessors: {
+          '**/*.ipynb': ['jupyter', 'nbconvert'],
+        },
+      };
+
+      expect(() => v.parse(repomixConfigFileSchema, invalidConfig)).toThrow(v.ValiError);
     });
 
     it('should accept partial config', () => {
@@ -381,6 +399,9 @@ describe('configSchema', () => {
         tokenCount: {
           encoding: 'o200k_base',
         },
+        fileProcessors: {
+          '**/*.ipynb': 'jupyter nbconvert --to python --stdout {file}',
+        },
       };
       expect(v.parse(repomixConfigMergedSchema, validConfig)).toEqual(validConfig);
     });
@@ -455,6 +476,7 @@ describe('configSchema', () => {
         ignore: { useGitignore: true, useDotIgnore: true, useDefaultPatterns: true, customPatterns: [] },
         security: { enableSecurityCheck: true },
         tokenCount: { encoding: 'o200k_base' },
+        fileProcessors: {},
         skillGenerate: 'my-skill',
       };
       const result = v.parse(repomixConfigMergedSchema, merged) as typeof merged;

--- a/tests/core/file/fileCollect.test.ts
+++ b/tests/core/file/fileCollect.test.ts
@@ -59,6 +59,35 @@ describe('fileCollect', () => {
     });
   });
 
+  it('should apply file processors to collected text files before returning raw files', async () => {
+    const mockFilePaths = ['analysis.ipynb'];
+    const mockRootDir = '/root';
+    const mockConfig = createMockConfig({
+      fileProcessors: {
+        '**/*.ipynb': 'jupyter nbconvert --to python --stdout {file}',
+      },
+    });
+    const mockProgress = vi.fn();
+    const applyFileProcessors = vi.fn(async () => [
+      { path: 'analysis.ipynb', content: '# converted notebook\nprint(1)' },
+    ]);
+
+    mockReadRawFile.mockResolvedValue({ content: '{"cells":[]}' });
+
+    const result = await collectFiles(mockFilePaths, mockRootDir, mockConfig, mockProgress, {
+      readRawFile: mockReadRawFile,
+      applyFileProcessors,
+    });
+
+    expect(applyFileProcessors).toHaveBeenCalledWith(
+      [{ path: 'analysis.ipynb', content: '{"cells":[]}' }],
+      mockRootDir,
+      mockConfig,
+      mockProgress,
+    );
+    expect(result.rawFiles).toEqual([{ path: 'analysis.ipynb', content: '# converted notebook\nprint(1)' }]);
+  });
+
   it('should skip large files based on default maxFileSize', async () => {
     const mockFilePaths = ['large.txt', 'normal.txt'];
     const mockRootDir = '/root';

--- a/tests/core/file/fileProcessors.test.ts
+++ b/tests/core/file/fileProcessors.test.ts
@@ -1,0 +1,106 @@
+import path from 'node:path';
+import { beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest';
+import type { FileProcessorDeps } from '../../../src/core/file/fileProcessors.js';
+import { applyFileProcessors } from '../../../src/core/file/fileProcessors.js';
+import type { RawFile } from '../../../src/core/file/fileTypes.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+type MockFileProcessorDeps = {
+  [Key in keyof FileProcessorDeps]: MockedFunction<FileProcessorDeps[Key]>;
+};
+
+const createDeps = (): MockFileProcessorDeps => ({
+  mkdtemp: vi.fn(async () => path.join('/tmp', 'repomix-processors-abc')),
+  writeFile: vi.fn(async () => {}),
+  rm: vi.fn(async () => {}),
+  runCommand: vi.fn(async () => ({ stdout: 'converted output\n' })),
+});
+
+describe('fileProcessors', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('replaces matching file content with processor stdout', async () => {
+    const rawFiles: RawFile[] = [
+      { path: 'notebook.ipynb', content: '{"cells":[]}' },
+      { path: 'src/index.ts', content: 'export const value = 1;' },
+    ];
+    const config = createMockConfig({
+      fileProcessors: {
+        '**/*.ipynb': 'jupyter nbconvert --to python --stdout {file}',
+      },
+    });
+    const deps = createDeps();
+
+    const result = await applyFileProcessors(rawFiles, '/repo', config, vi.fn(), deps);
+
+    expect(result).toEqual([
+      { path: 'notebook.ipynb', content: 'converted output\n' },
+      { path: 'src/index.ts', content: 'export const value = 1;' },
+    ]);
+    expect(deps.mkdtemp).toHaveBeenCalledWith(expect.stringContaining('repomix-file-processors-'));
+    expect(deps.writeFile).toHaveBeenCalledWith(
+      path.join('/tmp', 'repomix-processors-abc', 'notebook.ipynb'),
+      '{"cells":[]}',
+      'utf8',
+    );
+    expect(deps.runCommand).toHaveBeenCalledWith(
+      `jupyter nbconvert --to python --stdout '${path.join('/tmp', 'repomix-processors-abc', 'notebook.ipynb')}'`,
+      expect.objectContaining({
+        cwd: '/repo',
+        maxBuffer: expect.any(Number),
+        timeout: expect.any(Number),
+      }),
+    );
+    expect(deps.rm).toHaveBeenCalledWith(path.join('/tmp', 'repomix-processors-abc'), {
+      force: true,
+      recursive: true,
+    });
+  });
+
+  it('uses the first matching processor in config order', async () => {
+    const rawFiles: RawFile[] = [{ path: 'data/notebook.ipynb', content: '{"cells":[]}' }];
+    const config = createMockConfig({
+      fileProcessors: {
+        '**/*.ipynb': 'first {file}',
+        'data/*.ipynb': 'second {file}',
+      },
+    });
+    const deps = createDeps();
+
+    await applyFileProcessors(rawFiles, '/repo', config, vi.fn(), deps);
+
+    expect(deps.runCommand.mock.calls[0][0]).toMatch(/^first /);
+  });
+
+  it('rejects processor commands without a file placeholder', async () => {
+    const config = createMockConfig({
+      fileProcessors: {
+        '**/*.ipynb': 'jupyter nbconvert --to python --stdout',
+      },
+    });
+
+    await expect(
+      applyFileProcessors([{ path: 'notebook.ipynb', content: '{}' }], '/repo', config, vi.fn(), createDeps()),
+    ).rejects.toThrow('must include {file}');
+  });
+
+  it('wraps processor command failures with file context and cleans up the temp directory', async () => {
+    const config = createMockConfig({
+      fileProcessors: {
+        '**/*.ipynb': 'jupyter nbconvert --to python --stdout {file}',
+      },
+    });
+    const deps = createDeps();
+    deps.runCommand.mockRejectedValue(new Error('nbconvert failed'));
+
+    await expect(
+      applyFileProcessors([{ path: 'notebook.ipynb', content: '{}' }], '/repo', config, vi.fn(), deps),
+    ).rejects.toThrow('Failed to process notebook.ipynb');
+    expect(deps.rm).toHaveBeenCalledWith(path.join('/tmp', 'repomix-processors-abc'), {
+      force: true,
+      recursive: true,
+    });
+  });
+});

--- a/tests/core/file/fileProcessors.test.ts
+++ b/tests/core/file/fileProcessors.test.ts
@@ -103,4 +103,19 @@ describe('fileProcessors', () => {
       recursive: true,
     });
   });
+
+  it('preserves processor command failures when temp cleanup also fails', async () => {
+    const config = createMockConfig({
+      fileProcessors: {
+        '**/*.ipynb': 'jupyter nbconvert --to python --stdout {file}',
+      },
+    });
+    const deps = createDeps();
+    deps.runCommand.mockRejectedValue(new Error('nbconvert failed'));
+    deps.rm.mockRejectedValue(new Error('cleanup failed'));
+
+    await expect(
+      applyFileProcessors([{ path: 'notebook.ipynb', content: '{}' }], '/repo', config, vi.fn(), deps),
+    ).rejects.toThrow('nbconvert failed');
+  });
 });

--- a/tests/core/metrics/calculateGitDiffMetrics.test.ts
+++ b/tests/core/metrics/calculateGitDiffMetrics.test.ts
@@ -69,6 +69,7 @@ describe('calculateGitDiffMetrics', () => {
     tokenCount: {
       encoding: 'o200k_base' as const,
     },
+    fileProcessors: {},
     cwd: '/test/project',
   };
 

--- a/tests/core/metrics/calculateGitLogMetrics.test.ts
+++ b/tests/core/metrics/calculateGitLogMetrics.test.ts
@@ -69,6 +69,7 @@ describe('calculateGitLogMetrics', () => {
     tokenCount: {
       encoding: 'o200k_base' as const,
     },
+    fileProcessors: {},
     cwd: '/test/project',
   };
 

--- a/tests/core/output/flagFullDirectoryStructure.test.ts
+++ b/tests/core/output/flagFullDirectoryStructure.test.ts
@@ -47,6 +47,7 @@ const createMockConfig = (overrides: Partial<RepomixConfigMerged> = {}): Repomix
     encoding: 'cl100k_base',
   },
   ...overrides,
+  fileProcessors: overrides.fileProcessors ?? {},
 });
 
 describe('includeFullDirectoryStructure flag', () => {
@@ -161,6 +162,7 @@ describe('includeEmptyDirectories with pre-computed emptyDirPaths', () => {
     security: { enableSecurityCheck: true },
     tokenCount: { encoding: 'cl100k_base' },
     ...overrides,
+    fileProcessors: overrides.fileProcessors ?? {},
   });
 
   test('uses pre-computed emptyDirPaths and skips searchFiles call', async () => {

--- a/tests/core/output/outputStyles/jsonStyle.test.ts
+++ b/tests/core/output/outputStyles/jsonStyle.test.ts
@@ -47,6 +47,7 @@ const createMockConfig = (overrides: Partial<RepomixConfigMerged> = {}): Repomix
     encoding: 'cl100k_base',
   },
   ...overrides,
+  fileProcessors: overrides.fileProcessors ?? {},
 });
 
 const createMockProcessedFiles = (): ProcessedFile[] => [

--- a/tests/testing/testUtils.ts
+++ b/tests/testing/testUtils.ts
@@ -5,13 +5,15 @@ import process from 'node:process';
 import { defaultConfig, type RepomixConfigMerged } from '../../src/config/configSchema.js';
 
 type DeepPartial<T> = {
-  [P in keyof T]?: T[P] extends (infer U)[]
-    ? DeepPartial<U>[]
-    : T[P] extends readonly (infer U)[]
-      ? readonly DeepPartial<U>[]
-      : T[P] extends object
-        ? DeepPartial<T[P]>
-        : T[P];
+  [P in keyof T]?: T[P] extends Record<string, string>
+    ? Record<string, string>
+    : T[P] extends (infer U)[]
+      ? DeepPartial<U>[]
+      : T[P] extends readonly (infer U)[]
+        ? readonly DeepPartial<U>[]
+        : T[P] extends object
+          ? DeepPartial<T[P]>
+          : T[P];
 };
 
 export const createMockConfig = (config: DeepPartial<RepomixConfigMerged> = {}): RepomixConfigMerged => {
@@ -42,6 +44,10 @@ export const createMockConfig = (config: DeepPartial<RepomixConfigMerged> = {}):
     tokenCount: {
       ...defaultConfig.tokenCount,
       ...config.tokenCount,
+    },
+    fileProcessors: {
+      ...defaultConfig.fileProcessors,
+      ...config.fileProcessors,
     },
     // CLI-only optional properties
     ...(config.skillGenerate !== undefined && { skillGenerate: config.skillGenerate }),

--- a/website/client/src/en/guide/configuration.md
+++ b/website/client/src/en/guide/configuration.md
@@ -116,6 +116,7 @@ JavaScript configuration files work the same as TypeScript, supporting `defineCo
 | `output.git.includeLogs`         | Whether to include git logs in the output. Shows commit history with dates, messages, and file paths                        | `false`                |
 | `output.git.includeLogsCount`    | Number of git log commits to include in the output                                                                          | `50`                   |
 | `include`                        | Patterns of files to include using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)    | `[]`                   |
+| `fileProcessors`                 | Map of glob patterns to shell commands that transform matched file contents. Commands must include `{file}`; stdout becomes packed content. Local repositories only | `{}`                   |
 | `ignore.useGitignore`            | Whether to use patterns from the project's `.gitignore` file                                                                 | `true`                 |
 | `ignore.useDotIgnore`            | Whether to use patterns from the project's `.ignore` file                                                                    | `true`                 |
 | `ignore.useDefaultPatterns`      | Whether to use default ignore patterns (node_modules, .git, etc.)                                                           | `true`                 |
@@ -180,6 +181,7 @@ Here's an example of a complete configuration file (`repomix.config.json`):
     }
   },
   "include": ["**/*"],
+  "fileProcessors": {},
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,
@@ -234,6 +236,24 @@ You can specify include patterns in your configuration file:
 ```
 
 Or use the `--include` command-line option for one-time filtering.
+
+## File Processors
+
+`fileProcessors` lets you transform matched text files with an external command before Repomix packs them. Repomix writes the current file content to a temporary file, replaces `{file}` in the command with that temporary file path, and uses the command's stdout as the new file content.
+
+For example, to convert Jupyter notebooks to Python with `jupyter nbconvert`:
+
+```json
+{
+  "fileProcessors": {
+    "**/*.ipynb": "jupyter nbconvert --to python --stdout {file}"
+  }
+}
+```
+
+Processor patterns use the same glob syntax as `include`. When multiple patterns match a file, the first matching entry in the configuration is used. Commands run from the repository root, and the transformed content is used by downstream packing steps, including security checks.
+
+This feature is opt-in and runs local commands, so only configure processors you trust. It is disabled for remote repository processing.
 
 ## Ignore Patterns
 

--- a/website/client/src/public/schemas/1.14.1/schema.json
+++ b/website/client/src/public/schemas/1.14.1/schema.json
@@ -92,6 +92,11 @@
             }
           ]
         },
+        "tokenBudget": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9007199254740991
+        },
         "git": {
           "type": "object",
           "properties": {
@@ -160,6 +165,15 @@
         }
       },
       "additionalProperties": false
+    },
+    "fileProcessors": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": false,

--- a/website/client/src/public/schemas/latest/schema.json
+++ b/website/client/src/public/schemas/latest/schema.json
@@ -92,6 +92,11 @@
             }
           ]
         },
+        "tokenBudget": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9007199254740991
+        },
         "git": {
           "type": "object",
           "properties": {
@@ -160,6 +165,15 @@
         }
       },
       "additionalProperties": false
+    },
+    "fileProcessors": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
## Summary

This adds an opt-in `fileProcessors` config map for transforming files before they are packed. Each entry maps a glob pattern to a shell command, and the command must include `{file}` so Repomix can pass the current file through a temporary file and use stdout as the replacement content.

The main notebook use case can now be handled without making Jupyter a Repomix dependency:

```json
{
  "fileProcessors": {
    "**/*.ipynb": "jupyter nbconvert --to python --stdout {file}"
  }
}
```

I kept this local-only for now. Remote repository runs disable processors explicitly so a remote config cannot trigger local command execution, even when remote config loading is trusted.

## Details

- Adds `fileProcessors` to config parsing, defaults, merging, generated JSON schema, and docs.
- Applies processors after file contents are collected and before security checks and the normal file processing pipeline.
- Uses the first matching processor in config order.
- Adds a 30s command timeout, a 10MB stdout buffer, temp-file cleanup, and command failure context.
- Documents the Jupyter `nbconvert` recipe in the README and configuration guide.

I regenerated the config schema after adding the new field. That also picked up the existing `tokenBudget` field from the source schema.

Closes #933.
Addresses #1366.

## Validation

- `npm run lint`
- `npm test -- --run`
- `npm run build`
- `npm run website-generate-schema`
- `git diff --check`
- Manual CLI smoke test with a local processor replacing `.ipynb` content before output generation
