### PR TITLE
refactor(core): Use a discriminated node type for the token count tree

### DIFF
--- a/src/cli/reporters/tokenCountTreeReporter.ts
+++ b/src/cli/reporters/tokenCountTreeReporter.ts
@@ -4,7 +4,7 @@ import type { ProcessedFile } from '../../core/file/fileTypes.js';
 import {
   buildTokenCountTree,
   type FileWithTokens,
-  type TreeNode,
+  type TokenCountTreeNode,
 } from '../../core/tokenCount/buildTokenCountStructure.js';
 import { logger } from '../../shared/logger.js';
 
@@ -38,23 +38,12 @@ export const reportTokenCountTree = (
   displayNode(tree, '', true, minTokenCount);
 };
 
-const displayNode = (node: TreeNode, prefix: string, isRoot: boolean, minTokenCount: number): void => {
-  // Get all directory entries. The _files (array) and _tokenSum (number)
-  // metadata fields are excluded by the value-type check, so directories whose
-  // name starts with '_' (e.g. __tests__) are still rendered.
-  const allEntries = Object.entries(node).filter(
-    ([, value]) => value && typeof value === 'object' && !Array.isArray(value),
-  );
-
-  // Filter directories by minimum token count
-  const entries = allEntries.filter(([, value]) => {
-    const tokenSum = (value as TreeNode)._tokenSum || 0;
-    return tokenSum >= minTokenCount;
-  });
+const displayNode = (node: TokenCountTreeNode, prefix: string, isRoot: boolean, minTokenCount: number): void => {
+  // Get child directories that meet the minimum token count
+  const entries = Object.entries(node.children).filter(([, child]) => child.tokenSum >= minTokenCount);
 
   // Get files in this directory and filter by minimum token count
-  const allFiles = node._files || [];
-  const files = allFiles.filter((file) => file.tokens >= minTokenCount);
+  const files = node.files.filter((file) => file.tokens >= minTokenCount);
 
   // Sort entries alphabetically
   entries.sort(([a], [b]) => a.localeCompare(b));
@@ -77,8 +66,7 @@ const displayNode = (node: TreeNode, prefix: string, isRoot: boolean, minTokenCo
   entries.forEach(([name, childNode], index) => {
     const isLastEntry = index === entries.length - 1;
     const connector = isLastEntry ? '└── ' : '├── ';
-    const tokenSum = (childNode as TreeNode)._tokenSum || 0;
-    const tokenInfo = pc.dim(`(${tokenSum.toLocaleString()} tokens)`);
+    const tokenInfo = pc.dim(`(${childNode.tokenSum.toLocaleString()} tokens)`);
 
     if (isRoot && prefix === '') {
       logger.log(`${connector}${name}/ ${tokenInfo}`);
@@ -90,7 +78,7 @@ const displayNode = (node: TreeNode, prefix: string, isRoot: boolean, minTokenCo
     const childPrefix =
       isRoot && prefix === '' ? (isLastEntry ? '    ' : '│   ') : prefix + (isLastEntry ? '    ' : '│   ');
 
-    displayNode(childNode as TreeNode, childPrefix, false, minTokenCount);
+    displayNode(childNode, childPrefix, false, minTokenCount);
   });
 
   // If this is the root and it's empty, show a message

--- a/src/cli/reporters/tokenCountTreeReporter.ts
+++ b/src/cli/reporters/tokenCountTreeReporter.ts
@@ -40,7 +40,7 @@ export const reportTokenCountTree = (
 
 const displayNode = (node: TokenCountTreeNode, prefix: string, isRoot: boolean, minTokenCount: number): void => {
   // Get child directories that meet the minimum token count
-  const entries = Object.entries(node.children).filter(([, child]) => child.tokenSum >= minTokenCount);
+  const entries = [...node.children].filter(([, child]) => child.tokenSum >= minTokenCount);
 
   // Get files in this directory and filter by minimum token count
   const files = node.files.filter((file) => file.tokens >= minTokenCount);

--- a/src/core/tokenCount/buildTokenCountStructure.ts
+++ b/src/core/tokenCount/buildTokenCountStructure.ts
@@ -6,15 +6,16 @@ export interface FileWithTokens {
 }
 
 // A directory node in the token-count tree. Files and metadata live in dedicated
-// fields, and child directories are kept in their own `children` map, so a directory
-// can be named anything (including `files` or `tokenSum`) without colliding with them.
+// fields, and child directories are kept in a separate `children` map, so a directory
+// can be named anything (including `files`, `tokenSum`, or `__proto__`) without
+// colliding with the metadata fields or the object prototype.
 export interface TokenCountTreeNode {
   files: FileTokenInfo[];
   tokenSum: number;
-  children: Record<string, TokenCountTreeNode>;
+  children: Map<string, TokenCountTreeNode>;
 }
 
-const createNode = (): TokenCountTreeNode => ({ files: [], tokenSum: 0, children: {} });
+const createNode = (): TokenCountTreeNode => ({ files: [], tokenSum: 0, children: new Map() });
 
 export const buildTokenCountTree = (filesWithTokens: FileWithTokens[]): TokenCountTreeNode => {
   const root = createNode();
@@ -32,10 +33,10 @@ export const buildTokenCountTree = (filesWithTokens: FileWithTokens[]): TokenCou
     // Navigate/create the directory structure
     let current = root;
     for (const part of parts) {
-      let child = current.children[part];
+      let child = current.children.get(part);
       if (!child) {
         child = createNode();
-        current.children[part] = child;
+        current.children.set(part, child);
       }
       current = child;
     }
@@ -58,7 +59,7 @@ const calculateTokenSums = (node: TokenCountTreeNode): number => {
   let totalTokens = node.files.reduce((sum, file) => sum + file.tokens, 0);
 
   // Plus tokens rolled up from every subdirectory
-  for (const child of Object.values(node.children)) {
+  for (const child of node.children.values()) {
     totalTokens += calculateTokenSums(child);
   }
 

--- a/src/core/tokenCount/buildTokenCountStructure.ts
+++ b/src/core/tokenCount/buildTokenCountStructure.ts
@@ -5,14 +5,19 @@ export interface FileWithTokens {
   tokens: number;
 }
 
-export interface TreeNode {
-  _files?: FileTokenInfo[];
-  _tokenSum?: number;
-  [key: string]: TreeNode | FileTokenInfo[] | number | undefined;
+// A directory node in the token-count tree. Files and metadata live in dedicated
+// fields, and child directories are kept in their own `children` map, so a directory
+// can be named anything (including `files` or `tokenSum`) without colliding with them.
+export interface TokenCountTreeNode {
+  files: FileTokenInfo[];
+  tokenSum: number;
+  children: Record<string, TokenCountTreeNode>;
 }
 
-export const buildTokenCountTree = (filesWithTokens: FileWithTokens[]): TreeNode => {
-  const root: TreeNode = {};
+const createNode = (): TokenCountTreeNode => ({ files: [], tokenSum: 0, children: {} });
+
+export const buildTokenCountTree = (filesWithTokens: FileWithTokens[]): TokenCountTreeNode => {
+  const root = createNode();
 
   for (const file of filesWithTokens) {
     // The file.path is already relative to the root directory
@@ -27,17 +32,16 @@ export const buildTokenCountTree = (filesWithTokens: FileWithTokens[]): TreeNode
     // Navigate/create the directory structure
     let current = root;
     for (const part of parts) {
-      if (!current[part]) {
-        current[part] = {};
+      let child = current.children[part];
+      if (!child) {
+        child = createNode();
+        current.children[part] = child;
       }
-      current = current[part] as TreeNode;
+      current = child;
     }
 
     // Add the file
-    if (!current._files) {
-      current._files = [];
-    }
-    current._files.push({
+    current.files.push({
       name: fileName,
       tokens: file.tokens,
     });
@@ -49,25 +53,15 @@ export const buildTokenCountTree = (filesWithTokens: FileWithTokens[]): TreeNode
   return root;
 };
 
-const calculateTokenSums = (node: TreeNode): number => {
-  let totalTokens = 0;
+const calculateTokenSums = (node: TokenCountTreeNode): number => {
+  // Tokens from files directly in this directory
+  let totalTokens = node.files.reduce((sum, file) => sum + file.tokens, 0);
 
-  // Add tokens from files in this directory
-  if (node._files) {
-    totalTokens += node._files.reduce((sum, file) => sum + file.tokens, 0);
+  // Plus tokens rolled up from every subdirectory
+  for (const child of Object.values(node.children)) {
+    totalTokens += calculateTokenSums(child);
   }
 
-  // Add tokens from subdirectories. Subdirectory values are TreeNode objects,
-  // while the metadata fields are an array (_files) and a number (_tokenSum),
-  // so the value-type check alone separates them. A key-prefix check here would
-  // also drop real directories whose name starts with '_' (e.g. __tests__).
-  for (const value of Object.values(node)) {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      continue;
-    }
-    totalTokens += calculateTokenSums(value as TreeNode);
-  }
-
-  node._tokenSum = totalTokens;
+  node.tokenSum = totalTokens;
   return totalTokens;
 };

--- a/tests/core/tokenCount/buildTokenCountStructure.test.ts
+++ b/tests/core/tokenCount/buildTokenCountStructure.test.ts
@@ -10,7 +10,7 @@ const convertToOutput = (node: TokenCountTreeNode, isRoot = true): TokenCountOut
   const result: DirectoryTokenInfo[] = [];
 
   // Handle directories
-  for (const [name, child] of Object.entries(node.children)) {
+  for (const [name, child] of node.children) {
     const dirInfo: DirectoryTokenInfo = {
       name,
       files: child.files,
@@ -127,13 +127,13 @@ describe('buildTokenCountStructure', () => {
     ];
 
     const tree = buildTokenCountTree(files);
-    const src = tree.children.src;
+    const src = tree.children.get('src');
 
     // The __tests__ subtree must roll up into its ancestors' sums, and a directory
     // whose name starts with '_' must live in `children` like any other directory.
     expect(tree.tokenSum).toBe(150);
-    expect(src.tokenSum).toBe(150);
-    expect(src.children.__tests__.tokenSum).toBe(100);
+    expect(src?.tokenSum).toBe(150);
+    expect(src?.children.get('__tests__')?.tokenSum).toBe(100);
   });
 
   test('should handle files with same name in different directories', () => {

--- a/tests/core/tokenCount/buildTokenCountStructure.test.ts
+++ b/tests/core/tokenCount/buildTokenCountStructure.test.ts
@@ -136,6 +136,24 @@ describe('buildTokenCountStructure', () => {
     expect(src?.children.get('__tests__')?.tokenSum).toBe(100);
   });
 
+  test('should keep directories whose name matches a node field (files, tokenSum, __proto__)', () => {
+    const files: FileWithTokens[] = [
+      { path: 'src/files/a.ts', tokens: 10 },
+      { path: 'src/tokenSum/b.ts', tokens: 20 },
+      { path: 'src/__proto__/c.ts', tokens: 30 },
+    ];
+
+    const tree = buildTokenCountTree(files);
+    const src = tree.children.get('src');
+
+    // Directory names that clash with node fields or the object prototype must
+    // still be stored as ordinary children, not collide with metadata.
+    expect(src?.children.get('files')?.tokenSum).toBe(10);
+    expect(src?.children.get('tokenSum')?.tokenSum).toBe(20);
+    expect(src?.children.get('__proto__')?.tokenSum).toBe(30);
+    expect(src?.tokenSum).toBe(60);
+  });
+
   test('should handle files with same name in different directories', () => {
     const files: FileWithTokens[] = [
       { path: 'src/index.js', tokens: 100 },

--- a/tests/core/tokenCount/buildTokenCountStructure.test.ts
+++ b/tests/core/tokenCount/buildTokenCountStructure.test.ts
@@ -1,27 +1,23 @@
 import { describe, expect, test } from 'vitest';
-import { buildTokenCountTree, type FileWithTokens } from '../../../src/core/tokenCount/buildTokenCountStructure.js';
-import type { DirectoryTokenInfo, FileTokenInfo, TokenCountOutput } from '../../../src/core/tokenCount/types.js';
+import {
+  buildTokenCountTree,
+  type FileWithTokens,
+  type TokenCountTreeNode,
+} from '../../../src/core/tokenCount/buildTokenCountStructure.js';
+import type { DirectoryTokenInfo, TokenCountOutput } from '../../../src/core/tokenCount/types.js';
 
-interface TreeNode {
-  _files?: FileTokenInfo[];
-  _tokenSum?: number;
-  [key: string]: TreeNode | FileTokenInfo[] | number | undefined;
-}
-
-const convertToOutput = (node: TreeNode, isRoot = true): TokenCountOutput => {
+const convertToOutput = (node: TokenCountTreeNode, isRoot = true): TokenCountOutput => {
   const result: DirectoryTokenInfo[] = [];
 
   // Handle directories
-  for (const [key, value] of Object.entries(node)) {
-    if (key.startsWith('_')) continue;
-
+  for (const [name, child] of Object.entries(node.children)) {
     const dirInfo: DirectoryTokenInfo = {
-      name: key,
-      files: (value as TreeNode)._files || [],
+      name,
+      files: child.files,
     };
 
     // Check for subdirectories
-    const subdirs = convertToOutput(value as TreeNode, false);
+    const subdirs = convertToOutput(child, false);
     if (subdirs.length > 0) {
       dirInfo.directories = subdirs;
     }
@@ -30,8 +26,8 @@ const convertToOutput = (node: TreeNode, isRoot = true): TokenCountOutput => {
   }
 
   // Handle root-level files (only at the actual root level)
-  if (isRoot && node._files) {
-    for (const file of node._files) {
+  if (isRoot) {
+    for (const file of node.files) {
       result.push({
         name: file.name,
         files: [file],
@@ -130,14 +126,14 @@ describe('buildTokenCountStructure', () => {
       { path: 'src/index.ts', tokens: 50 },
     ];
 
-    const tree = buildTokenCountTree(files) as TreeNode;
-    const src = tree.src as TreeNode;
+    const tree = buildTokenCountTree(files);
+    const src = tree.children.src;
 
-    // The __tests__ subtree must roll up into its ancestors' sums rather than
-    // being dropped by the metadata guard.
-    expect(tree._tokenSum).toBe(150);
-    expect(src._tokenSum).toBe(150);
-    expect((src.__tests__ as TreeNode)._tokenSum).toBe(100);
+    // The __tests__ subtree must roll up into its ancestors' sums, and a directory
+    // whose name starts with '_' must live in `children` like any other directory.
+    expect(tree.tokenSum).toBe(150);
+    expect(src.tokenSum).toBe(150);
+    expect(src.children.__tests__.tokenSum).toBe(100);
   });
 
   test('should handle files with same name in different directories', () => {


### PR DESCRIPTION
Refactors the token count tree (`--token-count-tree`) node type for stronger type safety, with no change to behavior or output.

Previously a tree node stored child directories, `_files`, and `_tokenSum` together in a single index-signature object. Directory entries therefore had to be distinguished from metadata at runtime (value-type checks) and reached through `as TreeNode` casts, and a directory literally named `_files`/`_tokenSum` would collide with the metadata slots.

This replaces `TreeNode` with a discriminated `TokenCountTreeNode`:

```ts
interface TokenCountTreeNode {
  files: FileTokenInfo[];
  tokenSum: number;
  children: Record<string, TokenCountTreeNode>;
}
```

- Child directories live in their own `children` map, so a directory can be named anything (including `files` or `tokenSum`) without colliding with metadata.
- The runtime type-discrimination filters are gone; iteration is just `Object.values(node.children)`.
- Every `as TreeNode` cast is removed (reporter, builder, and tests).

Internal type only (not exported from `src/index.ts`), so there is no public API impact.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`