### PR TITLE
fix(core): fall back to uncompressed content when tree-sitter compression fails

### DIFF
--- a/src/core/file/fileProcessContent.ts
+++ b/src/core/file/fileProcessContent.ts
@@ -35,16 +35,20 @@ export const processContent = async (
   // output.patterns overrides and the global output.compress setting.
   const effectiveLevel = level ?? resolveFileLevel(rawFile.path, config.output);
   if (effectiveLevel === 'compress') {
+    // Compression is best-effort. parseFile returns undefined when it cannot
+    // compress a file (unsupported language, parse failure, or a tree-sitter
+    // WASM abort on a pathological file); in that case we keep the uncompressed
+    // content so a single file's failure never aborts the entire pack. The
+    // catch is a safety net: parseFile is designed not to throw.
     try {
       const parsedContent = await parseFile(processedContent, rawFile.path, config);
       if (parsedContent === undefined) {
-        logger.trace(`Failed to parse ${rawFile.path} in compressed mode. Using original content.`);
+        logger.trace(`Could not compress ${rawFile.path}. Using uncompressed content.`);
       }
       processedContent = parsedContent ?? processedContent;
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
-      logger.error(`Error parsing ${rawFile.path} in compressed mode: ${message}`);
-      throw error;
+      logger.warn(`Error compressing ${rawFile.path}, using uncompressed content: ${message}`);
     }
   }
 

--- a/src/core/file/fileProcessContent.ts
+++ b/src/core/file/fileProcessContent.ts
@@ -48,7 +48,7 @@ export const processContent = async (
       processedContent = parsedContent ?? processedContent;
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
-      logger.warn(`Error compressing ${rawFile.path}, using uncompressed content: ${message}`);
+      logger.warn(`Failed to compress ${rawFile.path}, using uncompressed content: ${message}`);
     }
   }
 

--- a/src/core/treeSitter/parseFile.ts
+++ b/src/core/treeSitter/parseFile.ts
@@ -34,7 +34,6 @@ let languageParserSingleton: LanguageParser | null = null;
 
 export const CHUNK_SEPARATOR = '⋮----';
 
-// TODO: Do something with config: RepomixConfigMerged, it is not used (yet)
 // Compression is best-effort: this function never throws. On any failure it
 // returns undefined so callers can fall back to the uncompressed content. This
 // matters because tree-sitter runs on WASM, where a pathological file can
@@ -109,6 +108,14 @@ export const parseFile = async (
   } catch (error: unknown) {
     // Any failure here (language preparation, parsing, or a WASM runtime abort)
     // degrades to uncompressed content instead of aborting the whole pack.
+    //
+    // Note on hard WASM aborts (e.g. "table index is out of bounds"): such an
+    // abort can leave this worker's shared tree-sitter runtime degraded. The
+    // parser singleton is reused for the worker's lifetime, so later files routed
+    // to the same worker may also fall back to uncompressed output. This is
+    // bounded per worker and surfaced by the warning below. Recovering the
+    // runtime would require recycling the worker, which is out of scope here; the
+    // init-failure path is already retried by getLanguageParserSingleton.
     const message = error instanceof Error ? error.message : String(error);
     logger.warn(`Failed to compress ${filePath}, using uncompressed content: ${message}`);
     return undefined;

--- a/src/core/treeSitter/parseFile.ts
+++ b/src/core/treeSitter/parseFile.ts
@@ -48,9 +48,6 @@ export const parseFile = async (
 ): Promise<string | undefined> => {
   // Split the file content into individual lines
   const lines = fileContent.split('\n');
-  if (lines.length < 1) {
-    return '';
-  }
 
   try {
     const languageParser = await getLanguageParserSingleton();

--- a/src/core/treeSitter/parseFile.ts
+++ b/src/core/treeSitter/parseFile.ts
@@ -35,27 +35,37 @@ let languageParserSingleton: LanguageParser | null = null;
 export const CHUNK_SEPARATOR = '⋮----';
 
 // TODO: Do something with config: RepomixConfigMerged, it is not used (yet)
-export const parseFile = async (fileContent: string, filePath: string, config: RepomixConfigMerged) => {
-  const languageParser = await getLanguageParserSingleton();
-
+// Compression is best-effort: this function never throws. On any failure it
+// returns undefined so callers can fall back to the uncompressed content. This
+// matters because tree-sitter runs on WASM, where a pathological file can
+// trigger a runtime abort; without this, a single bad file would crash the
+// whole pack. The success path is fully wrapped so a partially-built result is
+// never returned on error.
+export const parseFile = async (
+  fileContent: string,
+  filePath: string,
+  config: RepomixConfigMerged,
+): Promise<string | undefined> => {
   // Split the file content into individual lines
   const lines = fileContent.split('\n');
   if (lines.length < 1) {
     return '';
   }
 
-  const lang: SupportedLang | undefined = languageParser.guessTheLang(filePath);
-  if (lang === undefined) {
-    // Language not supported
-    return undefined;
-  }
-
-  const query = await languageParser.getQueryForLang(lang);
-  const parser = await languageParser.getParserForLang(lang);
-  const processedChunks = new Set<string>();
-  const capturedChunks: CapturedChunk[] = [];
-
   try {
+    const languageParser = await getLanguageParserSingleton();
+
+    const lang: SupportedLang | undefined = languageParser.guessTheLang(filePath);
+    if (lang === undefined) {
+      // Language not supported: fall back to uncompressed content quietly.
+      return undefined;
+    }
+
+    const query = await languageParser.getQueryForLang(lang);
+    const parser = await languageParser.getParserForLang(lang);
+    const processedChunks = new Set<string>();
+    const capturedChunks: CapturedChunk[] = [];
+
     // Parse the file content into an Abstract Syntax Tree (AST)
     const tree = parser.parse(fileContent);
     if (!tree) {
@@ -91,23 +101,32 @@ export const parseFile = async (fileContent: string, filePath: string, config: R
         });
       }
     }
+
+    const filteredChunks = filterDuplicatedChunks(capturedChunks);
+    const mergedChunks = mergeAdjacentChunks(filteredChunks);
+
+    return mergedChunks
+      .map((chunk) => chunk.content)
+      .join(`\n${CHUNK_SEPARATOR}\n`)
+      .trim();
   } catch (error: unknown) {
-    logger.log(`Error parsing file: ${error}\n`);
+    // Any failure here (language preparation, parsing, or a WASM runtime abort)
+    // degrades to uncompressed content instead of aborting the whole pack.
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn(`Failed to compress ${filePath}, using uncompressed content: ${message}`);
+    return undefined;
   }
-
-  const filteredChunks = filterDuplicatedChunks(capturedChunks);
-  const mergedChunks = mergeAdjacentChunks(filteredChunks);
-
-  return mergedChunks
-    .map((chunk) => chunk.content)
-    .join(`\n${CHUNK_SEPARATOR}\n`)
-    .trim();
 };
 
 const getLanguageParserSingleton = async () => {
   if (!languageParserSingleton) {
-    languageParserSingleton = new LanguageParser();
-    await languageParserSingleton.init();
+    // Assign only after init() succeeds. Otherwise a failed init would leave an
+    // uninitialized parser cached for the rest of the worker's lifetime, so
+    // every subsequent file would throw "not initialized" and silently lose
+    // compression. Keeping the singleton null lets the next call retry init.
+    const parser = new LanguageParser();
+    await parser.init();
+    languageParserSingleton = parser;
   }
   return languageParserSingleton;
 };

--- a/tests/core/file/fileProcessContent.test.ts
+++ b/tests/core/file/fileProcessContent.test.ts
@@ -98,7 +98,10 @@ describe('processContent', () => {
     expect(result).toBe(rawFile.content);
   });
 
-  it('should handle Tree-sitter parse error', async () => {
+  it('should fall back to uncompressed content when parseFile throws', async () => {
+    // Safety net: even though parseFile is designed not to throw, a thrown error
+    // (e.g. a tree-sitter WASM abort) must not abort the whole pack. The file
+    // degrades to its uncompressed content instead.
     const rawFile: RawFile = {
       path: 'test.ts',
       content: 'const x = 1;\nconst y = 2;',
@@ -115,7 +118,31 @@ describe('processContent', () => {
     const error = new Error('Parse error');
     vi.mocked(parseFile).mockRejectedValue(error);
 
-    await expect(processContent(rawFile, config)).rejects.toThrow('Parse error');
+    const result = await processContent(rawFile, config);
+    expect(result).toBe(rawFile.content);
+  });
+
+  it('should fall back to comment-stripped content when compression fails after removeComments', async () => {
+    const rawFile: RawFile = {
+      path: 'test.ts',
+      content: 'const x = 1; // comment\nconst y = 2;',
+    };
+    const config: RepomixConfigMerged = {
+      output: {
+        removeComments: true,
+        removeEmptyLines: false,
+        compress: true,
+        showLineNumbers: false,
+      },
+    } as RepomixConfigMerged;
+
+    // Compression fails, so the fallback should be the already comment-stripped
+    // content (the best available content at this stage), not the raw original.
+    vi.mocked(parseFile).mockResolvedValue(undefined);
+
+    const result = await processContent(rawFile, config);
+    expect(mockManipulator.removeComments).toHaveBeenCalledWith(rawFile.content);
+    expect(result).toBe('const x = 1; \nconst y = 2;');
   });
 
   it('should handle files without a manipulator', async () => {

--- a/tests/core/treeSitter/parseFile.errorHandling.test.ts
+++ b/tests/core/treeSitter/parseFile.errorHandling.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanupLanguageParser, parseFile } from '../../../src/core/treeSitter/parseFile.js';
+import { logger } from '../../../src/shared/logger.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+// A single mock LanguageParser instance reused via the module singleton in
+// parseFile.ts. Each test reconfigures its methods to simulate failures at
+// different stages of the compression pipeline.
+const mockParser = {
+  init: vi.fn(),
+  guessTheLang: vi.fn(),
+  getQueryForLang: vi.fn(),
+  getParserForLang: vi.fn(),
+  getStrategyForLang: vi.fn(),
+  dispose: vi.fn(),
+};
+
+vi.mock('../../../src/core/treeSitter/languageParser.js', () => ({
+  // A class so `new LanguageParser()` works; it delegates to the shared
+  // mockParser whose method behaviors each test reconfigures.
+  LanguageParser: class {
+    init = mockParser.init;
+    guessTheLang = mockParser.guessTheLang;
+    getQueryForLang = mockParser.getQueryForLang;
+    getParserForLang = mockParser.getParserForLang;
+    getStrategyForLang = mockParser.getStrategyForLang;
+    dispose = mockParser.dispose;
+  },
+}));
+
+vi.mock('../../../src/shared/logger.js', () => ({
+  logger: {
+    warn: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    log: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const makeTree = () => ({ rootNode: {} });
+const makeWorkingQuery = () => ({ captures: vi.fn().mockReturnValue([]) });
+const makeWorkingParser = () => ({ parse: vi.fn().mockReturnValue(makeTree()) });
+const makeWorkingStrategy = () => ({ parseCapture: vi.fn().mockReturnValue(null) });
+
+const config = createMockConfig({});
+
+describe('parseFile error handling', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Reset the module singleton so each test starts from a clean init() state.
+    mockParser.dispose.mockResolvedValue(undefined);
+    await cleanupLanguageParser();
+    vi.clearAllMocks();
+    // Working defaults; individual tests override one stage to make it fail.
+    mockParser.init.mockResolvedValue(undefined);
+    mockParser.guessTheLang.mockReturnValue('javascript');
+    mockParser.getQueryForLang.mockResolvedValue(makeWorkingQuery());
+    mockParser.getParserForLang.mockResolvedValue(makeWorkingParser());
+    mockParser.getStrategyForLang.mockResolvedValue(makeWorkingStrategy());
+  });
+
+  it('returns undefined (not an empty string) and warns when language preparation throws', async () => {
+    // Mirrors a tree-sitter WASM abort surfacing as a prepare-time error.
+    mockParser.getQueryForLang.mockRejectedValue(
+      new Error('Failed to prepare language cpp: table index is out of bounds'),
+    );
+
+    const result = await parseFile('int main() { return 0; }', 'main.cpp', config);
+
+    expect(result).toBeUndefined();
+    expect(result).not.toBe('');
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns undefined when the parser throws during parse', async () => {
+    mockParser.getParserForLang.mockResolvedValue({
+      parse: vi.fn(() => {
+        throw new Error('Aborted(). Build with -sASSERTIONS for more info.');
+      }),
+    });
+
+    const result = await parseFile('int main() { return 0; }', 'main.cpp', config);
+
+    expect(result).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns undefined when query.captures throws', async () => {
+    mockParser.getQueryForLang.mockResolvedValue({
+      captures: vi.fn(() => {
+        throw new Error('captures failed');
+      }),
+    });
+
+    const result = await parseFile('const x = 1;', 'main.js', config);
+
+    expect(result).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns undefined when the parse strategy throws', async () => {
+    const capture = { node: { startPosition: { row: 0 }, endPosition: { row: 0 } } };
+    mockParser.getQueryForLang.mockResolvedValue({ captures: vi.fn().mockReturnValue([capture]) });
+    mockParser.getStrategyForLang.mockResolvedValue({
+      parseCapture: vi.fn(() => {
+        throw new Error('strategy failed');
+      }),
+    });
+
+    const result = await parseFile('const x = 1;', 'main.js', config);
+
+    expect(result).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns undefined without warning for unsupported languages', async () => {
+    mockParser.guessTheLang.mockReturnValue(undefined);
+
+    const result = await parseFile('some content', 'file.unknown', config);
+
+    expect(result).toBeUndefined();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('returns the compressed string on the success path', async () => {
+    const capture = { node: { startPosition: { row: 0 }, endPosition: { row: 0 } } };
+    mockParser.getQueryForLang.mockResolvedValue({ captures: vi.fn().mockReturnValue([capture]) });
+    mockParser.getStrategyForLang.mockResolvedValue({
+      parseCapture: vi.fn().mockReturnValue('function foo()'),
+    });
+
+    const result = await parseFile('function foo() {}', 'foo.js', config);
+
+    expect(result).toBe('function foo()');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('retries initialization on the next call after a failed init', async () => {
+    // A failed init must not cache an uninitialized parser. The first call
+    // degrades to undefined; the next call re-attempts init and succeeds.
+    mockParser.init.mockRejectedValueOnce(new Error('init failed')).mockResolvedValue(undefined);
+    const capture = { node: { startPosition: { row: 0 }, endPosition: { row: 0 } } };
+    mockParser.getQueryForLang.mockResolvedValue({ captures: vi.fn().mockReturnValue([capture]) });
+    mockParser.getStrategyForLang.mockResolvedValue({
+      parseCapture: vi.fn().mockReturnValue('function foo()'),
+    });
+
+    const firstResult = await parseFile('function foo() {}', 'foo.js', config);
+    expect(firstResult).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+
+    const secondResult = await parseFile('function foo() {}', 'foo.js', config);
+    expect(secondResult).toBe('function foo()');
+    expect(mockParser.init).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/core/treeSitter/parseFile.errorHandling.test.ts
+++ b/tests/core/treeSitter/parseFile.errorHandling.test.ts
@@ -165,4 +165,23 @@ describe('parseFile error handling', () => {
     expect(secondResult).toBe('function foo()');
     expect(mockParser.init).toHaveBeenCalledTimes(2);
   });
+
+  it('reuses the initialized singleton across repeated post-init aborts (does not re-init per file)', async () => {
+    // The #1668 trigger is a post-init WASM abort surfacing during language
+    // preparation. init() has already succeeded, so the singleton is cached and
+    // reused: subsequent files degrade to uncompressed without re-running
+    // Parser.init(). This documents the bounded per-worker degradation; full
+    // runtime recovery would require recycling the worker.
+    mockParser.getQueryForLang.mockRejectedValue(
+      new Error('Failed to prepare language cpp: table index is out of bounds'),
+    );
+
+    const first = await parseFile('int main() { return 0; }', 'a.cpp', config);
+    const second = await parseFile('int main() { return 0; }', 'b.cpp', config);
+
+    expect(first).toBeUndefined();
+    expect(second).toBeUndefined();
+    expect(mockParser.init).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
 });

--- a/tests/core/treeSitter/parseFile.errorHandling.test.ts
+++ b/tests/core/treeSitter/parseFile.errorHandling.test.ts
@@ -114,6 +114,17 @@ describe('parseFile error handling', () => {
     expect(logger.warn).toHaveBeenCalledTimes(1);
   });
 
+  it('returns an empty string (not undefined) when a parseable file yields no captures', async () => {
+    // Contract boundary: '' means "compressed to nothing, keep it" while
+    // undefined means "could not compress, fall back". The default mock yields
+    // zero captures, exercising the success-with-empty-result path; the caller
+    // preserves '' via `parsedContent ?? processedContent`.
+    const result = await parseFile('const x = 1;', 'main.js', config);
+
+    expect(result).toBe('');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
   it('returns undefined without warning when the parser yields no tree', async () => {
     // parser.parse() can return null; this is an expected non-result, logged at
     // debug level (not warn), and falls back to uncompressed content.

--- a/tests/core/treeSitter/parseFile.errorHandling.test.ts
+++ b/tests/core/treeSitter/parseFile.errorHandling.test.ts
@@ -114,6 +114,17 @@ describe('parseFile error handling', () => {
     expect(logger.warn).toHaveBeenCalledTimes(1);
   });
 
+  it('returns undefined without warning when the parser yields no tree', async () => {
+    // parser.parse() can return null; this is an expected non-result, logged at
+    // debug level (not warn), and falls back to uncompressed content.
+    mockParser.getParserForLang.mockResolvedValue({ parse: vi.fn().mockReturnValue(null) });
+
+    const result = await parseFile('const x = 1;', 'main.js', config);
+
+    expect(result).toBeUndefined();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
   it('returns undefined without warning for unsupported languages', async () => {
     mockParser.guessTheLang.mockReturnValue(undefined);
 


### PR DESCRIPTION
## Summary

Fixes #1668.

When packing with `--compress`, a single file that tree-sitter cannot parse could abort the **entire** pack. On a pathological C++ file the web-tree-sitter (WASM) runtime calls `Aborted()` ("table index is out of bounds"), which surfaced as `Failed to prepare language cpp` and crashed the whole run:

```
Error during file processing: RepomixError: Failed to prepare language cpp: table index is out of bounds
✖ Error during packing
```

Compression is a best-effort optimization, so one bad file should degrade gracefully to uncompressed output rather than failing everything.

## Changes

- **`parseFile.ts`** — `parseFile` is now a non-throwing best-effort API returning `string | undefined`. The whole success path (language preparation, parsing, captures, strategy, chunk assembly) is wrapped in a single `try`; on any error it logs a warning and returns `undefined` so the caller falls back to the uncompressed content. A partially-built result is never returned on error (previously a caught parse error fell through and could return an empty string). Unsupported languages still return `undefined` quietly.
- **`fileProcessContent.ts`** — the compress path no longer rethrows on failure; it warns and keeps the uncompressed (optionally comment-stripped) content. The `catch` remains as a safety net.
- **`getLanguageParserSingleton()`** — the parser singleton is now cached only after `init()` succeeds, so a failed init can be retried on the next call instead of caching a broken instance that would silently disable compression for the rest of the worker. (Latent bug surfaced once failures stopped crashing the pack.)
- **Tests** — added `parseFile.errorHandling.test.ts` covering prepare/parse/captures/strategy failures (each falls back to `undefined`, not `''`), the unsupported-language quiet path, the success path, and init retry-after-failure. Updated `fileProcessContent.test.ts` so a thrown `parseFile` now falls back to the uncompressed content (and comment-stripped content when `removeComments` is on) instead of rethrowing.

## Behavior

A file that fails to compress is now emitted **uncompressed** with a warning; all other files compress normally and the pack completes.

## Checklist

- [x] Run `npm run test` — 1479 passed
- [x] Run `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
