### PR TITLE
chore(ci): Ignore adhoc-packages zizmor findings for intentional installs

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -12,3 +12,10 @@ rules:
       - claude-issue-similar.yml
       - claude-issue-triage.yml
       - claude.yml
+  adhoc-packages:
+    ignore:
+      # Installing repomix at a user-specified version is this action's core function,
+      # so it cannot go through a lockfile
+      - action.yml
+      # Intentional: update npm itself to latest before publishing
+      - npm-publish.yml


### PR DESCRIPTION
The zizmor v0.5.7 bump (#1692) introduced the new `adhoc-packages` audit, which flags package installs that don't go through a lockfile. It detected two spots and turned CI Quality red on main:

- `.github/actions/repomix/action.yml:66` — `npm install --global "repomix@${REPOMIX_VERSION}"`. Installing repomix at a user-specified version is this action's core function, so a lockfile-based install is impossible here.
- `.github/workflows/npm-publish.yml:32` — `npm install -g npm@latest`. Intentionally updates npm itself before publishing.

Both are deliberate, so this adds file-level ignores for `adhoc-packages` to `.github/zizmor.yml`, following the existing `artipacked` / `secrets-outside-env` style.

Verified locally with `zizmor 1.26.1 --config .github/zizmor.yml .`: the old config reports exactly these 2 low findings, the new config reports none.

## Checklist

- [x] Run `npm run test` — N/A (CI config only; verified with a local zizmor run instead)
- [x] Run `npm run lint` — N/A (CI config only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)