### PR TITLE
refactor: Remove duplicate code found by similarity analysis

### DIFF
--- a/src/core/security/securityCheck.ts
+++ b/src/core/security/securityCheck.ts
@@ -8,15 +8,9 @@ import type { RepomixProgressCallback } from '../../shared/types.js';
 import type { RawFile } from '../file/fileTypes.js';
 import type { GitDiffResult } from '../git/gitDiffHandle.js';
 import type { GitLogResult } from '../git/gitLogHandle.js';
-import type { SecurityCheckItem, SecurityCheckTask, SecurityCheckType } from './workers/securityCheckWorker.js';
+import type { SecurityCheckItem, SecurityCheckTask, SuspiciousFileResult } from './workers/securityCheckWorker.js';
 
-export type { SecurityCheckType } from './workers/securityCheckWorker.js';
-
-export interface SuspiciousFileResult {
-  filePath: string;
-  messages: string[];
-  type: SecurityCheckType;
-}
+export type { SecurityCheckType, SuspiciousFileResult } from './workers/securityCheckWorker.js';
 
 // Batch size for grouping files into worker tasks to reduce IPC overhead.
 // Each batch is sent as a single message to a worker thread, avoiding

--- a/src/core/skill/skillTechStack.ts
+++ b/src/core/skill/skillTechStack.ts
@@ -290,6 +290,25 @@ function parseBuildGradle(content: string): Partial<TechStackInfo> {
   return { dependencies, frameworks: [...new Set(frameworks)] };
 }
 
+// Version manager files that hold a single bare version string (e.g. `.node-version`,
+// `.ruby-version`) all parse the same way: trim the content and, when non-empty, report
+// it for the associated runtime. Build one parser per runtime from this shared logic.
+const createSingleRuntimeParser =
+  (runtime: string) =>
+  (content: string): RuntimeVersion[] => {
+    const version = content.trim();
+    if (version) {
+      return [{ runtime, version }];
+    }
+    return [];
+  };
+
+const parseNodeVersion = createSingleRuntimeParser('Node.js');
+const parseRubyVersion = createSingleRuntimeParser('Ruby');
+const parsePythonVersion = createSingleRuntimeParser('Python');
+const parseGoVersion = createSingleRuntimeParser('Go');
+const parseJavaVersion = createSingleRuntimeParser('Java');
+
 // Version manager files and their parsers
 const VERSION_FILES: Record<string, (content: string) => RuntimeVersion[]> = {
   '.node-version': parseNodeVersion,
@@ -300,46 +319,6 @@ const VERSION_FILES: Record<string, (content: string) => RuntimeVersion[]> = {
   '.java-version': parseJavaVersion,
   '.tool-versions': parseToolVersions,
 };
-
-function parseNodeVersion(content: string): RuntimeVersion[] {
-  const version = content.trim();
-  if (version) {
-    return [{ runtime: 'Node.js', version }];
-  }
-  return [];
-}
-
-function parseRubyVersion(content: string): RuntimeVersion[] {
-  const version = content.trim();
-  if (version) {
-    return [{ runtime: 'Ruby', version }];
-  }
-  return [];
-}
-
-function parsePythonVersion(content: string): RuntimeVersion[] {
-  const version = content.trim();
-  if (version) {
-    return [{ runtime: 'Python', version }];
-  }
-  return [];
-}
-
-function parseGoVersion(content: string): RuntimeVersion[] {
-  const version = content.trim();
-  if (version) {
-    return [{ runtime: 'Go', version }];
-  }
-  return [];
-}
-
-function parseJavaVersion(content: string): RuntimeVersion[] {
-  const version = content.trim();
-  if (version) {
-    return [{ runtime: 'Java', version }];
-  }
-  return [];
-}
 
 // Configuration files to detect
 const CONFIG_FILE_PATTERNS: string[] = [


### PR DESCRIPTION
## Summary

While running a code-similarity analysis (`@kongyo2/similarity-ts`) over `src/`, two
pieces of duplicated code stood out as safe, behavior-preserving cleanups. This PR
removes both. There is **no change to runtime behavior or public types** — purely a
readability/maintainability refactor.

## Changes

### 1. `core/skill`: collapse duplicate single-runtime version parsers
`parseNodeVersion`, `parseRubyVersion`, `parsePythonVersion`, `parseGoVersion`, and
`parseJavaVersion` in `src/core/skill/skillTechStack.ts` were byte-for-byte identical
except for the runtime label string. They are now generated from a single
`createSingleRuntimeParser` factory.

- The generated parsers are declared **above** `VERSION_FILES` because they are `const`
  (the previous `function` declarations were hoisted; `const` is not).
- `.tool-versions` parsing (`parseToolVersions`, which has distinct multi-runtime logic)
  is untouched.

### 2. `core/security`: deduplicate the `SuspiciousFileResult` interface
The `SuspiciousFileResult` interface was defined identically in both
`src/core/security/securityCheck.ts` and
`src/core/security/workers/securityCheckWorker.ts`. The single definition now lives in
the worker and is re-exported from `securityCheck.ts` — mirroring the existing
`SecurityCheckType` re-export in that same file. Every existing import path is preserved,
including the public re-export via `src/index.ts`.

## Verification

- [x] `npm run test` — 1489 tests across 139 files pass
- [x] `npm run lint` — passes (biome, oxlint, tsgo, secretlint)

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
