### PR TITLE
chore(renovate): Extend schedule to full weekend window

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended",
   ],
-  "schedule": ["before 9am on saturday"],
+  "schedule": ["on saturday", "before 1pm on sunday"],
   "rangeStrategy": "bump",
   "dependencyDashboard": false,
   "labels": ["dependencies", "renovate"],


### PR DESCRIPTION
Extends the Renovate schedule from Saturday morning only (`before 9am on saturday`) to a full weekend window: `["on saturday", "before 1pm on sunday"]` (UTC), i.e. Saturday 9:00 through Sunday 22:00 JST.

The window is expressed in UTC rather than adding `timezone: "Asia/Tokyo"`, keeping the config locale-neutral. Note that `schedule` only gates when the hosted Renovate app may create PRs — actual runs follow Mend's crawl cadence within the window.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

(Config-only change; no code affected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)