### PR TITLE
feat(output): add per-file inclusion levels (output.patterns)

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,6 +850,37 @@ interface Item {
 > [!NOTE]
 > This is an experimental feature that we'll be actively improving based on user feedback and real-world usage
 
+### Per-file Inclusion Levels (`output.patterns`)
+
+While `--compress` applies one level to every file, `output.patterns` lets you control the detail level **per glob** from your config file. Each entry targets files by glob (matched the same way as `include`/`ignore`) and overrides the global `output.compress` setting for matching files:
+
+```json5
+{
+  "output": {
+    "compress": false, // global default acts as the catch-all
+    "patterns": [
+      { "pattern": "docs/**/*", "compress": true },
+      { "pattern": "website/**/*", "directoryStructureOnly": true }
+    ]
+  }
+}
+```
+
+There are three levels:
+
+- **Full content** (default) — the file's full content is included.
+- **Compressed** (`compress: true`) — the content is passed through the same Tree-sitter pipeline as `--compress`.
+- **Directory-structure-only** (`directoryStructureOnly: true`) — the file is listed in the directory structure, but its content block is omitted from the output entirely.
+
+Semantics:
+
+- Patterns are evaluated in array order and the **first matching pattern wins** for a given file.
+- A matched pattern's flags override the global `output.compress` setting. A pattern that matches without setting either flag forces **full content** for that file (useful for whitelisting files out of a global `compress`).
+- `directoryStructureOnly` takes precedence over `compress` when both are set.
+- If no pattern matches, the global behavior applies (full content, or compressed when `output.compress` is `true`).
+
+This is a config-file-only option; there is no CLI flag for per-pattern levels.
+
 ### Token Count Optimization
 
 Understanding your codebase's token distribution is crucial for optimizing AI interactions. Use the `--token-count-tree` option to visualize token usage across your project:
@@ -1396,6 +1427,7 @@ Here's an explanation of the configuration options:
 | `output.filePathStyle`           | How file paths are shown in output (`target-relative` keeps paths relative to each target root, `cwd-relative` keeps paths relative to the current working directory) | `"target-relative"`    |
 | `output.parsableStyle`           | Whether to escape the output based on the chosen style schema. Note that this can increase token count.                      | `false`                |
 | `output.compress`                | Whether to perform intelligent code extraction to reduce token count                                                         | `false`                |
+| `output.patterns`                | Per-file inclusion levels. An ordered array of `{ pattern, compress?, directoryStructureOnly? }` entries; the first matching glob wins and overrides the global `output.compress` for that file. See [Per-file Inclusion Levels](#per-file-inclusion-levels-outputpatterns) | Not set |
 | `output.headerText`              | Custom text to include in the file header                                                                                    | `null`                 |
 | `output.instructionFilePath`     | Path to a file containing detailed custom instructions                                                                       | `null`                 |
 | `output.fileSummary`             | Whether to include a summary section at the beginning of the output                                                          | `true`                 |
@@ -1463,6 +1495,11 @@ Example configuration:
     "filePathStyle": "target-relative",
     "parsableStyle": false,
     "compress": false,
+    // Optional: override the inclusion level per glob (first match wins)
+    // "patterns": [
+    //   { "pattern": "docs/**/*", "compress": true },
+    //   { "pattern": "website/**/*", "directoryStructureOnly": true }
+    // ],
     "headerText": "Custom header information for the packed file.",
     "fileSummary": true,
     "directoryStructure": true,

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -18,6 +18,19 @@ export const defaultFilePathMap: Record<RepomixOutputStyle, string> = {
   json: 'repomix-output.json',
 } as const;
 
+// Per-file inclusion level pattern (output.patterns).
+// Each entry targets files by glob (matched the same way as include/ignore) and
+// overrides the global output.compress setting for matching files. Patterns are
+// evaluated in array order and the first match wins. `directoryStructureOnly`
+// takes precedence over `compress`: the file is listed in the directory
+// structure but its content block is omitted from the output.
+export const outputPatternSchema = v.object({
+  pattern: v.string(),
+  compress: v.optional(v.boolean()),
+  directoryStructureOnly: v.optional(v.boolean()),
+});
+export type OutputPattern = v.InferOutput<typeof outputPatternSchema>;
+
 // Base config schema
 export const repomixConfigBaseSchema = v.object({
   $schema: v.optional(v.string()),
@@ -40,6 +53,7 @@ export const repomixConfigBaseSchema = v.object({
       removeComments: v.optional(v.boolean()),
       removeEmptyLines: v.optional(v.boolean()),
       compress: v.optional(v.boolean()),
+      patterns: v.optional(v.array(outputPatternSchema)),
       topFilesLength: v.optional(v.number()),
       showLineNumbers: v.optional(v.boolean()),
       truncateBase64: v.optional(v.boolean()),

--- a/src/core/file/fileLevelResolve.ts
+++ b/src/core/file/fileLevelResolve.ts
@@ -25,6 +25,12 @@ export interface FileLevelOutputConfig {
  * with `directoryStructureOnly` taking precedence over `compress`. A pattern
  * that matches without setting either flag forces full content for that file.
  *
+ * `filePath` is expected to be the file's per-root-relative path — the same
+ * basis `include`/`ignore` match against — so `output.patterns` globs match
+ * exactly like include/ignore. The packager resolves the level before rewriting
+ * the path to its display form (which, with multiple roots or
+ * `output.filePathStyle`, would otherwise shift what the globs match).
+ *
  * Globs are matched the same way as include/ignore patterns in fileSearch:
  * minimatch with `{ dot: true }`, against the posix (forward-slash) form of the
  * path so Windows backslash paths still match forward-slash globs.

--- a/src/core/file/fileLevelResolve.ts
+++ b/src/core/file/fileLevelResolve.ts
@@ -1,0 +1,52 @@
+import { minimatch } from 'minimatch';
+import type { OutputPattern } from '../../config/configSchema.js';
+
+/**
+ * The effective inclusion level for a single file in the packed output:
+ * - `full`: the file's full content is included (the default behavior).
+ * - `compress`: the content is passed through the Tree-sitter compression pipeline.
+ * - `directory-only`: the file is listed in the directory structure but its
+ *   content block is omitted from the output entirely.
+ */
+export type FileInclusionLevel = 'full' | 'compress' | 'directory-only';
+
+/** Subset of the output config that affects a file's inclusion level. */
+export interface FileLevelOutputConfig {
+  compress?: boolean;
+  patterns?: OutputPattern[];
+}
+
+/**
+ * Resolve the inclusion level for a file from `output.patterns`, falling back to
+ * the global `output.compress` setting when no pattern matches.
+ *
+ * Patterns are evaluated in array order and the first match wins. A matched
+ * pattern's flags override the global `output.compress` setting for that file,
+ * with `directoryStructureOnly` taking precedence over `compress`. A pattern
+ * that matches without setting either flag forces full content for that file.
+ *
+ * Globs are matched the same way as include/ignore patterns in fileSearch:
+ * minimatch with `{ dot: true }`, against the posix (forward-slash) form of the
+ * path so Windows backslash paths still match forward-slash globs.
+ */
+export const resolveFileLevel = (filePath: string, output: FileLevelOutputConfig): FileInclusionLevel => {
+  const patterns = output.patterns;
+
+  if (patterns && patterns.length > 0) {
+    const normalizedPath = filePath.replace(/\\/g, '/');
+
+    for (const entry of patterns) {
+      if (minimatch(normalizedPath, entry.pattern, { dot: true })) {
+        if (entry.directoryStructureOnly) {
+          return 'directory-only';
+        }
+        if (entry.compress) {
+          return 'compress';
+        }
+        return 'full';
+      }
+    }
+  }
+
+  return output.compress ? 'compress' : 'full';
+};

--- a/src/core/file/fileProcess.ts
+++ b/src/core/file/fileProcess.ts
@@ -3,6 +3,7 @@ import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
 import { initTaskRunner } from '../../shared/processConcurrency.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
+import { resolveFileLevel } from './fileLevelResolve.js';
 import { type FileManipulator, getFileManipulator } from './fileManipulate.js';
 import type { ProcessedFile, RawFile } from './fileTypes.js';
 import { truncateBase64Content } from './truncateBase64.js';
@@ -43,7 +44,10 @@ export const applyLightweightTransforms = (
 
     content = content.trim();
 
-    if (config.output.showLineNumbers && !config.output.compress) {
+    // Line numbers are suppressed for compressed files (their content is
+    // restructured signatures, not line-faithful source), matching the global
+    // compress behavior on a per-file basis.
+    if (config.output.showLineNumbers && resolveFileLevel(file.path, config.output) !== 'compress') {
       const lines = content.split('\n');
       const padding = lines.length.toString().length;
       const numberedLines = lines.map((line, idx) => `${(idx + 1).toString().padStart(padding)}: ${line}`);
@@ -84,21 +88,32 @@ export const processFiles = async (
   const startTime = process.hrtime.bigint();
   let files: ProcessedFile[];
 
-  // Only compress (tree-sitter) and removeComments (AST manipulation) justify worker thread overhead
-  const useWorkers = config.output.compress || config.output.removeComments;
+  // Resolve each file's inclusion level once. Files at the 'directory-only'
+  // level are dropped from the content output entirely — their paths still
+  // appear in the directory structure, which is built from the search results
+  // rather than from processedFiles.
+  const leveledFiles = rawFiles
+    .map((rawFile) => ({ rawFile, level: resolveFileLevel(rawFile.path, config.output) }))
+    .filter((entry) => entry.level !== 'directory-only');
+
+  // Only compress (tree-sitter) and removeComments (AST manipulation) justify worker thread overhead.
+  // Compression can be requested globally or per-file via output.patterns, so check the resolved
+  // levels rather than the global compress flag alone.
+  const needsCompression = leveledFiles.some((entry) => entry.level === 'compress');
+  const useWorkers = needsCompression || config.output.removeComments;
 
   if (useWorkers) {
     // Phase 1: Heavy processing via workers (removeComments, compress)
-    logger.trace(`Starting file processing for ${rawFiles.length} files using worker pool`);
+    logger.trace(`Starting file processing for ${leveledFiles.length} files using worker pool`);
 
     const taskRunner = deps.initTaskRunner<FileProcessTask, ProcessedFile>({
-      numOfTasks: rawFiles.length,
+      numOfTasks: leveledFiles.length,
       workerType: 'fileProcess',
       runtime: 'worker_threads',
     });
 
-    const tasks = rawFiles.map(
-      (rawFile) =>
+    const tasks = leveledFiles.map(
+      ({ rawFile }) =>
         ({
           rawFile,
           config,
@@ -130,8 +145,8 @@ export const processFiles = async (
     files = applyLightweightTransforms(files, config, () => {}, deps);
   } else {
     // No heavy processing needed - apply lightweight transforms directly
-    logger.trace(`Starting file processing for ${rawFiles.length} files in main thread (lightweight mode)`);
-    const inputFiles = rawFiles.map((rawFile) => ({ path: rawFile.path, content: rawFile.content }));
+    logger.trace(`Starting file processing for ${leveledFiles.length} files in main thread (lightweight mode)`);
+    const inputFiles = leveledFiles.map(({ rawFile }) => ({ path: rawFile.path, content: rawFile.content }));
     files = applyLightweightTransforms(inputFiles, config, progressCallback, deps);
   }
 

--- a/src/core/file/fileProcess.ts
+++ b/src/core/file/fileProcess.ts
@@ -93,14 +93,17 @@ export const processFiles = async (
   const startTime = process.hrtime.bigint();
   let files: ProcessedFile[];
 
-  // Resolve each file's inclusion level once and cache it by path. Files at the
-  // 'directory-only' level are dropped from the content output entirely — their
-  // paths still appear in the directory structure, which is built from the search
-  // results rather than from processedFiles. The cached levels are reused by
+  // Use each file's inclusion level, normally precomputed by the packager against
+  // the per-root-relative path (the same basis include/ignore use) and threaded on
+  // rawFile.level, falling back to resolving it from the path for callers that
+  // build RawFiles directly. Files at the 'directory-only' level are dropped from
+  // the content output entirely — their paths still appear in the directory
+  // structure, which is built from the search results rather than from
+  // processedFiles. The levels are cached by path and reused by
   // applyLightweightTransforms so the glob matching is not repeated.
   const fileLevels = new Map<string, FileInclusionLevel>();
   const leveledFiles = rawFiles.flatMap((rawFile) => {
-    const level = resolveFileLevel(rawFile.path, config.output);
+    const level = rawFile.level ?? resolveFileLevel(rawFile.path, config.output);
     fileLevels.set(rawFile.path, level);
     return level !== 'directory-only' ? [{ rawFile, level }] : [];
   });

--- a/src/core/file/fileProcess.ts
+++ b/src/core/file/fileProcess.ts
@@ -99,13 +99,11 @@ export const processFiles = async (
   // results rather than from processedFiles. The cached levels are reused by
   // applyLightweightTransforms so the glob matching is not repeated.
   const fileLevels = new Map<string, FileInclusionLevel>();
-  const leveledFiles = rawFiles
-    .map((rawFile) => {
-      const level = resolveFileLevel(rawFile.path, config.output);
-      fileLevels.set(rawFile.path, level);
-      return { rawFile, level };
-    })
-    .filter((entry) => entry.level !== 'directory-only');
+  const leveledFiles = rawFiles.flatMap((rawFile) => {
+    const level = resolveFileLevel(rawFile.path, config.output);
+    fileLevels.set(rawFile.path, level);
+    return level !== 'directory-only' ? [{ rawFile, level }] : [];
+  });
 
   // Only compress (tree-sitter) and removeComments (AST manipulation) justify worker thread overhead.
   // Compression can be requested globally or per-file via output.patterns, so check the resolved
@@ -124,10 +122,11 @@ export const processFiles = async (
     });
 
     const tasks = leveledFiles.map(
-      ({ rawFile }) =>
+      ({ rawFile, level }) =>
         ({
           rawFile,
           config,
+          level,
         }) satisfies FileProcessTask,
     );
 

--- a/src/core/file/fileProcess.ts
+++ b/src/core/file/fileProcess.ts
@@ -3,7 +3,7 @@ import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
 import { initTaskRunner } from '../../shared/processConcurrency.js';
 import type { RepomixProgressCallback } from '../../shared/types.js';
-import { resolveFileLevel } from './fileLevelResolve.js';
+import { type FileInclusionLevel, resolveFileLevel } from './fileLevelResolve.js';
 import { type FileManipulator, getFileManipulator } from './fileManipulate.js';
 import type { ProcessedFile, RawFile } from './fileTypes.js';
 import { truncateBase64Content } from './truncateBase64.js';
@@ -23,6 +23,10 @@ export const applyLightweightTransforms = (
   config: RepomixConfigMerged,
   progressCallback: RepomixProgressCallback,
   deps: { getFileManipulator: GetFileManipulator },
+  // Optional precomputed inclusion levels keyed by file path. When provided,
+  // the showLineNumbers guard reuses them instead of recomputing via
+  // resolveFileLevel; callers without the map fall back to recomputing.
+  fileLevels?: Map<string, FileInclusionLevel>,
 ): ProcessedFile[] => {
   const totalFiles = files.length;
   const results: ProcessedFile[] = Array.from({ length: totalFiles }) as ProcessedFile[];
@@ -47,7 +51,8 @@ export const applyLightweightTransforms = (
     // Line numbers are suppressed for compressed files (their content is
     // restructured signatures, not line-faithful source), matching the global
     // compress behavior on a per-file basis.
-    if (config.output.showLineNumbers && resolveFileLevel(file.path, config.output) !== 'compress') {
+    const level = fileLevels?.get(file.path) ?? resolveFileLevel(file.path, config.output);
+    if (config.output.showLineNumbers && level !== 'compress') {
       const lines = content.split('\n');
       const padding = lines.length.toString().length;
       const numberedLines = lines.map((line, idx) => `${(idx + 1).toString().padStart(padding)}: ${line}`);
@@ -88,12 +93,18 @@ export const processFiles = async (
   const startTime = process.hrtime.bigint();
   let files: ProcessedFile[];
 
-  // Resolve each file's inclusion level once. Files at the 'directory-only'
-  // level are dropped from the content output entirely — their paths still
-  // appear in the directory structure, which is built from the search results
-  // rather than from processedFiles.
+  // Resolve each file's inclusion level once and cache it by path. Files at the
+  // 'directory-only' level are dropped from the content output entirely — their
+  // paths still appear in the directory structure, which is built from the search
+  // results rather than from processedFiles. The cached levels are reused by
+  // applyLightweightTransforms so the glob matching is not repeated.
+  const fileLevels = new Map<string, FileInclusionLevel>();
   const leveledFiles = rawFiles
-    .map((rawFile) => ({ rawFile, level: resolveFileLevel(rawFile.path, config.output) }))
+    .map((rawFile) => {
+      const level = resolveFileLevel(rawFile.path, config.output);
+      fileLevels.set(rawFile.path, level);
+      return { rawFile, level };
+    })
     .filter((entry) => entry.level !== 'directory-only');
 
   // Only compress (tree-sitter) and removeComments (AST manipulation) justify worker thread overhead.
@@ -142,12 +153,12 @@ export const processFiles = async (
     }
 
     // Phase 2: Lightweight transforms (no progress - already reported by workers)
-    files = applyLightweightTransforms(files, config, () => {}, deps);
+    files = applyLightweightTransforms(files, config, () => {}, deps, fileLevels);
   } else {
     // No heavy processing needed - apply lightweight transforms directly
     logger.trace(`Starting file processing for ${leveledFiles.length} files in main thread (lightweight mode)`);
     const inputFiles = leveledFiles.map(({ rawFile }) => ({ path: rawFile.path, content: rawFile.content }));
-    files = applyLightweightTransforms(inputFiles, config, progressCallback, deps);
+    files = applyLightweightTransforms(inputFiles, config, progressCallback, deps, fileLevels);
   }
 
   const endTime = process.hrtime.bigint();

--- a/src/core/file/fileProcessContent.ts
+++ b/src/core/file/fileProcessContent.ts
@@ -1,6 +1,7 @@
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
 import { parseFile } from '../treeSitter/parseFile.js';
+import { resolveFileLevel } from './fileLevelResolve.js';
 import { getFileManipulator } from './fileManipulate.js';
 import type { RawFile } from './fileTypes.js';
 
@@ -24,7 +25,10 @@ export const processContent = async (rawFile: RawFile, config: RepomixConfigMerg
     processedContent = manipulator.removeComments(processedContent);
   }
 
-  if (config.output.compress) {
+  // Compress when this file resolves to the 'compress' level. This honors
+  // per-file output.patterns overrides and falls back to the global
+  // output.compress setting when no pattern matches.
+  if (resolveFileLevel(rawFile.path, config.output) === 'compress') {
     try {
       const parsedContent = await parseFile(processedContent, rawFile.path, config);
       if (parsedContent === undefined) {

--- a/src/core/file/fileProcessContent.ts
+++ b/src/core/file/fileProcessContent.ts
@@ -1,7 +1,7 @@
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
 import { parseFile } from '../treeSitter/parseFile.js';
-import { resolveFileLevel } from './fileLevelResolve.js';
+import { type FileInclusionLevel, resolveFileLevel } from './fileLevelResolve.js';
 import { getFileManipulator } from './fileManipulate.js';
 import type { RawFile } from './fileTypes.js';
 
@@ -14,7 +14,11 @@ import type { RawFile } from './fileTypes.js';
  * Lightweight transforms (truncateBase64, removeEmptyLines, trim, showLineNumbers)
  * are applied separately on the main thread by processFiles().
  */
-export const processContent = async (rawFile: RawFile, config: RepomixConfigMerged): Promise<string> => {
+export const processContent = async (
+  rawFile: RawFile,
+  config: RepomixConfigMerged,
+  level?: FileInclusionLevel,
+): Promise<string> => {
   const processStartAt = process.hrtime.bigint();
   let processedContent = rawFile.content;
   const manipulator = getFileManipulator(rawFile.path);
@@ -25,10 +29,12 @@ export const processContent = async (rawFile: RawFile, config: RepomixConfigMerg
     processedContent = manipulator.removeComments(processedContent);
   }
 
-  // Compress when this file resolves to the 'compress' level. This honors
-  // per-file output.patterns overrides and falls back to the global
-  // output.compress setting when no pattern matches.
-  if (resolveFileLevel(rawFile.path, config.output) === 'compress') {
+  // Compress when this file resolves to the 'compress' level. The level is
+  // normally precomputed in the main thread and threaded through; fall back to
+  // resolving it here when it is not supplied. This honors per-file
+  // output.patterns overrides and the global output.compress setting.
+  const effectiveLevel = level ?? resolveFileLevel(rawFile.path, config.output);
+  if (effectiveLevel === 'compress') {
     try {
       const parsedContent = await parseFile(processedContent, rawFile.path, config);
       if (parsedContent === undefined) {

--- a/src/core/file/fileTypes.ts
+++ b/src/core/file/fileTypes.ts
@@ -1,6 +1,17 @@
+import type { FileInclusionLevel } from './fileLevelResolve.js';
+
 export interface RawFile {
   path: string;
   content: string;
+  /**
+   * Per-file inclusion level, resolved by the packager against the file's
+   * per-root-relative path (the same basis `include`/`ignore` match against),
+   * before `path` is rewritten to its display form. Carried on the file object
+   * so `processFiles` does not have to re-derive it from the display `path`.
+   * Optional: callers that build RawFiles directly (e.g. tests) may omit it, in
+   * which case `processFiles` falls back to resolving it from `path`.
+   */
+  level?: FileInclusionLevel;
 }
 
 export interface ProcessedFile {

--- a/src/core/file/workers/fileProcessWorker.ts
+++ b/src/core/file/workers/fileProcessWorker.ts
@@ -1,6 +1,7 @@
 import type { RepomixConfigMerged } from '../../../config/configSchema.js';
 import { setLogLevelByWorkerData } from '../../../shared/logger.js';
 import { cleanupLanguageParser } from '../../treeSitter/parseFile.js';
+import type { FileInclusionLevel } from '../fileLevelResolve.js';
 import { processContent } from '../fileProcessContent.js';
 import type { ProcessedFile, RawFile } from '../fileTypes.js';
 
@@ -11,10 +12,13 @@ setLogLevelByWorkerData();
 export interface FileProcessTask {
   rawFile: RawFile;
   config: RepomixConfigMerged;
+  // Precomputed in the main thread (processFiles) so the worker does not repeat
+  // the glob matching to resolve the inclusion level.
+  level: FileInclusionLevel;
 }
 
-export default async ({ rawFile, config }: FileProcessTask): Promise<ProcessedFile> => {
-  const processedContent = await processContent(rawFile, config);
+export default async ({ rawFile, config, level }: FileProcessTask): Promise<ProcessedFile> => {
+  const processedContent = await processContent(rawFile, config, level);
   return {
     path: rawFile.path,
     content: processedContent,

--- a/src/core/output/outputStyleDecorate.ts
+++ b/src/core/output/outputStyleDecorate.ts
@@ -39,7 +39,12 @@ export const analyzeContent = (config: RepomixConfigMerged): ContentInfo => {
       parsableStyle: config.output.parsableStyle,
       // True when compression is applied globally or to any subset via output.patterns,
       // so the header note accurately reflects that some content uses the ⋮---- delimiter.
-      compressed: config.output.compress || (config.output.patterns?.some((p) => p.compress === true) ?? false),
+      // A pattern only compresses when directoryStructureOnly does not take precedence
+      // over compress (matching resolveFileLevel), so both flags together omit content
+      // rather than compressing it.
+      compressed:
+        config.output.compress ||
+        (config.output.patterns?.some((p) => p.compress === true && p.directoryStructureOnly !== true) ?? false),
       truncatedBase64: config.output.truncateBase64,
     },
     sorting: {

--- a/src/core/output/outputStyleDecorate.ts
+++ b/src/core/output/outputStyleDecorate.ts
@@ -37,7 +37,9 @@ export const analyzeContent = (config: RepomixConfigMerged): ContentInfo => {
       securityCheckEnabled: config.security.enableSecurityCheck,
       showLineNumbers: config.output.showLineNumbers,
       parsableStyle: config.output.parsableStyle,
-      compressed: config.output.compress,
+      // True when compression is applied globally or to any subset via output.patterns,
+      // so the header note accurately reflects that some content uses the ⋮---- delimiter.
+      compressed: config.output.compress || (config.output.patterns?.some((p) => p.compress === true) ?? false),
       truncatedBase64: config.output.truncateBase64,
     },
     sorting: {

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -4,6 +4,7 @@ import { logger } from '../shared/logger.js';
 import { logMemoryUsage, withMemoryLogging } from '../shared/memoryUtils.js';
 import type { RepomixProgressCallback } from '../shared/types.js';
 import { collectFiles, type SkippedFileInfo } from './file/fileCollect.js';
+import { resolveFileLevel } from './file/fileLevelResolve.js';
 import { sortPaths } from './file/filePathSort.js';
 import { processFiles } from './file/fileProcess.js';
 import { searchFiles } from './file/fileSearch.js';
@@ -186,6 +187,12 @@ export const pack = async (
       const rootLabel = rootLabels?.[index];
       return curr.rawFiles.map((file) => ({
         ...file,
+        // Resolve the inclusion level against the per-root-relative path (the same
+        // basis include/ignore match against), before `path` is rewritten to its
+        // display form below. Carrying it on the file means output.patterns globs
+        // match per-root regardless of root labels or output.filePathStyle, instead
+        // of being matched against the rewritten display path inside processFiles.
+        level: resolveFileLevel(file.path, config.output),
         path: buildFileDisplayPath({
           rootDir,
           filePath: file.path,

--- a/tests/config/configLoad.test.ts
+++ b/tests/config/configLoad.test.ts
@@ -372,6 +372,28 @@ describe('configLoad', () => {
       expect(merged.output.filePathStyle).toBe('cwd-relative');
     });
 
+    test('should preserve output.patterns from the file config through the merge', () => {
+      // Regression guard: output.patterns is declared only on the base/file schema
+      // member of repomixConfigMergedSchema's intersect (the default member's output
+      // does not declare it). If the intersect ever stopped merging per-schema
+      // outputs, config-file inclusion-level patterns would be silently dropped.
+      const fileConfig: RepomixConfigFile = {
+        output: {
+          patterns: [
+            { pattern: 'docs/**/*', compress: true },
+            { pattern: 'website/**/*', directoryStructureOnly: true },
+          ],
+        },
+      };
+
+      const merged = mergeConfigs(process.cwd(), fileConfig, {});
+
+      expect(merged.output.patterns).toEqual([
+        { pattern: 'docs/**/*', compress: true },
+        { pattern: 'website/**/*', directoryStructureOnly: true },
+      ]);
+    });
+
     test('should not mutate defaultConfig', () => {
       const originalFilePath = defaultConfig.output.filePath;
       const fileConfig: RepomixConfigFile = {

--- a/tests/config/configSchema.test.ts
+++ b/tests/config/configSchema.test.ts
@@ -68,6 +68,74 @@ describe('configSchema', () => {
     });
   });
 
+  describe('output.patterns inclusion level', () => {
+    it('should accept patterns with compress and directoryStructureOnly flags', () => {
+      const configWithPatterns = {
+        output: {
+          patterns: [
+            { pattern: 'docs/**/*', compress: true },
+            { pattern: 'website/**/*', directoryStructureOnly: true },
+          ],
+        },
+      };
+      expect(v.parse(repomixConfigBaseSchema, configWithPatterns)).toEqual(configWithPatterns);
+    });
+
+    it('should accept a pattern entry with only the required pattern field', () => {
+      const configWithPattern = {
+        output: {
+          patterns: [{ pattern: 'src/**/*' }],
+        },
+      };
+      expect(v.parse(repomixConfigBaseSchema, configWithPattern)).toEqual(configWithPattern);
+    });
+
+    it('should reject a pattern entry missing the pattern field', () => {
+      const invalidConfig = {
+        output: {
+          patterns: [{ compress: true }],
+        },
+      };
+      expect(() => v.parse(repomixConfigBaseSchema, invalidConfig)).toThrow(v.ValiError);
+    });
+
+    it('should reject a non-string pattern', () => {
+      const invalidConfig = {
+        output: {
+          patterns: [{ pattern: 123 }],
+        },
+      };
+      expect(() => v.parse(repomixConfigBaseSchema, invalidConfig)).toThrow(v.ValiError);
+    });
+
+    it('should reject a non-boolean compress flag', () => {
+      const invalidConfig = {
+        output: {
+          patterns: [{ pattern: 'docs/**/*', compress: 'yes' }],
+        },
+      };
+      expect(() => v.parse(repomixConfigBaseSchema, invalidConfig)).toThrow(v.ValiError);
+    });
+
+    it('should reject a non-boolean directoryStructureOnly flag', () => {
+      const invalidConfig = {
+        output: {
+          patterns: [{ pattern: 'docs/**/*', directoryStructureOnly: 'yes' }],
+        },
+      };
+      expect(() => v.parse(repomixConfigBaseSchema, invalidConfig)).toThrow(v.ValiError);
+    });
+
+    it('should reject patterns that is not an array', () => {
+      const invalidConfig = {
+        output: {
+          patterns: 'docs/**/*',
+        },
+      };
+      expect(() => v.parse(repomixConfigBaseSchema, invalidConfig)).toThrow(v.ValiError);
+    });
+  });
+
   describe('repomixConfigBaseSchema', () => {
     it('should accept valid base config', () => {
       const validConfig = {

--- a/tests/core/file/fileLevelResolve.test.ts
+++ b/tests/core/file/fileLevelResolve.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { resolveFileLevel } from '../../../src/core/file/fileLevelResolve.js';
+
+describe('resolveFileLevel', () => {
+  describe('without patterns (backward compatibility)', () => {
+    it('returns "full" when there are no patterns and global compress is off', () => {
+      expect(resolveFileLevel('src/index.ts', { compress: false })).toBe('full');
+    });
+
+    it('returns "compress" when there are no patterns and global compress is on', () => {
+      expect(resolveFileLevel('src/index.ts', { compress: true })).toBe('compress');
+    });
+
+    it('treats an empty patterns array the same as no patterns (falls back to global)', () => {
+      expect(resolveFileLevel('src/index.ts', { compress: true, patterns: [] })).toBe('compress');
+      expect(resolveFileLevel('src/index.ts', { compress: false, patterns: [] })).toBe('full');
+    });
+
+    it('treats an undefined global compress as "full"', () => {
+      expect(resolveFileLevel('src/index.ts', {})).toBe('full');
+    });
+  });
+
+  describe('per-pattern levels', () => {
+    it('returns "compress" for a file matching a compress pattern', () => {
+      expect(
+        resolveFileLevel('docs/guide.md', { compress: false, patterns: [{ pattern: 'docs/**/*', compress: true }] }),
+      ).toBe('compress');
+    });
+
+    it('returns "directory-only" for a file matching a directoryStructureOnly pattern', () => {
+      expect(
+        resolveFileLevel('website/index.html', {
+          compress: false,
+          patterns: [{ pattern: 'website/**/*', directoryStructureOnly: true }],
+        }),
+      ).toBe('directory-only');
+    });
+
+    it('returns "full" for a matched pattern that sets no level flags', () => {
+      expect(resolveFileLevel('src/index.ts', { compress: false, patterns: [{ pattern: 'src/**/*' }] })).toBe('full');
+    });
+  });
+
+  describe('first match wins', () => {
+    it('uses the first matching pattern and ignores later overlapping ones', () => {
+      const output = {
+        compress: false,
+        patterns: [
+          { pattern: 'docs/**/*', compress: true },
+          { pattern: 'docs/**/*', directoryStructureOnly: true },
+        ],
+      };
+      expect(resolveFileLevel('docs/guide.md', output)).toBe('compress');
+    });
+
+    it('falls back to the global behavior when no pattern matches', () => {
+      const patterns = [{ pattern: 'docs/**/*', compress: true }];
+      expect(resolveFileLevel('src/index.ts', { compress: true, patterns })).toBe('compress');
+      expect(resolveFileLevel('src/index.ts', { compress: false, patterns })).toBe('full');
+    });
+  });
+
+  describe('flag override semantics', () => {
+    it('lets a matched pattern force full content over a global compress', () => {
+      expect(
+        resolveFileLevel('src/index.ts', { compress: true, patterns: [{ pattern: 'src/**/*', compress: false }] }),
+      ).toBe('full');
+    });
+
+    it('gives directoryStructureOnly precedence over compress when both are set', () => {
+      expect(
+        resolveFileLevel('website/index.html', {
+          compress: false,
+          patterns: [{ pattern: 'website/**/*', compress: true, directoryStructureOnly: true }],
+        }),
+      ).toBe('directory-only');
+    });
+  });
+
+  describe('path matching', () => {
+    it('matches nested files under a ** glob', () => {
+      expect(
+        resolveFileLevel('docs/sub/deep/guide.md', {
+          compress: false,
+          patterns: [{ pattern: 'docs/**/*', compress: true }],
+        }),
+      ).toBe('compress');
+    });
+
+    it('matches Windows-style backslash paths against forward-slash globs', () => {
+      expect(
+        resolveFileLevel('docs\\sub\\guide.md', {
+          compress: false,
+          patterns: [{ pattern: 'docs/**/*', compress: true }],
+        }),
+      ).toBe('compress');
+    });
+
+    it('matches dotfiles (dot: true)', () => {
+      expect(
+        resolveFileLevel('.github/workflows/ci.yml', {
+          compress: false,
+          patterns: [{ pattern: '.github/**/*', directoryStructureOnly: true }],
+        }),
+      ).toBe('directory-only');
+    });
+  });
+});

--- a/tests/core/file/fileProcess.inclusionLevel.test.ts
+++ b/tests/core/file/fileProcess.inclusionLevel.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FileManipulator } from '../../../src/core/file/fileManipulate.js';
+import { applyLightweightTransforms, processFiles } from '../../../src/core/file/fileProcess.js';
+import type { ProcessedFile, RawFile } from '../../../src/core/file/fileTypes.js';
+import type { FileProcessTask } from '../../../src/core/file/workers/fileProcessWorker.js';
+import fileProcessWorker from '../../../src/core/file/workers/fileProcessWorker.js';
+import { parseFile } from '../../../src/core/treeSitter/parseFile.js';
+import type { WorkerOptions } from '../../../src/shared/processConcurrency.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+// parseFile is the Tree-sitter compression entry point. Mock it so these tests
+// assert routing/decisions (which files get compressed) without depending on
+// the exact compressed output of the real parser.
+vi.mock('../../../src/core/treeSitter/parseFile.js');
+vi.mock('../../../src/shared/logger.js');
+
+const mockGetFileManipulator = (_filePath: string): FileManipulator | null => null;
+
+const mockInitTaskRunner = <T, R>(_options: WorkerOptions) => {
+  return {
+    run: async (task: T) => {
+      return (await fileProcessWorker(task as FileProcessTask)) as R;
+    },
+    cleanup: async () => {
+      // no-op for tests
+    },
+  };
+};
+
+const byPath = (files: ProcessedFile[]): Record<string, string> =>
+  Object.fromEntries(files.map((f) => [f.path, f.content]));
+
+describe('fileProcess inclusion levels (output.patterns)', () => {
+  beforeEach(() => {
+    vi.mocked(parseFile).mockResolvedValue('<<compressed>>');
+  });
+
+  describe('processFiles', () => {
+    it('excludes directory-only files from the content output while keeping other files', async () => {
+      const rawFiles: RawFile[] = [
+        { path: 'src/index.ts', content: 'const a = 1;' },
+        { path: 'website/index.html', content: '<html></html>' },
+      ];
+      const config = createMockConfig({
+        output: { patterns: [{ pattern: 'website/**/*', directoryStructureOnly: true }] },
+      });
+
+      const result = await processFiles(rawFiles, config, () => {}, {
+        initTaskRunner: mockInitTaskRunner,
+        getFileManipulator: mockGetFileManipulator,
+      });
+
+      expect(result.map((f) => f.path)).toEqual(['src/index.ts']);
+    });
+
+    it('compresses files matched by a compress pattern even when global compress is off', async () => {
+      const rawFiles: RawFile[] = [
+        { path: 'docs/guide.md', content: 'real docs content' },
+        { path: 'src/index.ts', content: 'const a = 1;' },
+      ];
+      const config = createMockConfig({
+        output: { compress: false, patterns: [{ pattern: 'docs/**/*', compress: true }] },
+      });
+
+      const result = await processFiles(rawFiles, config, () => {}, {
+        initTaskRunner: mockInitTaskRunner,
+        getFileManipulator: mockGetFileManipulator,
+      });
+
+      const content = byPath(result);
+      expect(content['docs/guide.md']).toBe('<<compressed>>');
+      expect(content['src/index.ts']).toBe('const a = 1;');
+    });
+
+    it('keeps full content for a pattern that overrides a global compress, while still compressing others', async () => {
+      const rawFiles: RawFile[] = [
+        { path: 'src/index.ts', content: 'const a = 1;' },
+        { path: 'lib/util.ts', content: 'const b = 2;' },
+      ];
+      const config = createMockConfig({
+        output: { compress: true, patterns: [{ pattern: 'src/**/*', compress: false }] },
+      });
+
+      const result = await processFiles(rawFiles, config, () => {}, {
+        initTaskRunner: mockInitTaskRunner,
+        getFileManipulator: mockGetFileManipulator,
+      });
+
+      const content = byPath(result);
+      expect(content['src/index.ts']).toBe('const a = 1;');
+      expect(content['lib/util.ts']).toBe('<<compressed>>');
+    });
+
+    it('handles compress and directory-only patterns together (compress, exclude, keep full)', async () => {
+      const rawFiles: RawFile[] = [
+        { path: 'src/index.ts', content: 'const a = 1;' },
+        { path: 'docs/guide.md', content: 'real docs content' },
+        { path: 'website/index.html', content: '<html></html>' },
+      ];
+      const config = createMockConfig({
+        output: {
+          compress: false,
+          patterns: [
+            { pattern: 'docs/**/*', compress: true },
+            { pattern: 'website/**/*', directoryStructureOnly: true },
+          ],
+        },
+      });
+
+      const result = await processFiles(rawFiles, config, () => {}, {
+        initTaskRunner: mockInitTaskRunner,
+        getFileManipulator: mockGetFileManipulator,
+      });
+
+      const content = byPath(result);
+      expect(Object.keys(content).sort()).toEqual(['docs/guide.md', 'src/index.ts']);
+      expect(content['docs/guide.md']).toBe('<<compressed>>');
+      expect(content['src/index.ts']).toBe('const a = 1;');
+    });
+
+    it('does not compress when global compress is off and no pattern matches', async () => {
+      const rawFiles: RawFile[] = [{ path: 'src/index.ts', content: 'const a = 1;' }];
+      const config = createMockConfig({
+        output: { compress: false, patterns: [{ pattern: 'docs/**/*', compress: true }] },
+      });
+
+      const result = await processFiles(rawFiles, config, () => {}, {
+        initTaskRunner: mockInitTaskRunner,
+        getFileManipulator: mockGetFileManipulator,
+      });
+
+      expect(byPath(result)['src/index.ts']).toBe('const a = 1;');
+    });
+  });
+
+  describe('applyLightweightTransforms', () => {
+    it('does not add line numbers to a file compressed via an output pattern', () => {
+      const files: ProcessedFile[] = [{ path: 'docs/guide.md', content: 'Line 1\nLine 2' }];
+      const config = createMockConfig({
+        output: {
+          showLineNumbers: true,
+          compress: false,
+          patterns: [{ pattern: 'docs/**/*', compress: true }],
+        },
+      });
+
+      const result = applyLightweightTransforms(files, config, () => {}, {
+        getFileManipulator: mockGetFileManipulator,
+      });
+
+      expect(result).toEqual([{ path: 'docs/guide.md', content: 'Line 1\nLine 2' }]);
+    });
+
+    it('still adds line numbers to files not matched by a compress pattern', () => {
+      const files: ProcessedFile[] = [{ path: 'src/index.ts', content: 'Line 1\nLine 2' }];
+      const config = createMockConfig({
+        output: {
+          showLineNumbers: true,
+          compress: false,
+          patterns: [{ pattern: 'docs/**/*', compress: true }],
+        },
+      });
+
+      const result = applyLightweightTransforms(files, config, () => {}, {
+        getFileManipulator: mockGetFileManipulator,
+      });
+
+      expect(result).toEqual([{ path: 'src/index.ts', content: '1: Line 1\n2: Line 2' }]);
+    });
+  });
+});

--- a/tests/core/file/fileProcess.inclusionLevel.test.ts
+++ b/tests/core/file/fileProcess.inclusionLevel.test.ts
@@ -132,6 +132,45 @@ describe('fileProcess inclusion levels (output.patterns)', () => {
 
       expect(byPath(result)['src/index.ts']).toBe('const a = 1;');
     });
+
+    // The packager resolves the inclusion level against each file's
+    // per-root-relative path (the basis include/ignore use) and threads it on
+    // rawFile.level before rewriting path to its display form. processFiles must
+    // honor that threaded level rather than re-deriving it from the display path,
+    // which is what makes output.patterns match per-root for multiple roots and
+    // for output.filePathStyle: 'cwd-relative'.
+    it('honors a precomputed directory-only level threaded on rawFile.level over the path-derived level', async () => {
+      // No output.patterns are configured, so resolving from the (display) path
+      // alone would yield 'full'. The threaded 'directory-only' level must win and
+      // drop the file from the content output.
+      const rawFiles: RawFile[] = [
+        { path: 'app/src/index.ts', content: 'const a = 1;', level: 'directory-only' },
+        { path: 'app/README.md', content: '# app', level: 'full' },
+      ];
+      const config = createMockConfig({ output: {} });
+
+      const result = await processFiles(rawFiles, config, () => {}, {
+        initTaskRunner: mockInitTaskRunner,
+        getFileManipulator: mockGetFileManipulator,
+      });
+
+      expect(result.map((f) => f.path)).toEqual(['app/README.md']);
+    });
+
+    it('honors a precomputed compress level threaded on rawFile.level over the path-derived level', async () => {
+      // Global compress is off and no pattern matches, so the path-derived level
+      // would be 'full'. The threaded 'compress' level must route the file through
+      // the compression pipeline (worker path).
+      const rawFiles: RawFile[] = [{ path: 'app/src/index.ts', content: 'const a = 1;', level: 'compress' }];
+      const config = createMockConfig({ output: { compress: false } });
+
+      const result = await processFiles(rawFiles, config, () => {}, {
+        initTaskRunner: mockInitTaskRunner,
+        getFileManipulator: mockGetFileManipulator,
+      });
+
+      expect(byPath(result)['app/src/index.ts']).toBe('<<compressed>>');
+    });
   });
 
   describe('applyLightweightTransforms', () => {

--- a/tests/core/file/fileProcess.inclusionLevel.test.ts
+++ b/tests/core/file/fileProcess.inclusionLevel.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FileInclusionLevel } from '../../../src/core/file/fileLevelResolve.js';
 import type { FileManipulator } from '../../../src/core/file/fileManipulate.js';
 import { applyLightweightTransforms, processFiles } from '../../../src/core/file/fileProcess.js';
 import type { ProcessedFile, RawFile } from '../../../src/core/file/fileTypes.js';
@@ -166,6 +167,25 @@ describe('fileProcess inclusion levels (output.patterns)', () => {
       });
 
       expect(result).toEqual([{ path: 'src/index.ts', content: '1: Line 1\n2: Line 2' }]);
+    });
+
+    it('consults a provided fileLevels map instead of recomputing the level', () => {
+      // The file resolves to 'full' on its own (no patterns), but the precomputed
+      // map marks it 'compress', so line numbers must be suppressed. This proves the
+      // map is consulted rather than resolveFileLevel being called again.
+      const files: ProcessedFile[] = [{ path: 'src/index.ts', content: 'Line 1\nLine 2' }];
+      const config = createMockConfig({ output: { showLineNumbers: true } });
+      const fileLevels = new Map<string, FileInclusionLevel>([['src/index.ts', 'compress']]);
+
+      const result = applyLightweightTransforms(
+        files,
+        config,
+        () => {},
+        { getFileManipulator: mockGetFileManipulator },
+        fileLevels,
+      );
+
+      expect(result).toEqual([{ path: 'src/index.ts', content: 'Line 1\nLine 2' }]);
     });
   });
 });

--- a/tests/core/file/fileProcessContent.test.ts
+++ b/tests/core/file/fileProcessContent.test.ts
@@ -137,4 +137,61 @@ describe('processContent', () => {
     const result = await processContent(rawFile, config);
     expect(result).toBe('some content');
   });
+
+  it('should compress based on the passed level even when global compress is off', async () => {
+    const rawFile: RawFile = {
+      path: 'test.ts',
+      content: 'const x = 1;',
+    };
+    const config: RepomixConfigMerged = {
+      output: {
+        removeComments: false,
+        removeEmptyLines: false,
+        compress: false,
+        showLineNumbers: false,
+      },
+    } as RepomixConfigMerged;
+
+    const result = await processContent(rawFile, config, 'compress');
+    expect(parseFile).toHaveBeenCalledWith(rawFile.content, rawFile.path, config);
+    expect(result).toBe('parsed content');
+  });
+
+  it('should not compress when the passed level is "full" even if global compress is on', async () => {
+    const rawFile: RawFile = {
+      path: 'test.ts',
+      content: 'const x = 1;',
+    };
+    const config: RepomixConfigMerged = {
+      output: {
+        removeComments: false,
+        removeEmptyLines: false,
+        compress: true,
+        showLineNumbers: false,
+      },
+    } as RepomixConfigMerged;
+
+    const result = await processContent(rawFile, config, 'full');
+    expect(parseFile).not.toHaveBeenCalled();
+    expect(result).toBe('const x = 1;');
+  });
+
+  it('should fall back to resolving the level from config when none is passed', async () => {
+    const rawFile: RawFile = {
+      path: 'test.ts',
+      content: 'const x = 1;',
+    };
+    const config: RepomixConfigMerged = {
+      output: {
+        removeComments: false,
+        removeEmptyLines: false,
+        compress: true,
+        showLineNumbers: false,
+      },
+    } as RepomixConfigMerged;
+
+    const result = await processContent(rawFile, config);
+    expect(parseFile).toHaveBeenCalledWith(rawFile.content, rawFile.path, config);
+    expect(result).toBe('parsed content');
+  });
 });

--- a/tests/core/output/inclusionLevelOutput.test.ts
+++ b/tests/core/output/inclusionLevelOutput.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { processFiles } from '../../../src/core/file/fileProcess.js';
+import type { RawFile } from '../../../src/core/file/fileTypes.js';
+import { generateOutput } from '../../../src/core/output/outputGenerate.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+// End-to-end coverage for the output.patterns "directory-only" inclusion level
+// (issue #608). This composes the two halves the packager wires together:
+//   - processFiles produces the per-file content blocks
+//   - generateOutput renders the directory tree from the search path list
+// The directory tree is built from `allFilePaths` (the search results, passed
+// through unchanged), while content blocks come from `processedFiles`. A
+// directory-only file must therefore still appear in the tree even though its
+// content is dropped from processedFiles.
+
+describe('output.patterns directory-only inclusion level (end-to-end)', () => {
+  const rootDir = '/repo';
+
+  it('lists a directory-only file in the directory structure but omits its content block', async () => {
+    const rawFiles: RawFile[] = [
+      { path: 'src/index.ts', content: 'export const greeting = "hello";' },
+      { path: 'website/index.html', content: '<html>OMITTED_WEBSITE_BODY</html>' },
+    ];
+    // Mirrors the packager: allFilePaths comes from the file search and is NOT
+    // filtered by inclusion level, so the directory-only path still feeds the tree.
+    const allFilePaths = ['src/index.ts', 'website/index.html'];
+    const config = createMockConfig({
+      cwd: rootDir,
+      output: {
+        style: 'markdown',
+        git: { sortByChanges: false },
+        patterns: [{ pattern: 'website/**/*', directoryStructureOnly: true }],
+      },
+    });
+
+    const processedFiles = await processFiles(rawFiles, config, () => {});
+
+    // The directory-only file is dropped from the content output.
+    expect(processedFiles.map((f) => f.path)).toEqual(['src/index.ts']);
+
+    const output = await generateOutput([rootDir], config, processedFiles, allFilePaths);
+
+    // The directory structure still lists the directory-only file's path...
+    expect(output).toContain('website/');
+    expect(output).toContain('index.html');
+    // ...but its content block is omitted entirely.
+    expect(output).not.toContain('OMITTED_WEBSITE_BODY');
+    // The full-content file is rendered as usual.
+    expect(output).toContain('export const greeting = "hello";');
+  });
+
+  it('keeps a directory-only directory in the tree even when all its files are excluded', async () => {
+    const rawFiles: RawFile[] = [
+      { path: 'src/index.ts', content: 'export const a = 1;' },
+      { path: 'website/css/site.css', content: 'body { color: OMITTED; }' },
+      { path: 'website/index.html', content: '<html>OMITTED</html>' },
+    ];
+    const allFilePaths = ['src/index.ts', 'website/css/site.css', 'website/index.html'];
+    const config = createMockConfig({
+      cwd: rootDir,
+      output: {
+        style: 'markdown',
+        git: { sortByChanges: false },
+        patterns: [{ pattern: 'website/**/*', directoryStructureOnly: true }],
+      },
+    });
+
+    const processedFiles = await processFiles(rawFiles, config, () => {});
+
+    // Every website file is excluded from content; only src remains.
+    expect(processedFiles.map((f) => f.path)).toEqual(['src/index.ts']);
+
+    const output = await generateOutput([rootDir], config, processedFiles, allFilePaths);
+
+    // The website directory and its files are still represented in the tree.
+    expect(output).toContain('website/');
+    expect(output).toContain('site.css');
+    expect(output).toContain('index.html');
+    // None of the excluded files leak their content.
+    expect(output).not.toContain('OMITTED');
+  });
+});

--- a/tests/core/output/outputStyleDecorate.test.ts
+++ b/tests/core/output/outputStyleDecorate.test.ts
@@ -57,6 +57,19 @@ describe('analyzeContent', () => {
     const result = analyzeContent(config);
     expect(result.processing.compressed).toBe(false);
   });
+
+  it('should not mark content as compressed for a pattern that sets both compress and directoryStructureOnly', () => {
+    // directoryStructureOnly takes precedence over compress in resolveFileLevel,
+    // so such a pattern omits the file's content rather than compressing it.
+    const config = createMockConfig({
+      output: {
+        compress: false,
+        patterns: [{ pattern: 'website/**/*', compress: true, directoryStructureOnly: true }],
+      },
+    });
+    const result = analyzeContent(config);
+    expect(result.processing.compressed).toBe(false);
+  });
 });
 
 describe('generateHeader', () => {

--- a/tests/core/output/outputStyleDecorate.test.ts
+++ b/tests/core/output/outputStyleDecorate.test.ts
@@ -35,6 +35,28 @@ describe('analyzeContent', () => {
     expect(result.processing.commentsRemoved).toBe(true);
     expect(result.processing.emptyLinesRemoved).toBe(true);
   });
+
+  it('should mark content as compressed when an output pattern requests compression', () => {
+    const config = createMockConfig({
+      output: {
+        compress: false,
+        patterns: [{ pattern: 'docs/**/*', compress: true }],
+      },
+    });
+    const result = analyzeContent(config);
+    expect(result.processing.compressed).toBe(true);
+  });
+
+  it('should not mark content as compressed when patterns only set directoryStructureOnly', () => {
+    const config = createMockConfig({
+      output: {
+        compress: false,
+        patterns: [{ pattern: 'website/**/*', directoryStructureOnly: true }],
+      },
+    });
+    const result = analyzeContent(config);
+    expect(result.processing.compressed).toBe(false);
+  });
 });
 
 describe('generateHeader', () => {

--- a/tests/core/packager.test.ts
+++ b/tests/core/packager.test.ts
@@ -88,14 +88,19 @@ describe('packager', () => {
     expect(mockDeps.produceOutput).toHaveBeenCalled();
     expect(mockDeps.calculateMetrics).toHaveBeenCalled();
 
+    // pack() resolves each file's inclusion level (against its per-root-relative
+    // path) and carries it on the raw file before handing them to the security
+    // check and file processing. With the default config every file resolves to
+    // 'full'.
+    const expectedLeveledRawFiles = mockRawFiles.map((file) => ({ ...file, level: 'full' as const }));
     expect(mockDeps.validateFileSafety).toHaveBeenCalledWith(
-      mockRawFiles,
+      expectedLeveledRawFiles,
       progressCallback,
       mockConfig,
       undefined,
       undefined,
     );
-    expect(mockDeps.processFiles).toHaveBeenCalledWith(mockRawFiles, mockConfig, progressCallback);
+    expect(mockDeps.processFiles).toHaveBeenCalledWith(expectedLeveledRawFiles, mockConfig, progressCallback);
     expect(mockDeps.produceOutput).toHaveBeenCalledWith(
       ['root'],
       mockConfig,

--- a/tests/core/packager/inclusionLevelSpec.test.ts
+++ b/tests/core/packager/inclusionLevelSpec.test.ts
@@ -1,0 +1,148 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { RepomixConfigMerged } from '../../../src/config/configSchema.js';
+import { collectFiles } from '../../../src/core/file/fileCollect.js';
+import { readRawFile } from '../../../src/core/file/fileRead.js';
+import { searchFiles } from '../../../src/core/file/fileSearch.js';
+import { produceOutput } from '../../../src/core/packager/produceOutput.js';
+import { pack } from '../../../src/core/packager.js';
+import { filterOutUntrustedFiles } from '../../../src/core/security/filterOutUntrustedFiles.js';
+import { validateFileSafety } from '../../../src/core/security/validateFileSafety.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+// End-to-end coverage that output.patterns globs match each file's
+// per-root-relative path (the same basis include/ignore use), not the rewritten
+// display path. Regression coverage for the per-root-relative matching fix:
+//   - Single root: `src/**` drops the src content (baseline, also the case that
+//     already worked because the display path equals the per-root path).
+//   - Multiple roots: `src/**` must match each root's `src/...` WITHOUT a
+//     root-label prefix, even though the display path is e.g. `app/src/index.ts`.
+//   - output.filePathStyle: 'cwd-relative': matching must be unaffected by the
+//     shifted display path (e.g. `app/src/index.ts`).
+//
+// Each test drives a real pack() with the real processFiles (which resolves and
+// consumes rawFile.level and filters directory-only files) and the real
+// produceOutput (which renders the directory tree from the unfiltered search
+// list). The directory tree must still list a directory-only file even though
+// its content block is dropped.
+
+const buildConfig = (cwd: string, outputPath: string, overrides: Partial<RepomixConfigMerged['output']> = {}) =>
+  createMockConfig({
+    cwd,
+    output: {
+      filePath: outputPath,
+      style: 'markdown',
+      git: { sortByChanges: false },
+      patterns: [{ pattern: 'src/**', directoryStructureOnly: true }],
+      ...overrides,
+    },
+  });
+
+// Mirror the production pipeline but stub the file system search/collect inputs'
+// heavy neighbours (security scan, metrics, git) — searchFiles, collectFiles,
+// processFiles and produceOutput are the REAL implementations so the level is
+// resolved, threaded and consumed exactly as in production.
+const runPack = (rootDirs: string[], config: RepomixConfigMerged) =>
+  pack(rootDirs, config, () => {}, {
+    searchFiles,
+    sortPaths: (filePaths) => [...filePaths].sort(),
+    collectFiles: (filePaths, root, cfg, progressCallback) =>
+      collectFiles(filePaths, root, cfg, progressCallback, { readRawFile }),
+    // processFiles is intentionally the real default: it resolves/honors
+    // rawFile.level and drops directory-only files from the content output.
+    validateFileSafety: (rawFiles, progressCallback, cfg, gitDiff, gitLog) =>
+      validateFileSafety(rawFiles, progressCallback, cfg, gitDiff, gitLog, {
+        runSecurityCheck: async () => [],
+        filterOutUntrustedFiles,
+      }),
+    produceOutput,
+    createMetricsTaskRunner: () => ({
+      taskRunner: { run: async () => 0, cleanup: async () => {} },
+      warmupPromise: Promise.resolve(),
+    }),
+    calculateMetrics: async (processedFiles) => ({
+      totalFiles: processedFiles.length,
+      totalCharacters: processedFiles.reduce((acc, f) => acc + f.content.length, 0),
+      totalTokens: 0,
+      gitDiffTokenCount: 0,
+      gitLogTokenCount: 0,
+      fileCharCounts: Object.fromEntries(processedFiles.map((f) => [f.path, f.content.length])),
+      fileTokenCounts: Object.fromEntries(processedFiles.map((f) => [f.path, 0])),
+      suspiciousFilesResults: [],
+      suspiciousGitDiffResults: [],
+    }),
+  });
+
+describe('output.patterns per-root-relative matching (end-to-end)', () => {
+  let rootParent: string;
+  let rootApp: string;
+  let rootLib: string;
+  let outputDir: string;
+  let outputPath: string;
+
+  beforeEach(async () => {
+    rootParent = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-inclusion-level-'));
+    rootApp = path.join(rootParent, 'app');
+    rootLib = path.join(rootParent, 'lib');
+    outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-inclusion-level-out-'));
+    outputPath = path.join(outputDir, 'output.md');
+
+    await fs.mkdir(path.join(rootApp, 'src'), { recursive: true });
+    await fs.writeFile(path.join(rootApp, 'README.md'), '# App\nREADME_A_CONTENT\n');
+    await fs.writeFile(path.join(rootApp, 'src', 'index.ts'), 'export const a = "SRC_A_CONTENT";\n');
+
+    await fs.mkdir(path.join(rootLib, 'src'), { recursive: true });
+    await fs.writeFile(path.join(rootLib, 'README.md'), '# Lib\nREADME_B_CONTENT\n');
+    await fs.writeFile(path.join(rootLib, 'src', 'index.ts'), 'export const b = "SRC_B_CONTENT";\n');
+  });
+
+  afterEach(async () => {
+    await fs.rm(rootParent, { recursive: true, force: true });
+    await fs.rm(outputDir, { recursive: true, force: true });
+  });
+
+  it('single root: drops src content via `src/**` while keeping it in the directory tree', async () => {
+    const config = buildConfig(rootParent, outputPath);
+    const result = await runPack([rootApp], config);
+    const output = await fs.readFile(outputPath, 'utf-8');
+
+    // The src file is excluded from the content output; only the README remains.
+    expect(result.processedFiles.map((f) => f.path).sort()).toEqual(['README.md']);
+    expect(output).toContain('README_A_CONTENT');
+    expect(output).not.toContain('SRC_A_CONTENT');
+    // ...but the src file still appears in the directory structure.
+    expect(output).toContain('index.ts');
+  });
+
+  it('multiple roots: `src/**` matches per-root without a root-label prefix', async () => {
+    const config = buildConfig(rootParent, outputPath);
+    const result = await runPack([rootApp, rootLib], config);
+    const output = await fs.readFile(outputPath, 'utf-8');
+
+    // Even though the display paths are `app/src/index.ts` and `lib/src/index.ts`,
+    // the bare `src/**` pattern matches each root's per-root-relative path, so
+    // BOTH src files are dropped from the content output.
+    expect(result.processedFiles.map((f) => f.path).sort()).toEqual(['app/README.md', 'lib/README.md']);
+    expect(output).toContain('README_A_CONTENT');
+    expect(output).toContain('README_B_CONTENT');
+    expect(output).not.toContain('SRC_A_CONTENT');
+    expect(output).not.toContain('SRC_B_CONTENT');
+    // Both src files still appear in the per-root directory structure.
+    expect(output).toContain('index.ts');
+  });
+
+  it('cwd-relative file path style: matching is unaffected by the shifted display path', async () => {
+    const config = buildConfig(rootParent, outputPath, { filePathStyle: 'cwd-relative' });
+    const result = await runPack([rootApp], config);
+    const output = await fs.readFile(outputPath, 'utf-8');
+
+    // The display path is `app/src/index.ts` (cwd-relative), but `src/**` still
+    // matches the per-root-relative `src/index.ts`, so the src file is dropped.
+    expect(result.processedFiles.map((f) => f.path).sort()).toEqual(['app/README.md']);
+    expect(output).toContain('README_A_CONTENT');
+    expect(output).not.toContain('SRC_A_CONTENT');
+    expect(output).toContain('index.ts');
+  });
+});

--- a/tests/core/packager/multiRootSpec.test.ts
+++ b/tests/core/packager/multiRootSpec.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mergeConfigs } from '../../../src/config/configLoad.js';
 import type { RepomixConfigFile, RepomixConfigMerged, RepomixOutputStyle } from '../../../src/config/configSchema.js';
 import { collectFiles } from '../../../src/core/file/fileCollect.js';
+import { resolveFileLevel } from '../../../src/core/file/fileLevelResolve.js';
 import { readRawFile } from '../../../src/core/file/fileRead.js';
 import { searchFiles } from '../../../src/core/file/fileSearch.js';
 import type { ProcessedFile } from '../../../src/core/file/fileTypes.js';
@@ -61,7 +62,8 @@ const runPack = (rootDirs: string[], config: RepomixConfigMerged) =>
     processFiles: async (rawFiles, cfg) => {
       const processedFiles: ProcessedFile[] = [];
       for (const rawFile of rawFiles) {
-        processedFiles.push(await fileProcessWorker({ rawFile, config: cfg }));
+        const level = resolveFileLevel(rawFile.path, cfg.output);
+        processedFiles.push(await fileProcessWorker({ rawFile, config: cfg, level }));
       }
       return processedFiles;
     },

--- a/tests/core/security/securityScanSpec.test.ts
+++ b/tests/core/security/securityScanSpec.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mergeConfigs } from '../../../src/config/configLoad.js';
 import type { RepomixConfigFile, RepomixConfigMerged, RepomixOutputStyle } from '../../../src/config/configSchema.js';
 import { collectFiles } from '../../../src/core/file/fileCollect.js';
+import { resolveFileLevel } from '../../../src/core/file/fileLevelResolve.js';
 import { readRawFile } from '../../../src/core/file/fileRead.js';
 import { searchFiles } from '../../../src/core/file/fileSearch.js';
 import type { ProcessedFile } from '../../../src/core/file/fileTypes.js';
@@ -66,7 +67,8 @@ const runPack = async (rootDir: string, config: RepomixConfigMerged) =>
     processFiles: async (rawFiles, cfg) => {
       const processedFiles: ProcessedFile[] = [];
       for (const rawFile of rawFiles) {
-        processedFiles.push(await fileProcessWorker({ rawFile, config: cfg }));
+        const level = resolveFileLevel(rawFile.path, cfg.output);
+        processedFiles.push(await fileProcessWorker({ rawFile, config: cfg, level }));
       }
       return processedFiles;
     },

--- a/tests/integration-tests/packager.test.ts
+++ b/tests/integration-tests/packager.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { loadFileConfig, mergeConfigs } from '../../src/config/configLoad.js';
 import type { RepomixConfigFile, RepomixConfigMerged, RepomixOutputStyle } from '../../src/config/configSchema.js';
 import { collectFiles } from '../../src/core/file/fileCollect.js';
+import { resolveFileLevel } from '../../src/core/file/fileLevelResolve.js';
 import { readRawFile } from '../../src/core/file/fileRead.js';
 import { searchFiles } from '../../src/core/file/fileSearch.js';
 import type { ProcessedFile } from '../../src/core/file/fileTypes.js';
@@ -100,7 +101,8 @@ describe.runIf(!isWindows)('packager integration', () => {
         processFiles: async (rawFiles, config, _progressCallback) => {
           const processedFiles: ProcessedFile[] = [];
           for (const rawFile of rawFiles) {
-            processedFiles.push(await fileProcessWorker({ rawFile, config }));
+            const level = resolveFileLevel(rawFile.path, config.output);
+            processedFiles.push(await fileProcessWorker({ rawFile, config, level }));
           }
           return processedFiles;
         },

--- a/website/client/src/en/guide/configuration.md
+++ b/website/client/src/en/guide/configuration.md
@@ -96,6 +96,7 @@ JavaScript configuration files work the same as TypeScript, supporting `defineCo
 | `output.filePathStyle`           | How file paths are shown in output (`target-relative` keeps paths relative to each target root, `cwd-relative` keeps paths relative to the current working directory) | `"target-relative"`    |
 | `output.parsableStyle`           | Whether to escape the output based on the chosen style schema. Enables better parsing but may increase token count           | `false`                |
 | `output.compress`                | Whether to perform intelligent code extraction using Tree-sitter to reduce token count while preserving structure             | `false`                |
+| `output.patterns`                | Per-file inclusion levels. An ordered array of `{ pattern, compress?, directoryStructureOnly? }` entries; the first matching glob wins and overrides the global `output.compress` for that file. See [Per-file Inclusion Levels](#per-file-inclusion-levels) | Not set                |
 | `output.headerText`              | Custom text to include in the file header. Useful for providing context or instructions for AI tools                         | `null`                 |
 | `output.instructionFilePath`     | Path to a file containing detailed custom instructions for AI processing                                                     | `null`                 |
 | `output.fileSummary`             | Whether to include a summary section at the beginning showing file counts, sizes, and other metrics                          | `true`                 |
@@ -170,6 +171,10 @@ Here's an example of a complete configuration file (`repomix.config.json`):
     "removeEmptyLines": false,
     "topFilesLength": 5,
     "showLineNumbers": false,
+    // "patterns": [
+    //   { "pattern": "docs/**/*", "compress": true },
+    //   { "pattern": "website/**/*", "directoryStructureOnly": true }
+    // ],
     "truncateBase64": false,
     "copyToClipboard": false,
     "includeEmptyDirectories": false,
@@ -329,6 +334,37 @@ Key benefits:
 - Removes function bodies and implementation details
 
 For more details and examples, see the [Code Compression Guide](code-compress).
+
+### Per-file Inclusion Levels
+
+While `output.compress` applies a single level to every file, `output.patterns` lets you control the detail level **per glob** from your configuration file. Each entry targets files by glob (matched the same way as `include`/`ignore`) and overrides the global `output.compress` setting for matching files.
+
+```json5
+{
+  "output": {
+    "compress": false, // global default acts as the catch-all
+    "patterns": [
+      { "pattern": "docs/**/*", "compress": true },
+      { "pattern": "website/**/*", "directoryStructureOnly": true }
+    ]
+  }
+}
+```
+
+Each file resolves to one of three levels:
+
+- **Full content** (default): the file's full content is included.
+- **Compressed** (`compress: true`): the content is passed through the same Tree-sitter pipeline as `output.compress`.
+- **Directory-structure-only** (`directoryStructureOnly: true`): the file is listed in the directory structure, but its content block is omitted from the output entirely.
+
+The rules:
+
+- Patterns are evaluated in array order and the **first matching pattern wins** for a given file.
+- A matched pattern's flags override the global `output.compress` setting. A pattern that matches without setting a flag forces **full content** for that file, which is handy for whitelisting files out of a global `compress`.
+- `directoryStructureOnly` takes precedence over `compress` when both are set on the same pattern.
+- If no pattern matches, the global behavior applies (full content, or compressed when `output.compress` is `true`).
+
+This option is config-file only; there is no equivalent CLI flag.
 
 ### Git Integration
 


### PR DESCRIPTION
## Summary

Implements per-file **inclusion levels** for the packed output, as proposed and designed in #608. A new optional `output.patterns` array in the config lets you control each file's detail level on a per-glob basis, with three levels:

- **Full content** (default) — current behavior.
- **Compressed** (`compress: true`) — runs the file through the existing `--compress` / Tree-sitter pipeline.
- **Directory-structure-only** (`directoryStructureOnly: true`) — the file is listed in the directory structure, but its content block is omitted.

```json5
{
  "output": {
    "compress": false,            // global default acts as the catch-all
    "patterns": [
      { "pattern": "docs/**/*", "compress": true },
      { "pattern": "website/**/*", "directoryStructureOnly": true }
    ]
  }
}
```

This follows the `output.patterns` design agreed in the issue thread.

### Semantics

- Patterns are evaluated in array order; the **first matching pattern wins** for a file.
- A matched pattern's flags **override** the global `output.compress` for that file. `directoryStructureOnly` takes precedence over `compress`. A matched pattern with no flags forces full content (useful for whitelisting files out of a global `compress`).
- If no pattern matches, the existing global behavior applies (full content, or compressed when `output.compress` is `true`).
- **Backward compatible** — configs without `patterns` behave exactly as before.
- `output.patterns` only affects *how* a collected file is rendered; `include`/`ignore` still decide *whether* a file is collected.

### Implementation notes

- New pure helper `resolveFileLevel(filePath, output)` → `'full' | 'compress' | 'directory-only'`, centralising the first-match-wins logic. Globs are matched with `minimatch({ dot: true })`, the same way `fileSearch` matches ignore patterns — no new dependency.
- `processFiles` resolves each file's level once: directory-only files are dropped from the content output, while their paths still feed the directory tree (the tree is built from the file-search results, not from `processedFiles` — the same mechanism the existing suspicious-file filter relies on). This covers the empty/directory edge case raised in the thread: a directory whose files are all directory-only still appears in the structure.
- Compression is routed per file, so a `compress` pattern works even when global `compress` is off. The `showLineNumbers` suppression and the "content has been compressed" header note are likewise per-file/per-pattern aware.
- `output.patterns` is added to the config schema (valibot) and validated strictly (`pattern` required string; `compress`/`directoryStructureOnly` optional booleans).

### Tests

- `tests/core/file/fileLevelResolve.test.ts` — resolver units: ordering, three levels, no-patterns backward-compat, override, dotfiles, posix path matching.
- `tests/core/file/fileProcess.inclusionLevel.test.ts` — pipeline wiring: directory-only exclusion, per-pattern compress with global off, global-compress override, line-number suppression.
- `tests/core/output/inclusionLevelOutput.test.ts` — end-to-end: a directory-only file (and a directory whose files are all directory-only) appears in the tree with content omitted.
- Additions to `tests/config/configSchema.test.ts`, `tests/config/configLoad.test.ts`, `tests/core/output/outputStyleDecorate.test.ts`.
- Full suite: 1422 passed, 10 skipped, 0 failed. `npm run lint` clean (biome, oxlint, tsgo, secretlint).

### Notes / scope

- Config-file only; no CLI flag (per the agreed design).
- English docs updated (`README.md`, `website/client/src/en/guide/configuration.md`); other locales can be translated separately.
- The versioned JSON schemas under `website/client/src/public/schemas/` are release-time artifacts generated from the file schema, so they're left untouched here and will pick up `patterns` on the next `website-generate-schema` run.
- Intentionally out of scope (later ideas in the thread): MCP packing scenarios, and per-pattern control of other options like `removeComments` (the schema is structured to allow adding these later).

Resolves #608.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
