### PR TITLE
docs: Reframe the 250-line rule as a cohesion-review signal

### DIFF
--- a/.agents/rules/base.md
+++ b/.agents/rules/base.md
@@ -43,7 +43,10 @@ repomix/
 
 - Follow the project's coding standards enforced by Biome (`biome.json`)
 - Maintain feature-based directory structure and avoid dependencies between features
-- Split files exceeding 250 lines into multiple files based on functionality
+- Keep each file focused on a single responsibility
+- Treat ~250 lines as a signal to review a file's cohesion, not a mandate to split:
+  split when the file mixes multiple responsibilities, but leave it as-is when the
+  length comes from one cohesive concern (e.g. large data/config tables)
 - Add comments in English where non-obvious logic exists
 - Provide corresponding unit tests for new features
 - Verify changes by running:


### PR DESCRIPTION
Reframe the file-size guideline in `CLAUDE.md` (`.agents/rules/base.md`) from a mechanical "split files exceeding 250 lines" mandate into a single-responsibility principle, where ~250 lines is a signal to review cohesion rather than an order to split.

In this repo most files cluster around 88 lines (median); 250 lines is already the top ~13% of files, so it works well as a review threshold. But a hard line-count rule misfires on cohesive, data-heavy files (e.g. `skillTechStack.ts` at 678 lines), which should stay intact. This change leads with the single-responsibility intent and notes the exception for one-concern files like large data/config tables.

## Checklist

- [ ] Run \`npm run test\`
- [ ] Run \`npm run lint\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)