### PR TITLE
feat(cli): expose skill project name option

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,6 +686,7 @@ Instruction
 | Option | Description |
 |--------|-------------|
 | `--skill-generate [name]` | Generate Claude Agent Skills format output to `.claude/skills/<name>/` directory (name auto-generated if omitted) |
+| `--skill-project-name <name>` | Override the project name used in generated Skills descriptions |
 | `--skill-output <path>` | Specify skill output directory path directly (skips location prompt) |
 | `-f, --force` | Skip all confirmation prompts (e.g., skill directory overwrite) |
 
@@ -1168,6 +1169,9 @@ repomix --skill-generate
 
 # Generate with custom Skills name
 repomix --skill-generate my-project-reference
+
+# Generate with a custom project name in Skills descriptions
+repomix --skill-generate --skill-project-name "My Project"
 
 # Generate from remote repository
 repomix --remote https://github.com/user/repo --skill-generate

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -62,7 +62,7 @@ export const runDefaultAction = async (
   if (cliOptions.force && config.skillGenerate === undefined) {
     throw new RepomixError('--force can only be used with --skill-generate');
   }
-  if (cliOptions.skillProjectName && config.skillGenerate === undefined) {
+  if (cliOptions.skillProjectName !== undefined && config.skillGenerate === undefined) {
     throw new RepomixError('--skill-project-name can only be used with --skill-generate');
   }
 

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -62,10 +62,16 @@ export const runDefaultAction = async (
   if (cliOptions.force && config.skillGenerate === undefined) {
     throw new RepomixError('--force can only be used with --skill-generate');
   }
+  if (cliOptions.skillProjectName && config.skillGenerate === undefined) {
+    throw new RepomixError('--skill-project-name can only be used with --skill-generate');
+  }
 
   // Validate --skill-output is not empty or whitespace only
   if (cliOptions.skillOutput !== undefined && !cliOptions.skillOutput.trim()) {
     throw new RepomixError('--skill-output path cannot be empty');
+  }
+  if (cliOptions.skillProjectName !== undefined && !cliOptions.skillProjectName.trim()) {
+    throw new RepomixError('--skill-project-name cannot be empty');
   }
 
   // Validate skill generation options and prompt for location

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -193,6 +193,7 @@ export const run = async () => {
         '--skill-generate [name]',
         'Generate Claude Agent Skills format output to .claude/skills/<name>/ directory (name auto-generated if omitted)',
       )
+      .option('--skill-project-name <name>', 'Override the project name used in generated Skills descriptions')
       .option('--skill-output <path>', 'Specify skill output directory path directly (skips location prompt)')
       .option('-f, --force', 'Skip all confirmation prompts (currently: skill directory overwrite)')
       .action(commanderActionEndpoint);

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -64,7 +64,7 @@ export interface CliOptions extends OptionValues {
   skillGenerate?: string | boolean;
   skillName?: string; // Pre-computed skill name (used internally for remote repos)
   skillDir?: string; // Pre-computed skill directory (used internally for remote repos)
-  skillProjectName?: string; // Pre-computed project name for skill description (used internally for remote repos)
+  skillProjectName?: string; // Project name for generated skill descriptions
   skillSourceUrl?: string; // Source URL for skill (used internally for remote repos only)
   skillOutput?: string; // Output path for skill (skips location prompt)
   force?: boolean; // Skip all confirmation prompts

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -424,5 +424,33 @@ describe('defaultAction', () => {
         '--skill-generate cannot be used with --copy',
       );
     });
+
+    it('should throw error when --skill-project-name is used without --skill-generate', async () => {
+      const options: CliOptions = {
+        skillProjectName: 'Repomix',
+      };
+
+      await expect(runDefaultAction(['.'], process.cwd(), options)).rejects.toThrow(
+        '--skill-project-name can only be used with --skill-generate',
+      );
+    });
+
+    it('should throw error when --skill-project-name is empty', async () => {
+      vi.mocked(configLoader.mergeConfigs).mockReturnValue(
+        createMockConfig({
+          cwd: process.cwd(),
+          skillGenerate: true,
+        }),
+      );
+
+      const options: CliOptions = {
+        skillGenerate: true,
+        skillProjectName: '   ',
+      };
+
+      await expect(runDefaultAction(['.'], process.cwd(), options)).rejects.toThrow(
+        '--skill-project-name cannot be empty',
+      );
+    });
   });
 });

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -435,6 +435,16 @@ describe('defaultAction', () => {
       );
     });
 
+    it('should throw error when empty --skill-project-name is used without --skill-generate', async () => {
+      const options: CliOptions = {
+        skillProjectName: '',
+      };
+
+      await expect(runDefaultAction(['.'], process.cwd(), options)).rejects.toThrow(
+        '--skill-project-name can only be used with --skill-generate',
+      );
+    });
+
     it('should throw error when --skill-project-name is empty', async () => {
       vi.mocked(configLoader.mergeConfigs).mockReturnValue(
         createMockConfig({

--- a/tests/cli/cliRun.test.ts
+++ b/tests/cli/cliRun.test.ts
@@ -352,6 +352,24 @@ describe('cliRun', () => {
     });
   });
 
+  describe('skill generation options', () => {
+    test('should pass --skill-project-name to default action', async () => {
+      await runCli(['.'], process.cwd(), {
+        skillGenerate: true,
+        skillProjectName: 'Repomix',
+      });
+
+      expect(defaultAction.runDefaultAction).toHaveBeenCalledWith(
+        ['.'],
+        process.cwd(),
+        expect.objectContaining({
+          skillGenerate: true,
+          skillProjectName: 'Repomix',
+        }),
+      );
+    });
+  });
+
   describe('security check flag', () => {
     test('should enable security check by default', async () => {
       await runCli(['.'], process.cwd(), {});


### PR DESCRIPTION
## Summary
- Add `--skill-project-name <name>` to local `--skill-generate` CLI usage.
- Validate that the option is only used with skill generation and is not empty.
- Document the new flag and cover option propagation/validation in tests.

Closes #1648

## Validation
- `npm run test -- --run`
- `npx biome check .`
- `npx oxlint .`
- `npm run lint-ts`
- `npx secretlint **/* --secretlintignore .gitignore`
- `npm run build`
- `node bin\repomix.cjs --help | Select-String -Pattern skill-project-name|skill-generate|skill-output`

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`