### PR TITLE
ci(schema): Use GITHUB_TOKEN instead of COMMITTER_TOKEN for schema PR

### DIFF
--- a/.github/workflows/schema-update.yml
+++ b/.github/workflows/schema-update.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   # Serialize all runs so concurrent triggers (a main push plus a
@@ -36,11 +37,17 @@ jobs:
       # schema back to a PR branch (the previous behavior) left the PR head on a
       # GITHUB_TOKEN-authored commit, which does not trigger CI and blocked merge.
       # Direct pushes to main are blocked by the branch ruleset, so the
-      # regenerated schema is delivered as this PR instead. COMMITTER_TOKEN is
-      # used so the PR triggers CI and is mergeable.
+      # regenerated schema is delivered as this PR instead.
+      #
+      # GITHUB_TOKEN is used (no PAT). A PR opened by GITHUB_TOKEN does not start
+      # further workflow runs, so CI does not run on the schema PR -- but the main
+      # ruleset requires no status checks (only review + code owner approval), so
+      # the PR is still mergeable after approval. This requires the repository
+      # setting "Allow GitHub Actions to create and approve pull requests" to be
+      # enabled (Settings > Actions > General > Workflow permissions).
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.COMMITTER_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           base: main
           commit-message: 'chore(schema): Auto-generate schema'
           branch: chore/schema-update


### PR DESCRIPTION
Replaces the expired personal access token (`COMMITTER_TOKEN`) in the Update Schema workflow with the built-in `GITHUB_TOKEN`, so schema-update PRs no longer depend on a long-lived PAT.

## Background

The `Update Schema` workflow has been failing on every run since ~2026-06-05 (e.g. [run #28378813251](https://github.com/yamadashy/repomix/actions/runs/28378813251)). Schema generation itself succeeds; the failure is only in the final `peter-evans/create-pull-request` step:

```
git push --force-with-lease origin chore/schema-update:...
fatal: could not read Username for 'https://github.com': No such device or address
The process '/usr/bin/git' failed with exit code 128
```

The auth header is set (`AUTHORIZATION: basic ***`) but the push is rejected — the classic symptom of an **expired/revoked PAT**. `COMMITTER_TOKEN` was originally created (2024-10) for the Homebrew formula auto-bump workflow, which pushed to an external repo and genuinely needed a cross-repo PAT. That workflow has since been removed (#1676), and the schema-update workflow reused the leftover token by inertia.

## Why GITHUB_TOKEN works here

The original rationale for using a PAT was that a `GITHUB_TOKEN`-authored PR does not trigger CI, which was assumed to block merge. However, the `main` ruleset requires **no status checks** — only review + code owner approval — so the schema PR is mergeable after approval regardless of whether CI runs on it.

## Changes

- Switch the `create-pull-request` token from `COMMITTER_TOKEN` to `GITHUB_TOKEN`
- Add `pull-requests: write` to the workflow permissions
- Update the explanatory comment

Also enabled the repository setting **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** (required for `GITHUB_TOKEN` to open the PR; `default_workflow_permissions` left at `read`).

## Follow-ups

- The now-unused `COMMITTER_TOKEN` secret can be deleted.
- Schema delivery for `1.16.0` + `latest` will auto-recover on the next push to `main` after this merges. Historical `1.15.x` schema dirs remain missing and can be backfilled separately if needed.

## Checklist

- [ ] Run `npm run test` — n/a (CI workflow YAML only)
- [ ] Run `npm run lint` — n/a (CI workflow YAML only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)