### PR TITLE
docs(config): Restructure agent rules per Claude Code best practices

### DIFF
--- a/.agents/rules/base.md
+++ b/.agents/rules/base.md
@@ -13,7 +13,7 @@ Refer to `README.md` for full project overview and `CONTRIBUTING.md` for contrib
 
 - `src/` — main source code (`cli/`, `config/`, `core/`, `shared/`). Feature-based structure; avoid dependencies between features
 - `tests/` — mirrors the `src/` directory structure
-- `website/` — documentation website (VitePress); docs live in 15 language directories under `website/client/src/`
+- `website/` — documentation website (VitePress); docs live in 15 language directories (`en` + 14 translated locales) under `website/client/src/`
 - `browser/` — browser extension
 
 ## Coding Guidelines
@@ -40,6 +40,10 @@ Refer to `README.md` for full project overview and `CONTRIBUTING.md` for contrib
   directories under `website/client/src/`, not just `en`.
 - Root `npm run lint` does not typecheck the website client. When changing
   `website/client`, verify with `npm run docs:build` in that directory.
+- The VitePress build does not validate in-page anchor links; when renaming a
+  heading, search the docs for links to its old anchor.
+- GitHub Actions steps must be pinned to full commit SHAs with a version comment
+  (e.g. `uses: actions/checkout@<sha> # v7.0.0`); pinact and zizmor enforce this in CI.
 
 ## Commit Messages
 
@@ -55,6 +59,7 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/) with scope: 
 - Follow the template at `.github/pull_request_template.md`
 - Include a clear summary of changes at the top
 - Reference related issues using `#issue-number`
+- Combine small, related changes in the same area into one PR rather than splitting them
 
 ## Dependencies and Testing
 

--- a/.agents/rules/base.md
+++ b/.agents/rules/base.md
@@ -9,44 +9,20 @@ A tool that packs repository contents into a single AI-friendly file. Supports X
 
 Refer to `README.md` for full project overview and `CONTRIBUTING.md` for contribution procedures.
 
-## Directory Structure
+## Repository Layout
 
-```
-repomix/
-├── browser/ # Browser extension source code.
-├── src/ # Main source code
-│   ├── cli/ # Command-line interface logic (argument parsing, command handling, output)
-│   ├── config/ # Configuration loading, schema, and defaults
-│   ├── core/ # Core logic of Repomix
-│   │   ├── file/ # File handling (reading, processing, searching, tree structure generation, git commands)
-│   │   ├── metrics/ # Calculating code metrics (character count, token count)
-│   │   ├── output/ # Output generation (different styles, headers, etc.)
-│   │   ├── packager/ # Orchestrates file collection, processing, output, and clipboard operations.
-│   │   ├── security/ # Security checks to exclude sensitive files
-│   │   ├── mcp/ # MCP server integration (packaging codebases for AI analysis)
-│   │   ├── tokenCount/ # Token counting using Tiktoken
-│   │   └── treeSitter/ # Code parsing using Tree-sitter and language-specific queries
-│   └── shared/ # Shared utilities and types (error handling, logging, helper functions)
-├── tests/ # Unit and integration tests (organized mirroring src/)
-│   ├── cli/
-│   ├── config/
-│   ├── core/
-│   ├── integration-tests/
-│   ├── shared/
-│   └── testing/
-└── website/ # Documentation website (VitePress).
-```
+- `src/` — main source code (`cli/`, `config/`, `core/`, `shared/`). Feature-based structure; avoid dependencies between features
+- `tests/` — mirrors the `src/` directory structure
+- `website/` — documentation website (VitePress); docs live in 15 language directories under `website/client/src/`
+- `browser/` — browser extension
 
-
-
-# Coding Guidelines
+## Coding Guidelines
 
 - Follow the project's coding standards enforced by Biome (`biome.json`)
-- Maintain feature-based directory structure and avoid dependencies between features
-- Keep each file focused on a single responsibility
-- Treat ~250 lines as a signal to review a file's cohesion, not a mandate to split:
-  split when the file mixes multiple responsibilities, but leave it as-is when the
-  length comes from one cohesive concern (e.g. large data/config tables)
+- Keep each file focused on a single responsibility. Treat ~250 lines as a signal
+  to review a file's cohesion, not a mandate to split: split when the file mixes
+  multiple responsibilities, but leave it as-is when the length comes from one
+  cohesive concern (e.g. large data/config tables)
 - Add comments in English where non-obvious logic exists
 - Provide corresponding unit tests for new features
 - Verify changes by running:
@@ -55,19 +31,21 @@ repomix/
   npm run test  # Verify all tests pass
   ```
 
+## Non-Obvious Rules and Pitfalls
+
+- The config JSON schema under `website/client/src/public/schemas/` is generated
+  (`npm run website-generate-schema`; CI regenerates it after merges to `main`).
+  Never edit it by hand.
+- User-facing option or feature changes must update the docs in all 15 language
+  directories under `website/client/src/`, not just `en`.
+- Root `npm run lint` does not typecheck the website client. When changing
+  `website/client`, verify with `npm run docs:build` in that directory.
+
 ## Commit Messages
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/) with scope: `type(scope): Description`
+(e.g. `feat(cli): Add new --no-progress flag`)
 
-```text
-feat(cli): Add new --no-progress flag
-fix(security): Handle special characters in file paths
-docs(website): Update installation guide
-refactor(core): Split packager into smaller modules
-test(cli): Add tests for new CLI options
-```
-
-- Types: feat, fix, docs, style, refactor, test, chore, etc.
 - Scope: affected area (cli, core, website, security, etc.)
 - Description: clear, concise present tense starting with a capital letter
 - Commit body: follow the `contextual-commit` skill (`.claude/skills/contextual-commit/SKILL.md`)


### PR DESCRIPTION
Restructures the shared agent rules file (`.agents/rules/base.md`, symlinked as `CLAUDE.md` / `AGENTS.md` / Cursor rules) following the [Claude Code best practices guide](https://code.claude.com/docs/en/best-practices): keep only rules an agent would get wrong without, and remove anything discoverable from the code itself.

## Changes

**Removed / condensed**
- Collapsed the detailed directory tree (with per-directory descriptions of `core/` internals) into a 4-bullet layout that keeps only the non-obvious facts: feature-based structure, `tests/` mirroring `src/`, and the 15-locale docs layout
- Trimmed the commit-message section to one example and dropped the Conventional Commits type list

**Added — Non-Obvious Rules and Pitfalls section**
- The config JSON schema under `website/client/src/public/schemas/` is generated (`npm run website-generate-schema`, regenerated by CI after merges to `main`) and must not be hand-edited
- User-facing option changes must update all 15 language directories, not just `en`
- Root `npm run lint` does not typecheck the website client; verify with `npm run docs:build`
- VitePress does not validate in-page anchor links (a heading rename shipped broken links, fixed in #1678)
- GitHub Actions steps must be SHA-pinned with a version comment (enforced by pinact/zizmor)

**PR etiquette**
- Documented the preference to combine small, related same-area changes into one PR

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)