### PR TITLE
fix(core): Count underscore-prefixed directories in token count tree

### DIFF
--- a/src/cli/reporters/tokenCountTreeReporter.ts
+++ b/src/cli/reporters/tokenCountTreeReporter.ts
@@ -39,9 +39,11 @@ export const reportTokenCountTree = (
 };
 
 const displayNode = (node: TreeNode, prefix: string, isRoot: boolean, minTokenCount: number): void => {
-  // Get all directory entries (excluding _files and _tokenSum)
+  // Get all directory entries. The _files (array) and _tokenSum (number)
+  // metadata fields are excluded by the value-type check, so directories whose
+  // name starts with '_' (e.g. __tests__) are still rendered.
   const allEntries = Object.entries(node).filter(
-    ([key, value]) => !key.startsWith('_') && value && typeof value === 'object' && !Array.isArray(value),
+    ([, value]) => value && typeof value === 'object' && !Array.isArray(value),
   );
 
   // Filter directories by minimum token count

--- a/src/core/tokenCount/buildTokenCountStructure.ts
+++ b/src/core/tokenCount/buildTokenCountStructure.ts
@@ -57,9 +57,12 @@ const calculateTokenSums = (node: TreeNode): number => {
     totalTokens += node._files.reduce((sum, file) => sum + file.tokens, 0);
   }
 
-  // Add tokens from subdirectories
-  for (const [key, value] of Object.entries(node)) {
-    if (key.startsWith('_') || !value || typeof value !== 'object' || Array.isArray(value)) {
+  // Add tokens from subdirectories. Subdirectory values are TreeNode objects,
+  // while the metadata fields are an array (_files) and a number (_tokenSum),
+  // so the value-type check alone separates them. A key-prefix check here would
+  // also drop real directories whose name starts with '_' (e.g. __tests__).
+  for (const value of Object.values(node)) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
       continue;
     }
     totalTokens += calculateTokenSums(value as TreeNode);

--- a/tests/cli/reporters/tokenCountTreeReporter.test.ts
+++ b/tests/cli/reporters/tokenCountTreeReporter.test.ts
@@ -52,6 +52,29 @@ describe('reportTokenCountTree', () => {
     expect(calls.some((call) => call.includes('file2.js'))).toBe(true);
   });
 
+  test('should display directories whose name starts with an underscore', () => {
+    const processedFiles: ProcessedFile[] = [
+      { path: 'src/__tests__/foo.test.js', content: 'test("example", () => {});' },
+      { path: 'src/index.js', content: 'const a = 1;' },
+    ];
+
+    const fileTokenCounts = {
+      'src/__tests__/foo.test.js': 100,
+      'src/index.js': 50,
+    };
+
+    const config = {
+      output: { tokenCountTree: true },
+    } as RepomixConfigMerged;
+
+    reportTokenCountTree(processedFiles, fileTokenCounts, config);
+
+    const calls = mockLogger.mock.calls.map((call: unknown[]) => call[0] as string);
+    // The __tests__ directory must appear, and src must sum both children (150).
+    expect(calls.some((call) => call.includes('__tests__/'))).toBe(true);
+    expect(calls.some((call) => call.includes('src/') && call.includes('150'))).toBe(true);
+  });
+
   test('should handle empty file list', () => {
     const processedFiles: ProcessedFile[] = [];
     const fileTokenCounts = {};

--- a/tests/core/tokenCount/buildTokenCountStructure.test.ts
+++ b/tests/core/tokenCount/buildTokenCountStructure.test.ts
@@ -124,6 +124,22 @@ describe('buildTokenCountStructure', () => {
     expect(result).toEqual([]);
   });
 
+  test('should include underscore-prefixed directories like __tests__ in token sums', () => {
+    const files: FileWithTokens[] = [
+      { path: 'src/__tests__/foo.test.ts', tokens: 100 },
+      { path: 'src/index.ts', tokens: 50 },
+    ];
+
+    const tree = buildTokenCountTree(files) as TreeNode;
+    const src = tree.src as TreeNode;
+
+    // The __tests__ subtree must roll up into its ancestors' sums rather than
+    // being dropped by the metadata guard.
+    expect(tree._tokenSum).toBe(150);
+    expect(src._tokenSum).toBe(150);
+    expect((src.__tests__ as TreeNode)._tokenSum).toBe(100);
+  });
+
   test('should handle files with same name in different directories', () => {
     const files: FileWithTokens[] = [
       { path: 'src/index.js', tokens: 100 },


### PR DESCRIPTION
`--token-count-tree` silently dropped any directory whose name starts with an underscore — `__tests__`, `__mocks__`, `__generated__`, `_internal` and friends. The directory never showed up in the tree, and worse, its tokens weren't counted toward any ancestor's total, so the numbers were just wrong.

The cause is a namespace collision in the tree: directory names are stored as keys alongside the `_files` and `_tokenSum` metadata fields. To tell them apart, both the sum calculation and the reporter filtered out every key starting with `_`. But the value-type checks right next to it already exclude the metadata (`_files` is an array, `_tokenSum` is a number), so the `key.startsWith('_')` check was redundant — and it also matched real directories. Dropping it fixes both the totals and the rendering.

Example: with `src/__tests__/foo.test.ts` (100) and `src/index.ts` (50), `src/` now reports 150 tokens and `__tests__/` shows up, instead of `src/` showing 50 and the test dir vanishing.

Added regression coverage in both `buildTokenCountStructure` (sums roll up through the `__tests__` subtree) and the reporter (the directory is rendered with the right total). Both fail on `main` and pass here.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`