### PR TITLE
Add cwd-relative output path style

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,7 @@ Instruction
 |--------|-------------|
 | `-o, --output <file>` | Output file path (default: `repomix-output.xml`, use `"-"` for stdout) |
 | `--style <style>` | Output format: `xml`, `markdown`, `json`, or `plain` (default: `xml`) |
+| `--output-file-path-style <style>` | How file paths are shown in output: `target-relative` or `cwd-relative` (default: `target-relative`) |
 | `--parsable-style` | Escape special characters to ensure valid XML/Markdown (needed when output contains code that breaks formatting) |
 | `--compress` | Extract essential code structure (classes, functions, interfaces) using Tree-sitter parsing |
 | `--output-show-line-numbers` | Prefix each line with its line number in the output |
@@ -1392,6 +1393,7 @@ Here's an explanation of the configuration options:
 | `input.maxFileSize`              | Maximum file size in bytes to process. Files larger than this will be skipped                                                | `50000000`            |
 | `output.filePath`                | The name of the output file                                                                                                  | `"repomix-output.xml"` |
 | `output.style`                   | The style of the output (`xml`, `markdown`, `json`, `plain`)                                                                 | `"xml"`                |
+| `output.filePathStyle`           | How file paths are shown in output (`target-relative` keeps paths relative to each target root, `cwd-relative` keeps paths relative to the current working directory) | `"target-relative"`    |
 | `output.parsableStyle`           | Whether to escape the output based on the chosen style schema. Note that this can increase token count.                      | `false`                |
 | `output.compress`                | Whether to perform intelligent code extraction to reduce token count                                                         | `false`                |
 | `output.headerText`              | Custom text to include in the file header                                                                                    | `null`                 |
@@ -1458,6 +1460,7 @@ Example configuration:
   "output": {
     "filePath": "repomix-output.xml",
     "style": "xml",
+    "filePathStyle": "target-relative",
     "parsableStyle": false,
     "compress": false,
     "headerText": "Custom header information for the packed file.",

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -5,6 +5,7 @@ import {
   type RepomixConfigCli,
   type RepomixConfigFile,
   type RepomixConfigMerged,
+  type RepomixOutputFilePathStyle,
   type RepomixOutputStyle,
   repomixConfigCliSchema,
 } from '../../config/configSchema.js';
@@ -229,6 +230,12 @@ export const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
     cliConfig.output = {
       ...cliConfig.output,
       style: options.style.toLowerCase() as RepomixOutputStyle,
+    };
+  }
+  if (options.outputFilePathStyle) {
+    cliConfig.output = {
+      ...cliConfig.output,
+      filePathStyle: options.outputFilePathStyle.toLowerCase() as RepomixOutputFilePathStyle,
     };
   }
   if (options.parsableStyle !== undefined) {

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -101,6 +101,12 @@ export const run = async () => {
       .optionsGroup('Repomix Output Options')
       .option('-o, --output <file>', 'Output file path (default: repomix-output.xml, use "-" for stdout)')
       .option('--style <type>', 'Output format: xml, markdown, json, or plain (default: xml)')
+      .addOption(
+        new Option(
+          '--output-file-path-style <style>',
+          'How file paths are shown in output: target-relative or cwd-relative (default: target-relative)',
+        ).choices(['target-relative', 'cwd-relative']),
+      )
       .option(
         '--parsable-style',
         'Escape special characters to ensure valid XML/Markdown (needed when output contains code that breaks formatting)',

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,5 +1,5 @@
 import type { OptionValues } from 'commander';
-import type { RepomixOutputStyle } from '../config/configSchema.js';
+import type { RepomixOutputFilePathStyle, RepomixOutputStyle } from '../config/configSchema.js';
 
 export interface CliOptions extends OptionValues {
   // Basic Options
@@ -9,6 +9,7 @@ export interface CliOptions extends OptionValues {
   output?: string;
   stdout?: boolean;
   style?: RepomixOutputStyle;
+  outputFilePathStyle?: RepomixOutputFilePathStyle;
   parsableStyle?: boolean;
   compress?: boolean;
   outputShowLineNumbers?: boolean;

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -6,6 +6,10 @@ import { TOKEN_ENCODINGS } from '../core/metrics/tokenEncodings.js';
 export const repomixOutputStyleSchema = v.picklist(['xml', 'markdown', 'json', 'plain']);
 export type RepomixOutputStyle = v.InferOutput<typeof repomixOutputStyleSchema>;
 
+// Output file path style enum
+export const repomixOutputFilePathStyleSchema = v.picklist(['target-relative', 'cwd-relative']);
+export type RepomixOutputFilePathStyle = v.InferOutput<typeof repomixOutputFilePathStyleSchema>;
+
 // Default values map
 export const defaultFilePathMap: Record<RepomixOutputStyle, string> = {
   xml: 'repomix-output.xml',
@@ -26,6 +30,7 @@ export const repomixConfigBaseSchema = v.object({
     v.object({
       filePath: v.optional(v.string()),
       style: v.optional(repomixOutputStyleSchema),
+      filePathStyle: v.optional(repomixOutputFilePathStyleSchema),
       parsableStyle: v.optional(v.boolean()),
       headerText: v.optional(v.string()),
       instructionFilePath: v.optional(v.string()),
@@ -84,6 +89,7 @@ export const repomixConfigDefaultSchema = v.object({
   output: v.object({
     filePath: v.optional(v.string(), defaultFilePathMap.xml),
     style: v.optional(repomixOutputStyleSchema, 'xml'),
+    filePathStyle: v.optional(repomixOutputFilePathStyleSchema, 'target-relative'),
     parsableStyle: v.optional(v.boolean(), false),
     headerText: v.optional(v.string()),
     instructionFilePath: v.optional(v.string()),

--- a/src/core/output/outputGenerate.ts
+++ b/src/core/output/outputGenerate.ts
@@ -8,6 +8,7 @@ import { type FilesByRoot, generateTreeString, generateTreeStringWithRoots } fro
 import type { ProcessedFile } from '../file/fileTypes.js';
 import type { GitDiffResult } from '../git/gitDiffHandle.js';
 import type { GitLogResult } from '../git/gitLogHandle.js';
+import { buildFileDisplayPath } from '../packager/rootDisplayPath.js';
 import type { OutputGeneratorContext, RenderContext } from './outputGeneratorTypes.js';
 import { sortOutputFiles } from './outputSort.js';
 import {
@@ -334,6 +335,15 @@ export const buildOutputGeneratorContext = async (
   let directoryPathsForTree: string[] = [];
   let filePathsForTree: string[] = allFilePaths;
 
+  const toOutputDisplayPath = (rootDir: string, filePath: string, index: number): string =>
+    buildFileDisplayPath({
+      rootDir,
+      filePath,
+      cwd: config.cwd,
+      filePathStyle: config.output.filePathStyle,
+      rootLabel: filePathsByRoot?.[index]?.rootLabel,
+    });
+
   if (shouldUseFullTree) {
     try {
       // Collect all directories and all files from all roots
@@ -343,8 +353,24 @@ export const buildOutputGeneratorContext = async (
       ]);
 
       // Merge, deduplicate, and sort for deterministic output
-      const allDirectories = Array.from(new Set(allDirectoriesByRoot.flat())).sort();
-      const allRepoFiles = Array.from(new Set(allFilesByRoot.flat()));
+      const allDirectories = Array.from(
+        new Set(
+          allDirectoriesByRoot.flatMap((directories, index) => {
+            const rootDir = rootDirs[index];
+            if (!rootDir) return [];
+            return directories.map((directoryPath) => toOutputDisplayPath(rootDir, directoryPath, index));
+          }),
+        ),
+      ).sort();
+      const allRepoFiles = Array.from(
+        new Set(
+          allFilesByRoot.flatMap((files, index) => {
+            const rootDir = rootDirs[index];
+            if (!rootDir) return [];
+            return files.map((filePath) => toOutputDisplayPath(rootDir, filePath, index));
+          }),
+        ),
+      );
 
       // Merge in any files that weren't part of the included files so they appear in the tree
       const includedSet = new Set(allFilePaths);
@@ -367,7 +393,11 @@ export const buildOutputGeneratorContext = async (
     } else {
       try {
         const results = await Promise.all(rootDirs.map((rootDir) => deps.searchFiles(rootDir, config)));
-        const merged = results.flatMap((r) => r.emptyDirPaths);
+        const merged = results.flatMap((result, index) => {
+          const rootDir = rootDirs[index];
+          if (!rootDir) return [];
+          return result.emptyDirPaths.map((emptyDirPath) => toOutputDisplayPath(rootDir, emptyDirPath, index));
+        });
         directoryPathsForTree = [...new Set(merged)].sort();
       } catch (error) {
         throw new RepomixError(

--- a/src/core/output/outputGenerate.ts
+++ b/src/core/output/outputGenerate.ts
@@ -335,13 +335,17 @@ export const buildOutputGeneratorContext = async (
   let directoryPathsForTree: string[] = [];
   let filePathsForTree: string[] = allFilePaths;
 
+  // Only prefix with the per-root label for genuine multi-root packs. For a single
+  // root, filePathsByRoot still carries a basename fallback label, but pack() leaves
+  // single-root file paths unprefixed — so prefixing the full-tree directories here
+  // would desync them from the included files and add a spurious root branch.
   const toOutputDisplayPath = (rootDir: string, filePath: string, index: number): string =>
     buildFileDisplayPath({
       rootDir,
       filePath,
       cwd: config.cwd,
       filePathStyle: config.output.filePathStyle,
-      rootLabel: filePathsByRoot?.[index]?.rootLabel,
+      rootLabel: rootDirs.length > 1 ? filePathsByRoot?.[index]?.rootLabel : undefined,
     });
 
   if (shouldUseFullTree) {

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -15,7 +15,7 @@ import { calculateMetrics, createMetricsTaskRunner } from './metrics/calculateMe
 import { loadTokenCountCache, saveTokenCountCache } from './metrics/tokenCountCache.js';
 import { prefetchSortData, sortOutputFiles } from './output/outputSort.js';
 import { produceOutput } from './packager/produceOutput.js';
-import { buildFileDisplayPath, buildRootLabels } from './packager/rootDisplayPath.js';
+import { buildFileDisplayPath, buildRootLabels, usesRootLabels } from './packager/rootDisplayPath.js';
 import type { SuspiciousFileResult } from './security/securityCheck.js';
 import { validateFileSafety } from './security/validateFileSafety.js';
 import type { PackSkillParams } from './skill/packSkill.js';
@@ -105,7 +105,7 @@ export const pack = async (
 
   const filePathStyle = config.output.filePathStyle;
   const rootLabels =
-    filePathStyle === 'target-relative' && rootDirs.length > 1 ? buildRootLabels(rootDirs, config.cwd) : undefined;
+    usesRootLabels(filePathStyle) && rootDirs.length > 1 ? buildRootLabels(rootDirs, config.cwd) : undefined;
 
   // Deduplicate and sort empty directory paths for reuse during output generation,
   // avoiding a redundant searchFiles call in buildOutputGeneratorContext.
@@ -267,13 +267,12 @@ export const pack = async (
     }
 
     // Build filePathsByRoot for multi-root tree generation
-    const filePathsByRoot: FilesByRoot[] | undefined =
-      filePathStyle === 'target-relative'
-        ? sortedFilePathsByDir.map(({ rootDir, filePaths }, index) => ({
-            rootLabel: rootLabels?.[index] ?? (path.basename(rootDir) || rootDir),
-            files: filePaths,
-          }))
-        : undefined;
+    const filePathsByRoot: FilesByRoot[] | undefined = usesRootLabels(filePathStyle)
+      ? sortedFilePathsByDir.map(({ rootDir, filePaths }, index) => ({
+          rootLabel: rootLabels?.[index] ?? (path.basename(rootDir) || rootDir),
+          files: filePaths,
+        }))
+      : undefined;
 
     // Ensure warm-up task completes before metrics calculation
     await metricsWarmupPromise;

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -15,7 +15,7 @@ import { calculateMetrics, createMetricsTaskRunner } from './metrics/calculateMe
 import { loadTokenCountCache, saveTokenCountCache } from './metrics/tokenCountCache.js';
 import { prefetchSortData, sortOutputFiles } from './output/outputSort.js';
 import { produceOutput } from './packager/produceOutput.js';
-import { buildRootLabels, joinDisplayPath } from './packager/rootDisplayPath.js';
+import { buildFileDisplayPath, buildRootLabels } from './packager/rootDisplayPath.js';
 import type { SuspiciousFileResult } from './security/securityCheck.js';
 import { validateFileSafety } from './security/validateFileSafety.js';
 import type { PackSkillParams } from './skill/packSkill.js';
@@ -103,10 +103,29 @@ export const pack = async (
     ),
   );
 
+  const filePathStyle = config.output.filePathStyle;
+  const rootLabels =
+    filePathStyle === 'target-relative' && rootDirs.length > 1 ? buildRootLabels(rootDirs, config.cwd) : undefined;
+
   // Deduplicate and sort empty directory paths for reuse during output generation,
   // avoiding a redundant searchFiles call in buildOutputGeneratorContext.
   const emptyDirPaths = config.output.includeEmptyDirectories
-    ? [...new Set(searchResultsByDir.flatMap((r) => r.emptyDirPaths))].sort()
+    ? [
+        ...new Set(
+          searchResultsByDir.flatMap(({ rootDir, emptyDirPaths }, index) => {
+            const rootLabel = rootLabels?.[index];
+            return emptyDirPaths.map((emptyDirPath) =>
+              buildFileDisplayPath({
+                rootDir,
+                filePath: emptyDirPath,
+                cwd: config.cwd,
+                filePathStyle,
+                rootLabel,
+              }),
+            );
+          }),
+        ),
+      ].sort()
     : undefined;
 
   // Sort file paths
@@ -115,12 +134,19 @@ export const pack = async (
     rootDir,
     filePaths: deps.sortPaths([...new Set(filePaths)]),
   }));
-  const rootLabels = rootDirs.length > 1 ? buildRootLabels(rootDirs, config.cwd) : undefined;
   const displayFilePathsByDir = sortedFilePathsByDir.map(({ rootDir, filePaths }, index) => {
     const rootLabel = rootLabels?.[index];
     return {
       rootDir,
-      filePaths: rootLabel ? filePaths.map((filePath) => joinDisplayPath(rootLabel, filePath)) : filePaths,
+      filePaths: filePaths.map((filePath) =>
+        buildFileDisplayPath({
+          rootDir,
+          filePath,
+          cwd: config.cwd,
+          filePathStyle,
+          rootLabel,
+        }),
+      ),
     };
   });
   const allFilePaths = displayFilePathsByDir.flatMap(({ filePaths }) => filePaths);
@@ -155,17 +181,33 @@ export const pack = async (
     ]);
 
     const rawFiles = collectResults.flatMap((curr, index) => {
+      const rootDir = sortedFilePathsByDir[index]?.rootDir;
+      if (!rootDir) return [];
       const rootLabel = rootLabels?.[index];
       return curr.rawFiles.map((file) => ({
         ...file,
-        path: rootLabel ? joinDisplayPath(rootLabel, file.path) : file.path,
+        path: buildFileDisplayPath({
+          rootDir,
+          filePath: file.path,
+          cwd: config.cwd,
+          filePathStyle,
+          rootLabel,
+        }),
       }));
     });
     const allSkippedFiles = collectResults.flatMap((curr, index) => {
+      const rootDir = sortedFilePathsByDir[index]?.rootDir;
+      if (!rootDir) return [];
       const rootLabel = rootLabels?.[index];
       return curr.skippedFiles.map((file) => ({
         ...file,
-        path: rootLabel ? joinDisplayPath(rootLabel, file.path) : file.path,
+        path: buildFileDisplayPath({
+          rootDir,
+          filePath: file.path,
+          cwd: config.cwd,
+          filePathStyle,
+          rootLabel,
+        }),
       }));
     });
 
@@ -225,10 +267,13 @@ export const pack = async (
     }
 
     // Build filePathsByRoot for multi-root tree generation
-    const filePathsByRoot: FilesByRoot[] = sortedFilePathsByDir.map(({ rootDir, filePaths }, index) => ({
-      rootLabel: rootLabels?.[index] ?? (path.basename(rootDir) || rootDir),
-      files: filePaths,
-    }));
+    const filePathsByRoot: FilesByRoot[] | undefined =
+      filePathStyle === 'target-relative'
+        ? sortedFilePathsByDir.map(({ rootDir, filePaths }, index) => ({
+            rootLabel: rootLabels?.[index] ?? (path.basename(rootDir) || rootDir),
+            files: filePaths,
+          }))
+        : undefined;
 
     // Ensure warm-up task completes before metrics calculation
     await metricsWarmupPromise;

--- a/src/core/packager/rootDisplayPath.ts
+++ b/src/core/packager/rootDisplayPath.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import type { RepomixOutputFilePathStyle } from '../../config/configSchema.js';
+import { RepomixError } from '../../shared/errorHandle.js';
 
 /**
  * Helpers for building stable, unique per-root display labels and display
@@ -82,10 +83,33 @@ export const buildFileDisplayPath = ({
   filePathStyle,
   rootLabel,
 }: BuildFileDisplayPathParams): string => {
-  if (filePathStyle === 'cwd-relative') {
-    const absolutePath = path.resolve(rootDir, filePath);
-    return toDisplayPath(path.relative(path.resolve(cwd), absolutePath)) || '.';
+  switch (filePathStyle) {
+    case 'cwd-relative': {
+      const absolutePath = path.resolve(rootDir, filePath);
+      return toDisplayPath(path.relative(path.resolve(cwd), absolutePath)) || '.';
+    }
+    case 'target-relative':
+      return rootLabel ? joinDisplayPath(rootLabel, filePath) : toDisplayPath(filePath);
+    default:
+      // Exhaustive: adding a new style to repomixOutputFilePathStyleSchema must
+      // be handled here explicitly rather than silently falling through.
+      throw new RepomixError(`Unsupported output file path style: ${filePathStyle}`);
   }
+};
 
-  return rootLabel ? joinDisplayPath(rootLabel, filePath) : toDisplayPath(filePath);
+/**
+ * Whether a file path style renders files with per-root display labels (and a
+ * per-root tree). Centralizing this keeps the "which styles use root labels"
+ * decision in one exhaustive place, so adding a new style surfaces here (and
+ * errors if left unhandled) instead of silently defaulting in scattered checks.
+ */
+export const usesRootLabels = (filePathStyle: RepomixOutputFilePathStyle): boolean => {
+  switch (filePathStyle) {
+    case 'target-relative':
+      return true;
+    case 'cwd-relative':
+      return false;
+    default:
+      throw new RepomixError(`Unsupported output file path style: ${filePathStyle}`);
+  }
 };

--- a/src/core/packager/rootDisplayPath.ts
+++ b/src/core/packager/rootDisplayPath.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import type { RepomixOutputFilePathStyle } from '../../config/configSchema.js';
 
 /**
  * Helpers for building stable, unique per-root display labels and display
@@ -64,4 +65,27 @@ export const joinDisplayPath = (rootLabel: string, filePath: string): string => 
   const normalizedRootLabel = toDisplayPath(rootLabel).replace(/^\/+|\/+$/g, '') || 'root';
   const normalizedFilePath = toDisplayPath(filePath).replace(/^\/+/, '');
   return normalizedFilePath ? `${normalizedRootLabel}/${normalizedFilePath}` : normalizedRootLabel;
+};
+
+export interface BuildFileDisplayPathParams {
+  rootDir: string;
+  filePath: string;
+  cwd: string;
+  filePathStyle: RepomixOutputFilePathStyle;
+  rootLabel?: string;
+}
+
+export const buildFileDisplayPath = ({
+  rootDir,
+  filePath,
+  cwd,
+  filePathStyle,
+  rootLabel,
+}: BuildFileDisplayPathParams): string => {
+  if (filePathStyle === 'cwd-relative') {
+    const absolutePath = path.resolve(rootDir, filePath);
+    return toDisplayPath(path.relative(path.resolve(cwd), absolutePath)) || '.';
+  }
+
+  return rootLabel ? joinDisplayPath(rootLabel, filePath) : toDisplayPath(filePath);
 };

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -274,6 +274,15 @@ describe('defaultAction', () => {
       expect(config.output?.style).toBe('xml');
     });
 
+    it('should handle custom output file path style', () => {
+      const options: CliOptions = {
+        outputFilePathStyle: 'cwd-relative',
+      };
+      const config = buildCliConfig(options);
+
+      expect(config.output?.filePathStyle).toBe('cwd-relative');
+    });
+
     it('should properly trim whitespace from comma-separated patterns', () => {
       const options = {
         include: 'src/**/*,  tests/**/*,   examples/**/*',

--- a/tests/cli/cliRun.test.ts
+++ b/tests/cli/cliRun.test.ts
@@ -459,6 +459,20 @@ describe('cliRun', () => {
       );
     });
 
+    test('should handle --output-file-path-style flag', async () => {
+      await runCli(['.'], process.cwd(), {
+        outputFilePathStyle: 'cwd-relative',
+      });
+
+      expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
+        ['.'],
+        process.cwd(),
+        expect.objectContaining({
+          outputFilePathStyle: 'cwd-relative',
+        }),
+      );
+    });
+
     test('should handle --include-empty-directories flag', async () => {
       await runCli(['.'], process.cwd(), {
         includeEmptyDirectories: true,

--- a/tests/config/configLoad.test.ts
+++ b/tests/config/configLoad.test.ts
@@ -353,6 +353,25 @@ describe('configLoad', () => {
       expect(merged.output.git.sortByChangesMaxCommits).toBe(100);
     });
 
+    test('should default output filePathStyle to target-relative', () => {
+      const merged = mergeConfigs(process.cwd(), {}, {});
+      expect(merged.output.filePathStyle).toBe('target-relative');
+    });
+
+    test('should merge output filePathStyle from file config', () => {
+      const merged = mergeConfigs(process.cwd(), { output: { filePathStyle: 'cwd-relative' } }, {});
+      expect(merged.output.filePathStyle).toBe('cwd-relative');
+    });
+
+    test('should let CLI output filePathStyle override file config', () => {
+      const merged = mergeConfigs(
+        process.cwd(),
+        { output: { filePathStyle: 'target-relative' } },
+        { output: { filePathStyle: 'cwd-relative' } },
+      );
+      expect(merged.output.filePathStyle).toBe('cwd-relative');
+    });
+
     test('should not mutate defaultConfig', () => {
       const originalFilePath = defaultConfig.output.filePath;
       const fileConfig: RepomixConfigFile = {

--- a/tests/config/configSchema.test.ts
+++ b/tests/config/configSchema.test.ts
@@ -6,10 +6,22 @@ import {
   repomixConfigDefaultSchema,
   repomixConfigFileSchema,
   repomixConfigMergedSchema,
+  repomixOutputFilePathStyleSchema,
   repomixOutputStyleSchema,
 } from '../../src/config/configSchema.js';
 
 describe('configSchema', () => {
+  describe('repomixOutputFilePathStyleSchema', () => {
+    it('should accept valid file path styles', () => {
+      expect(v.parse(repomixOutputFilePathStyleSchema, 'target-relative')).toBe('target-relative');
+      expect(v.parse(repomixOutputFilePathStyleSchema, 'cwd-relative')).toBe('cwd-relative');
+    });
+
+    it('should reject invalid file path styles', () => {
+      expect(() => v.parse(repomixOutputFilePathStyleSchema, 'absolute')).toThrow(v.ValiError);
+    });
+  });
+
   describe('repomixOutputStyleSchema', () => {
     it('should accept valid output styles', () => {
       expect(v.parse(repomixOutputStyleSchema, 'plain')).toBe('plain');
@@ -62,6 +74,7 @@ describe('configSchema', () => {
         output: {
           filePath: 'output.txt',
           style: 'plain',
+          filePathStyle: 'cwd-relative',
           removeComments: true,
           tokenCountTree: true,
         },
@@ -102,6 +115,7 @@ describe('configSchema', () => {
         output: {
           filePath: 'output.txt',
           style: 'plain',
+          filePathStyle: 'target-relative',
           parsableStyle: false,
           fileSummary: true,
           directoryStructure: true,
@@ -165,6 +179,7 @@ describe('configSchema', () => {
         output: {
           filePath: 'output.xml',
           style: 'xml',
+          filePathStyle: 'target-relative',
           parsableStyle: false,
           fileSummary: true,
           directoryStructure: true,
@@ -347,6 +362,7 @@ describe('configSchema', () => {
         output: {
           filePath: 'merged-output.txt',
           style: 'plain',
+          filePathStyle: 'target-relative',
           parsableStyle: false,
           fileSummary: true,
           directoryStructure: true,
@@ -429,6 +445,7 @@ describe('configSchema', () => {
         output: {
           filePath: 'output.xml',
           style: 'xml',
+          filePathStyle: 'target-relative',
           parsableStyle: false,
           fileSummary: true,
           directoryStructure: true,
@@ -451,8 +468,8 @@ describe('configSchema', () => {
             includeLogsCount: 50,
           },
         },
-        include: [],
-        ignore: { useGitignore: true, useDotIgnore: true, useDefaultPatterns: true, customPatterns: [] },
+        include: [] as string[],
+        ignore: { useGitignore: true, useDotIgnore: true, useDefaultPatterns: true, customPatterns: [] as string[] },
         security: { enableSecurityCheck: true },
         tokenCount: { encoding: 'o200k_base' },
         skillGenerate: 'my-skill',

--- a/tests/core/metrics/calculateGitDiffMetrics.test.ts
+++ b/tests/core/metrics/calculateGitDiffMetrics.test.ts
@@ -32,6 +32,7 @@ describe('calculateGitDiffMetrics', () => {
     output: {
       filePath: 'test-output.txt',
       style: 'xml',
+      filePathStyle: 'target-relative',
       parsableStyle: false,
       headerText: '',
       instructionFilePath: '',

--- a/tests/core/metrics/calculateGitLogMetrics.test.ts
+++ b/tests/core/metrics/calculateGitLogMetrics.test.ts
@@ -32,6 +32,7 @@ describe('calculateGitLogMetrics', () => {
     output: {
       filePath: 'test-output.txt',
       style: 'xml',
+      filePathStyle: 'target-relative',
       parsableStyle: false,
       headerText: '',
       instructionFilePath: '',

--- a/tests/core/output/flagFullDirectoryStructure.test.ts
+++ b/tests/core/output/flagFullDirectoryStructure.test.ts
@@ -87,6 +87,43 @@ describe('includeFullDirectoryStructure flag', () => {
     expect(ctx.treeString).toContain('index.ts');
   });
 
+  test('does not prefix single-root full-tree directories with the root basename', async () => {
+    const config = createMockConfig();
+    const processedFiles: ProcessedFile[] = [{ path: 'src/a/index.ts', content: 'export const a = 1;\n' }];
+    const allFilePaths = processedFiles.map((f) => f.path);
+
+    const deps = {
+      listDirectories: async () => ['src', 'src/a', 'src/b', 'docs', 'docs/guide'],
+      listFiles: async () => ['src/a/index.ts', 'src/b/other.ts', 'docs/guide/intro.md'],
+      searchFiles: async () => ({ filePaths: allFilePaths, emptyDirPaths: [] }),
+    };
+
+    // pack() passes a one-entry filePathsByRoot for a single target-relative root,
+    // whose rootLabel falls back to the target basename. That label must NOT prefix
+    // the full-tree directories: the included file paths are left unprefixed for a
+    // single root, so prefixing here would desync them and add a spurious `repo/` branch.
+    const filePathsByRoot = [{ rootLabel: 'repo', files: allFilePaths }];
+
+    const ctx = await buildOutputGeneratorContext(
+      ['/repo'],
+      config,
+      allFilePaths,
+      processedFiles,
+      undefined,
+      undefined,
+      filePathsByRoot,
+      undefined,
+      deps,
+    );
+
+    // Directories from the full tree should appear unprefixed alongside the included file
+    expect(ctx.treeString).toContain('src/');
+    expect(ctx.treeString).toContain('docs/');
+    expect(ctx.treeString).toContain('index.ts');
+    // No spurious root-basename branch
+    expect(ctx.treeString).not.toContain('repo/');
+  });
+
   test('does not render full tree when include is empty even if flag is enabled', async () => {
     const config = createMockConfig({ include: [] });
     const processedFiles: ProcessedFile[] = [{ path: 'src/a/index.ts', content: 'export const a = 1;\n' }];

--- a/tests/core/output/flagFullDirectoryStructure.test.ts
+++ b/tests/core/output/flagFullDirectoryStructure.test.ts
@@ -9,6 +9,7 @@ const createMockConfig = (overrides: Partial<RepomixConfigMerged> = {}): Repomix
   output: {
     filePath: 'repomix-output.json',
     style: 'json',
+    filePathStyle: 'target-relative',
     parsableStyle: false,
     headerText: undefined,
     instructionFilePath: undefined,
@@ -127,6 +128,7 @@ describe('includeEmptyDirectories with pre-computed emptyDirPaths', () => {
     output: {
       filePath: 'repomix-output.json',
       style: 'json',
+      filePathStyle: 'target-relative',
       parsableStyle: false,
       headerText: undefined,
       instructionFilePath: undefined,

--- a/tests/core/output/outputStyles/jsonStyle.test.ts
+++ b/tests/core/output/outputStyles/jsonStyle.test.ts
@@ -9,6 +9,7 @@ const createMockConfig = (overrides: Partial<RepomixConfigMerged> = {}): Repomix
   output: {
     filePath: 'test-output.json',
     style: 'json' as const,
+    filePathStyle: 'target-relative',
     parsableStyle: false,
     headerText: undefined,
     instructionFilePath: undefined,

--- a/tests/core/packager.test.ts
+++ b/tests/core/packager.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { pack } from '../../src/core/packager.js';
 import { createMockConfig } from '../testing/testUtils.js';
@@ -21,7 +20,10 @@ describe('packager', () => {
   });
 
   test('pack should orchestrate packing files and generating output', async () => {
-    const file2Path = path.join('dir1', 'file2.txt');
+    // Use a POSIX separator: globby yields forward-slash paths on every platform
+    // and pack() normalizes display paths to forward slashes, so the mock must match
+    // that (path.join would emit "dir1\\file2.txt" on Windows and fail the assertion).
+    const file2Path = 'dir1/file2.txt';
     const mockRawFiles = [
       { path: 'file1.txt', content: 'raw content 1' },
       { path: file2Path, content: 'raw content 2' },

--- a/tests/core/packager/multiRootSpec.test.ts
+++ b/tests/core/packager/multiRootSpec.test.ts
@@ -100,6 +100,8 @@ const countOccurrences = (haystack: string, needle: string): number => {
   return count;
 };
 
+const toDisplayPath = (filePath: string): string => filePath.replaceAll(path.win32.sep, path.posix.sep);
+
 describe('multi-root pack spec', () => {
   let rootAParent: string;
   let rootBParent: string;
@@ -195,6 +197,47 @@ describe('multi-root pack spec', () => {
     expect(parsed.files['app/src/index.ts']).toContain('ROOT_A_SRC_MARKER');
     expect(parsed.files['app-2/README.md']).toContain('MARKER_FROM_ROOT_B');
     expect(parsed.files['app-2/src/index.ts']).toContain('ROOT_B_SRC_MARKER');
+  });
+
+  it('uses cwd-relative file paths in xml output when requested', async () => {
+    const config = buildMergedConfig(outputDir, outputPath, 'xml', {
+      output: { filePathStyle: 'cwd-relative' },
+    });
+    await runPack([rootA], config);
+
+    const output = await fs.readFile(outputPath, 'utf-8');
+    const expectedReadmePath = toDisplayPath(path.relative(outputDir, path.join(rootA, 'README.md')));
+    const expectedSrcPath = toDisplayPath(path.relative(outputDir, path.join(rootA, 'src', 'index.ts')));
+
+    expect(output).toContain(`<file path="${expectedReadmePath}">`);
+    expect(output).toContain(`<file path="${expectedSrcPath}">`);
+    expect(output).not.toContain('<file path="README.md">');
+    expect(output).not.toContain('<file path="src/index.ts">');
+  });
+
+  it('uses cwd-relative file keys in json output for multiple roots when requested', async () => {
+    const config = buildMergedConfig(outputDir, outputPath, 'json', {
+      output: { filePathStyle: 'cwd-relative' },
+    });
+    await runPack([rootA, rootB], config);
+
+    const output = await fs.readFile(outputPath, 'utf-8');
+    const parsed = JSON.parse(output) as { files: Record<string, string> };
+
+    const expectedKeys = [
+      path.join(rootA, 'README.md'),
+      path.join(rootA, 'src', 'index.ts'),
+      path.join(rootB, 'README.md'),
+      path.join(rootB, 'src', 'index.ts'),
+    ].map((filePath) => toDisplayPath(path.relative(outputDir, filePath)));
+
+    expect(Object.keys(parsed.files).sort()).toEqual(expectedKeys.sort());
+    expect(parsed.files[toDisplayPath(path.relative(outputDir, path.join(rootA, 'README.md')))]).toContain(
+      'MARKER_FROM_ROOT_A',
+    );
+    expect(parsed.files[toDisplayPath(path.relative(outputDir, path.join(rootB, 'README.md')))]).toContain(
+      'MARKER_FROM_ROOT_B',
+    );
   });
 
   it('reports the real file count for duplicate-relative-path multi-root inputs', async () => {

--- a/tests/core/packager/rootDisplayPath.test.ts
+++ b/tests/core/packager/rootDisplayPath.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { buildRootLabels, joinDisplayPath } from '../../../src/core/packager/rootDisplayPath.js';
+import { buildFileDisplayPath, buildRootLabels, joinDisplayPath } from '../../../src/core/packager/rootDisplayPath.js';
 
 // Build absolute paths from a resolved virtual base so the tests stay
 // deterministic and cross-platform (buildRootLabels uses path.resolve/relative).
@@ -58,6 +58,64 @@ describe('rootDisplayPath', () => {
 
     it('falls back to "root" when the label is empty', () => {
       expect(joinDisplayPath('', 'README.md')).toBe('root/README.md');
+    });
+  });
+
+  describe('buildFileDisplayPath', () => {
+    it('keeps target-relative paths unchanged for the default style', () => {
+      expect(
+        buildFileDisplayPath({
+          rootDir: path.join(base, 'other', 'core-library'),
+          filePath: 'src/core.py',
+          cwd,
+          filePathStyle: 'target-relative',
+        }),
+      ).toBe('src/core.py');
+    });
+
+    it('uses a multi-root label for target-relative paths when provided', () => {
+      expect(
+        buildFileDisplayPath({
+          rootDir: path.join(base, 'other', 'core-library'),
+          filePath: 'src/core.py',
+          cwd,
+          filePathStyle: 'target-relative',
+          rootLabel: 'core-library',
+        }),
+      ).toBe('core-library/src/core.py');
+    });
+
+    it('uses cwd-relative paths for roots outside cwd', () => {
+      expect(
+        buildFileDisplayPath({
+          rootDir: path.join(base, 'core-library'),
+          filePath: 'src/core.py',
+          cwd,
+          filePathStyle: 'cwd-relative',
+        }),
+      ).toBe('../core-library/src/core.py');
+    });
+
+    it('uses cwd-relative paths for nested roots inside cwd', () => {
+      expect(
+        buildFileDisplayPath({
+          rootDir: path.join(cwd, 'packages', 'app'),
+          filePath: 'src/index.ts',
+          cwd,
+          filePathStyle: 'cwd-relative',
+        }),
+      ).toBe('packages/app/src/index.ts');
+    });
+
+    it('normalizes cwd-relative paths to posix separators', () => {
+      expect(
+        buildFileDisplayPath({
+          rootDir: path.join(cwd, 'packages', 'app'),
+          filePath: `src${path.win32.sep}index.ts`,
+          cwd,
+          filePathStyle: 'cwd-relative',
+        }),
+      ).toBe('packages/app/src/index.ts');
     });
   });
 });

--- a/website/client/src/en/guide/command-line-options.md
+++ b/website/client/src/en/guide/command-line-options.md
@@ -26,6 +26,7 @@ description: Reference every Repomix CLI option for input, output, file selectio
 |--------|-------------|
 | `-o, --output <file>` | Output file path (default: `repomix-output.xml`, use `"-"` for stdout) |
 | `--style <style>` | Output format: `xml`, `markdown`, `json`, or `plain` (default: `xml`) |
+| `--output-file-path-style <style>` | How file paths are shown in output: `target-relative` or `cwd-relative` (default: `target-relative`) |
 | `--parsable-style` | Escape special characters to ensure valid XML/Markdown (needed when output contains code that breaks formatting) |
 | `--compress` | Extract essential code structure (classes, functions, interfaces) using Tree-sitter parsing |
 | `--output-show-line-numbers` | Prefix each line with its line number in the output |

--- a/website/client/src/en/guide/configuration.md
+++ b/website/client/src/en/guide/configuration.md
@@ -93,6 +93,7 @@ JavaScript configuration files work the same as TypeScript, supporting `defineCo
 | `input.maxFileSize`              | Maximum file size in bytes to process. Files larger than this will be skipped. Useful for excluding large binary files or data files | `50000000`            |
 | `output.filePath`                | The name of the output file. Supports XML, Markdown, and plain text formats                                                   | `"repomix-output.xml"` |
 | `output.style`                   | The style of the output (`xml`, `markdown`, `json`, `plain`). Each format has its own advantages for different AI tools              | `"xml"`                |
+| `output.filePathStyle`           | How file paths are shown in output (`target-relative` keeps paths relative to each target root, `cwd-relative` keeps paths relative to the current working directory) | `"target-relative"`    |
 | `output.parsableStyle`           | Whether to escape the output based on the chosen style schema. Enables better parsing but may increase token count           | `false`                |
 | `output.compress`                | Whether to perform intelligent code extraction using Tree-sitter to reduce token count while preserving structure             | `false`                |
 | `output.headerText`              | Custom text to include in the file header. Useful for providing context or instructions for AI tools                         | `null`                 |
@@ -158,6 +159,7 @@ Here's an example of a complete configuration file (`repomix.config.json`):
   "output": {
     "filePath": "repomix-output.xml",
     "style": "xml",
+    "filePathStyle": "target-relative",
     "parsableStyle": false,
     "compress": false,
     "headerText": "Custom header information for the packed file.",

--- a/website/client/src/public/schemas/1.14.1/schema.json
+++ b/website/client/src/public/schemas/1.14.1/schema.json
@@ -29,13 +29,6 @@
           ],
           "type": "string"
         },
-        "filePathStyle": {
-          "enum": [
-            "target-relative",
-            "cwd-relative"
-          ],
-          "type": "string"
-        },
         "parsableStyle": {
           "type": "boolean"
         },
@@ -98,11 +91,6 @@
               "type": "string"
             }
           ]
-        },
-        "tokenBudget": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 9007199254740991
         },
         "git": {
           "type": "object",

--- a/website/client/src/public/schemas/1.14.1/schema.json
+++ b/website/client/src/public/schemas/1.14.1/schema.json
@@ -29,6 +29,13 @@
           ],
           "type": "string"
         },
+        "filePathStyle": {
+          "enum": [
+            "target-relative",
+            "cwd-relative"
+          ],
+          "type": "string"
+        },
         "parsableStyle": {
           "type": "boolean"
         },
@@ -91,6 +98,11 @@
               "type": "string"
             }
           ]
+        },
+        "tokenBudget": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9007199254740991
         },
         "git": {
           "type": "object",

--- a/website/client/src/public/schemas/latest/schema.json
+++ b/website/client/src/public/schemas/latest/schema.json
@@ -29,13 +29,6 @@
           ],
           "type": "string"
         },
-        "filePathStyle": {
-          "enum": [
-            "target-relative",
-            "cwd-relative"
-          ],
-          "type": "string"
-        },
         "parsableStyle": {
           "type": "boolean"
         },
@@ -98,11 +91,6 @@
               "type": "string"
             }
           ]
-        },
-        "tokenBudget": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 9007199254740991
         },
         "git": {
           "type": "object",

--- a/website/client/src/public/schemas/latest/schema.json
+++ b/website/client/src/public/schemas/latest/schema.json
@@ -29,6 +29,13 @@
           ],
           "type": "string"
         },
+        "filePathStyle": {
+          "enum": [
+            "target-relative",
+            "cwd-relative"
+          ],
+          "type": "string"
+        },
         "parsableStyle": {
           "type": "boolean"
         },
@@ -91,6 +98,11 @@
               "type": "string"
             }
           ]
+        },
+        "tokenBudget": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9007199254740991
         },
         "git": {
           "type": "object",


### PR DESCRIPTION
## Summary

- Add `output.filePathStyle` with the existing `target-relative` behavior as the default.
- Add `cwd-relative` support so file paths are rendered relative to the command's current working directory.
- Add `--output-file-path-style` for the CLI and update the docs/schema.

Closes #1424

## Testing

- `npm test -- --run`
- `npm run build`
- `npm run lint`
- Manual smoke test for `repomix ../core-library --output-file-path-style cwd-relative`
