### PR TITLE
fix(core): free web-tree-sitter Tree after parsing to avoid WASM heap leak

### DIFF
--- a/src/core/treeSitter/parseFile.ts
+++ b/src/core/treeSitter/parseFile.ts
@@ -18,6 +18,7 @@
  * The performance overhead of WASM is acceptable for the compress feature's use case.
  */
 
+import type { Tree } from 'web-tree-sitter';
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
 import type { SupportedLang } from './languageConfig.js';
@@ -48,6 +49,7 @@ export const parseFile = async (
   // Split the file content into individual lines
   const lines = fileContent.split('\n');
 
+  let tree: Tree | null | undefined;
   try {
     const languageParser = await getLanguageParserSingleton();
 
@@ -63,7 +65,7 @@ export const parseFile = async (
     const capturedChunks: CapturedChunk[] = [];
 
     // Parse the file content into an Abstract Syntax Tree (AST)
-    const tree = parser.parse(fileContent);
+    tree = parser.parse(fileContent);
     if (!tree) {
       logger.debug(`Failed to parse file: ${filePath}`);
       return undefined;
@@ -119,6 +121,8 @@ export const parseFile = async (
     const message = error instanceof Error ? error.message : String(error);
     logger.warn(`Failed to compress ${filePath}, using uncompressed content: ${message}`);
     return undefined;
+  } finally {
+    tree?.delete();
   }
 };
 

--- a/tests/core/treeSitter/parseFile.errorHandling.test.ts
+++ b/tests/core/treeSitter/parseFile.errorHandling.test.ts
@@ -38,7 +38,10 @@ vi.mock('../../../src/shared/logger.js', () => ({
   },
 }));
 
-const makeTree = () => ({ rootNode: {}, delete: vi.fn() });
+// Shared mock tree so tests can assert tree.delete() is invoked for WASM cleanup.
+// vi.clearAllMocks() in beforeEach resets its call history between tests.
+const mockTree = { rootNode: {}, delete: vi.fn() };
+const makeTree = () => mockTree;
 const makeWorkingQuery = () => ({ captures: vi.fn().mockReturnValue([]) });
 const makeWorkingParser = () => ({ parse: vi.fn().mockReturnValue(makeTree()) });
 const makeWorkingStrategy = () => ({ parseCapture: vi.fn().mockReturnValue(null) });
@@ -112,6 +115,8 @@ describe('parseFile error handling', () => {
 
     expect(result).toBeUndefined();
     expect(logger.warn).toHaveBeenCalledTimes(1);
+    // The tree was created before the strategy threw, so it must still be freed.
+    expect(mockTree.delete).toHaveBeenCalledTimes(1);
   });
 
   it('returns an empty string (not undefined) when a parseable file yields no captures', async () => {
@@ -156,6 +161,8 @@ describe('parseFile error handling', () => {
 
     expect(result).toBe('function foo()');
     expect(logger.warn).not.toHaveBeenCalled();
+    // The parsed tree is freed on the success path too.
+    expect(mockTree.delete).toHaveBeenCalledTimes(1);
   });
 
   it('retries initialization on the next call after a failed init', async () => {

--- a/tests/core/treeSitter/parseFile.errorHandling.test.ts
+++ b/tests/core/treeSitter/parseFile.errorHandling.test.ts
@@ -38,7 +38,7 @@ vi.mock('../../../src/shared/logger.js', () => ({
   },
 }));
 
-const makeTree = () => ({ rootNode: {} });
+const makeTree = () => ({ rootNode: {}, delete: vi.fn() });
 const makeWorkingQuery = () => ({ captures: vi.fn().mockReturnValue([]) });
 const makeWorkingParser = () => ({ parse: vi.fn().mockReturnValue(makeTree()) });
 const makeWorkingStrategy = () => ({ parseCapture: vi.fn().mockReturnValue(null) });


### PR DESCRIPTION
## Summary

During `--compress`, `parseFile` calls `parser.parse(fileContent)` (web-tree-sitter), which allocates a `Tree` in the WASM linear heap. web-tree-sitter `Tree` objects hold native WASM memory that is only reclaimed by an explicit `.delete()` — the same pattern already used by `LanguageParser.dispose()` for `Parser` objects. The `Tree` was never deleted, so every compressed file leaked one tree for the worker's lifetime (up to `TASKS_PER_THREAD` files per worker before recycling).

## Changes

- `src/core/treeSitter/parseFile.ts`: hoist the `tree` declaration before the `try` block so a `finally` clause can always call `tree?.delete()`. This covers the success path, the early-return path when `parse()` returns `null`, and any exception path. Typed as `Tree | null | undefined` (no `any`). Captured chunks are plain strings copied before `finally` runs, so deleting the tree afterwards is safe.
- `tests/core/treeSitter/parseFile.errorHandling.test.ts`: add `delete: vi.fn()` to the `makeTree()` mock so it satisfies the `Tree` contract.

## How was this tested

- `npx vitest run tests/core/treeSitter/` — 105 tests pass.
- `npm run lint-ts` (tsgo) and `npm run lint-biome` — pass.
- Ran the built CLI with `--compress` on a sample TypeScript file and confirmed the compressed output is unchanged (function/class signatures kept, bodies stripped, `⋮----` delimiters) and the process exits 0 — the new `finally` cleanup path does not regress compression.

Fixes #1680
