### PR TITLE
fix(core): split file paths on the POSIX separator so the tree doesn't collapse on Windows

### DIFF
--- a/src/core/file/filePathSort.ts
+++ b/src/core/file/filePathSort.ts
@@ -2,9 +2,16 @@ import path from 'node:path';
 
 // Sort paths for general use (not affected by git change count)
 // Uses decorate-sort-undecorate to pre-compute path.split() once per path
-// instead of O(N log N) repeated splits during comparisons
+// instead of O(N log N) repeated splits during comparisons.
+// Paths arrive normalized to POSIX separators (globby output, buildFileDisplayPath),
+// so split on "/" instead of the OS separator: on Windows path.sep is "\\", so a
+// "/"-separated path would never split and the directory-aware ordering below would
+// silently degrade to a flat whole-string comparison.
 export const sortPaths = (filePaths: string[]): string[] => {
-  const decorated = filePaths.map((p) => ({ original: p, parts: p.split(path.sep) }));
+  const decorated = filePaths.map((p) => ({
+    original: p,
+    parts: p.replaceAll(path.win32.sep, path.posix.sep).split(path.posix.sep),
+  }));
 
   decorated.sort((a, b) => {
     const partsA = a.parts;

--- a/src/core/file/fileTreeGenerate.ts
+++ b/src/core/file/fileTreeGenerate.ts
@@ -36,7 +36,10 @@ export const generateFileTree = (files: string[], emptyDirPaths: string[] = []):
 };
 
 const addPathToTree = (root: TreeNode, path: string, isDirectory: boolean): void => {
-  const parts = path.split(nodepath.sep);
+  // Paths arrive normalized to POSIX separators (globby output, buildFileDisplayPath),
+  // so split on "/" instead of the OS separator: on Windows path.sep is "\\", so a
+  // "/"-separated path would never split and the whole tree would collapse into a flat list.
+  const parts = path.replaceAll(nodepath.win32.sep, nodepath.posix.sep).split(nodepath.posix.sep);
   let currentNode = root;
 
   for (let i = 0; i < parts.length; i++) {

--- a/tests/core/file/filePathSort.test.ts
+++ b/tests/core/file/filePathSort.test.ts
@@ -60,4 +60,13 @@ describe('filePathSort', () => {
     const expected = [`a${sep}`, `B${sep}`, 'C', 'd'];
     expect(sortPaths(input)).toEqual(expected);
   });
+
+  // globby/buildFileDisplayPath always hand out "/"-separated paths, even on Windows
+  // where path.sep is "\\". Backslash input here stands in for that separator/path.sep
+  // mismatch: the directory-aware ordering must not depend on the OS separator.
+  test('should treat separators independently of the OS separator', () => {
+    const input = ['dir\\subdir\\file.txt', 'dir\\file.js', 'dir\\subdir\\', 'file.txt'];
+    const expected = ['dir\\subdir\\', 'dir\\subdir\\file.txt', 'dir\\file.js', 'file.txt'];
+    expect(sortPaths(input)).toEqual(expected);
+  });
 });

--- a/tests/core/file/fileTreeGenerate.test.ts
+++ b/tests/core/file/fileTreeGenerate.test.ts
@@ -16,6 +16,16 @@ describe('fileTreeGenerate', () => {
       expect(result).toContain('subdir/');
       expect(result).toContain('nested.txt');
     });
+
+    // globby/buildFileDisplayPath always hand out "/"-separated paths, even on Windows
+    // where path.sep is "\\". Backslash input here stands in for that separator/path.sep
+    // mismatch: the tree must nest by path segment regardless of the OS separator.
+    test('nests paths independently of the OS separator', () => {
+      const files = ['src\\index.ts', 'src\\utils\\helper.ts'];
+      const result = generateTreeString(files);
+
+      expect(result).toBe('src/\n  utils/\n    helper.ts\n  index.ts');
+    });
   });
 
   describe('generateTreeStringWithRoots', () => {


### PR DESCRIPTION
By the time paths reach `sortPaths` and `generateFileTree` they're already normalized to forward slashes — globby returns `/`-paths on every OS, and `buildFileDisplayPath`/`toDisplayPath` explicitly rewrite separators to `/`. But both functions then split on the OS `path.sep`. On Windows that's a backslash, so a `/`-separated path never splits: `generateFileTree` puts every file at the root and the `<directory_structure>` section renders as a flat list of full paths instead of a tree, and `sortPaths` falls through to a plain whole-string `localeCompare` instead of the directory-aware ordering.

Fixed both to normalize to `/` before splitting, which is what `outputSplit.getRootEntry` already does for the same reason.

The existing sort tests didn't catch this because they build their inputs from `path.sep` too, so the input separator and the split separator always agree; the tree test used loose `toContain` checks that still pass on a collapsed tree. Added tests that feed a separator different from the host `path.sep` (backslashes on POSIX CI) to exercise the mismatch directly — both fail on `main` and pass with the fix.