### PR TITLE
fix(website): Improve accessibility contrast and add main landmark

### DIFF
--- a/.github/workflows/ci-website.yml
+++ b/.github/workflows/ci-website.yml
@@ -66,13 +66,14 @@ jobs:
           npm link
       - name: Install website server dependencies
         working-directory: website/server
-        # npm 12 refuses to prepare the github:repomix git dependency while
-        # min-release-age is set — it conflicts with the --before npm uses
-        # internally. Disable the cooldown for this lockfile-pinned install,
-        # matching the pattern in npm-publish.yml.
-        env:
-          npm_config_min_release_age: "0"
         run: |
+          # npm 12 fails to prepare the github:repomix git dependency: its prep
+          # child process re-reads .npmrc (min-release-age=7) and hits npm's own
+          # --before, which cannot coexist. Setting npm_config_min_release_age=0
+          # does not help (0 still counts as "provided", and the child re-reads
+          # .npmrc), so downgrade to npm 11.4.0, which predates the flag.
+          # Matches website/server/Dockerfile.
+          npm install -g npm@11.4.0
           npm ci
           npm link repomix
       - name: Lint website server
@@ -98,13 +99,14 @@ jobs:
           npm link
       - name: Install website server dependencies
         working-directory: website/server
-        # npm 12 refuses to prepare the github:repomix git dependency while
-        # min-release-age is set — it conflicts with the --before npm uses
-        # internally. Disable the cooldown for this lockfile-pinned install,
-        # matching the pattern in npm-publish.yml.
-        env:
-          npm_config_min_release_age: "0"
         run: |
+          # npm 12 fails to prepare the github:repomix git dependency: its prep
+          # child process re-reads .npmrc (min-release-age=7) and hits npm's own
+          # --before, which cannot coexist. Setting npm_config_min_release_age=0
+          # does not help (0 still counts as "provided", and the child re-reads
+          # .npmrc), so downgrade to npm 11.4.0, which predates the flag.
+          # Matches website/server/Dockerfile.
+          npm install -g npm@11.4.0
           npm ci
           npm link repomix
       - name: Test website server
@@ -130,13 +132,14 @@ jobs:
           npm link
       - name: Install website server dependencies
         working-directory: website/server
-        # npm 12 refuses to prepare the github:repomix git dependency while
-        # min-release-age is set — it conflicts with the --before npm uses
-        # internally. Disable the cooldown for this lockfile-pinned install,
-        # matching the pattern in npm-publish.yml.
-        env:
-          npm_config_min_release_age: "0"
         run: |
+          # npm 12 fails to prepare the github:repomix git dependency: its prep
+          # child process re-reads .npmrc (min-release-age=7) and hits npm's own
+          # --before, which cannot coexist. Setting npm_config_min_release_age=0
+          # does not help (0 still counts as "provided", and the child re-reads
+          # .npmrc), so downgrade to npm 11.4.0, which predates the flag.
+          # Matches website/server/Dockerfile.
+          npm install -g npm@11.4.0
           npm ci
           npm link repomix
       - name: Bundle website server

--- a/.github/workflows/ci-website.yml
+++ b/.github/workflows/ci-website.yml
@@ -67,6 +67,10 @@ jobs:
       - name: Install website server dependencies
         working-directory: website/server
         run: |
+          # npm 12 fails to prepare the github:repomix git dependency because its
+          # min-release-age config conflicts with the --before it uses internally.
+          # Downgrade to npm 11.4.0, which predates the flag (matches Dockerfile).
+          npm install -g npm@11.4.0
           npm ci
           npm link repomix
       - name: Lint website server
@@ -93,6 +97,10 @@ jobs:
       - name: Install website server dependencies
         working-directory: website/server
         run: |
+          # npm 12 fails to prepare the github:repomix git dependency because its
+          # min-release-age config conflicts with the --before it uses internally.
+          # Downgrade to npm 11.4.0, which predates the flag (matches Dockerfile).
+          npm install -g npm@11.4.0
           npm ci
           npm link repomix
       - name: Test website server
@@ -119,6 +127,10 @@ jobs:
       - name: Install website server dependencies
         working-directory: website/server
         run: |
+          # npm 12 fails to prepare the github:repomix git dependency because its
+          # min-release-age config conflicts with the --before it uses internally.
+          # Downgrade to npm 11.4.0, which predates the flag (matches Dockerfile).
+          npm install -g npm@11.4.0
           npm ci
           npm link repomix
       - name: Bundle website server

--- a/.github/workflows/ci-website.yml
+++ b/.github/workflows/ci-website.yml
@@ -66,11 +66,13 @@ jobs:
           npm link
       - name: Install website server dependencies
         working-directory: website/server
+        # npm 12 refuses to prepare the github:repomix git dependency while
+        # min-release-age is set — it conflicts with the --before npm uses
+        # internally. Disable the cooldown for this lockfile-pinned install,
+        # matching the pattern in npm-publish.yml.
+        env:
+          npm_config_min_release_age: "0"
         run: |
-          # npm 12 fails to prepare the github:repomix git dependency because its
-          # min-release-age config conflicts with the --before it uses internally.
-          # Downgrade to npm 11.4.0, which predates the flag (matches Dockerfile).
-          npm install -g npm@11.4.0
           npm ci
           npm link repomix
       - name: Lint website server
@@ -96,11 +98,13 @@ jobs:
           npm link
       - name: Install website server dependencies
         working-directory: website/server
+        # npm 12 refuses to prepare the github:repomix git dependency while
+        # min-release-age is set — it conflicts with the --before npm uses
+        # internally. Disable the cooldown for this lockfile-pinned install,
+        # matching the pattern in npm-publish.yml.
+        env:
+          npm_config_min_release_age: "0"
         run: |
-          # npm 12 fails to prepare the github:repomix git dependency because its
-          # min-release-age config conflicts with the --before it uses internally.
-          # Downgrade to npm 11.4.0, which predates the flag (matches Dockerfile).
-          npm install -g npm@11.4.0
           npm ci
           npm link repomix
       - name: Test website server
@@ -126,11 +130,13 @@ jobs:
           npm link
       - name: Install website server dependencies
         working-directory: website/server
+        # npm 12 refuses to prepare the github:repomix git dependency while
+        # min-release-age is set — it conflicts with the --before npm uses
+        # internally. Disable the cooldown for this lockfile-pinned install,
+        # matching the pattern in npm-publish.yml.
+        env:
+          npm_config_min_release_age: "0"
         run: |
-          # npm 12 fails to prepare the github:repomix git dependency because its
-          # min-release-age config conflicts with the --before it uses internally.
-          # Downgrade to npm 11.4.0, which predates the flag (matches Dockerfile).
-          npm install -g npm@11.4.0
           npm ci
           npm link repomix
       - name: Bundle website server

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -19,6 +19,3 @@ rules:
       - action.yml
       # Intentional: update npm itself to latest before publishing
       - npm-publish.yml
-      # Intentional: downgrade npm to 11.4.0 so it can prepare the github:repomix
-      # git dependency without the min-release-age/--before conflict in npm 12
-      - ci-website.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -19,3 +19,6 @@ rules:
       - action.yml
       # Intentional: update npm itself to latest before publishing
       - npm-publish.yml
+      # Intentional: downgrade npm to 11.4.0 so it can prepare the github:repomix
+      # git dependency without the min-release-age/--before conflict in npm 12
+      - ci-website.yml

--- a/website/client/.vitepress/theme/custom.css
+++ b/website/client/.vitepress/theme/custom.css
@@ -15,6 +15,9 @@
   /* Inline code text: default is the brand orange, which fails contrast on the
      light code background. Use the accessible brand color instead. */
   --vp-code-color: var(--brand-text);
+  /* Linked inline code (<a><code>) uses its own token, also the brand orange. */
+  --vp-code-link-color: var(--brand-text);
+  --vp-code-link-hover-color: var(--brand-text);
   /* Code block language label: default (--vp-c-text-3) is too faint. */
   --vp-code-lang-color: var(--vp-c-text-2);
 
@@ -45,6 +48,10 @@
 .vp-doc a {
   color: var(--brand-text);
 }
+/* Default hover shifts to the lighter brand-2, which drops below AA on white. */
+.vp-doc a:hover {
+  color: var(--brand-text);
+}
 .vp-doc p a,
 .vp-doc li a {
   text-decoration: underline;
@@ -53,7 +60,9 @@
 /* Links/code inside tip blocks default to the brand orange, which fails
    contrast on the tinted tip background. Use the accessible brand color. */
 .custom-block.tip a,
-.custom-block.tip code {
+.custom-block.tip code,
+.custom-block.tip a:hover,
+.custom-block.tip a:hover > code {
   color: var(--brand-text);
 }
 

--- a/website/client/.vitepress/theme/custom.css
+++ b/website/client/.vitepress/theme/custom.css
@@ -60,10 +60,10 @@
 /* Syntax highlighting comments use #6A737D for both light and dark themes,
    which fails WCAG AA contrast on the code block background. Raise the contrast
    per mode by targeting the inline shiki color the tokens carry. */
-html:not(.dark) .vp-code span[style*='#6A737D'] {
+html:not(.dark) .vp-code span[style*="#6A737D"] {
   color: #57606a;
 }
-.dark .vp-code span[style*='#6A737D'] {
+.dark .vp-code span[style*="#6A737D"] {
   color: #8b949e;
 }
 

--- a/website/client/.vitepress/theme/custom.css
+++ b/website/client/.vitepress/theme/custom.css
@@ -60,10 +60,10 @@
 /* Syntax highlighting comments use #6A737D for both light and dark themes,
    which fails WCAG AA contrast on the code block background. Raise the contrast
    per mode by targeting the inline shiki color the tokens carry. */
-html:not(.dark) .vp-code span[style*="#6A737D"] {
+html:not(.dark) .vp-code span[style*="#6a737d" i] {
   color: #57606a;
 }
-.dark .vp-code span[style*="#6A737D"] {
+.dark .vp-code span[style*="#6a737d" i] {
   color: #8b949e;
 }
 

--- a/website/client/.vitepress/theme/custom.css
+++ b/website/client/.vitepress/theme/custom.css
@@ -4,6 +4,20 @@
   --vp-c-brand-3: #c2410c;
   --vp-c-brand-soft: rgba(249, 115, 22, 0.1);
 
+  /*
+   * Accessible brand color for text/links.
+   * The brand orange (#f97316) fails WCAG AA contrast as text on light
+   * backgrounds, so use the darker shade in light mode. On dark backgrounds
+   * the lighter orange has enough contrast, so .dark keeps #f97316.
+   */
+  --brand-text: var(--vp-c-brand-3);
+
+  /* Inline code text: default is the brand orange, which fails contrast on the
+     light code background. Use the accessible brand color instead. */
+  --vp-code-color: var(--brand-text);
+  /* Code block language label: default (--vp-c-text-3) is too faint. */
+  --vp-code-lang-color: var(--vp-c-text-2);
+
   --vp-c-danger: #f44336;
 
   --vp-home-hero-name-color: transparent;
@@ -22,9 +36,37 @@
   order: 1;
 }
 
-.hero-description__accent {
-  color: var(--vp-c-brand-1);
+.dark {
+  --brand-text: var(--vp-c-brand-1);
 }
+
+/* Content links: use the accessible brand color, and underline inline links
+   inside prose so they are distinguishable without relying on color alone. */
+.vp-doc a {
+  color: var(--brand-text);
+}
+.vp-doc p a,
+.vp-doc li a {
+  text-decoration: underline;
+}
+
+/* Links/code inside tip blocks default to the brand orange, which fails
+   contrast on the tinted tip background. Use the accessible brand color. */
+.custom-block.tip a,
+.custom-block.tip code {
+  color: var(--brand-text);
+}
+
+/* Syntax highlighting comments use #6A737D for both light and dark themes,
+   which fails WCAG AA contrast on the code block background. Raise the contrast
+   per mode by targeting the inline shiki color the tokens carry. */
+html:not(.dark) .vp-code span[style*='#6A737D'] {
+  color: #57606a;
+}
+.dark .vp-code span[style*='#6A737D'] {
+  color: #8b949e;
+}
+
 .cli-section {
   margin-bottom: 32px;
   max-width: 800px;

--- a/website/client/components/Home.vue
+++ b/website/client/components/Home.vue
@@ -3,11 +3,12 @@ import Hero from './Home/Hero.vue';
 import TryIt from './Home/TryIt.vue';
 </script>
 
+<!-- Use <main> so the home page exposes a main landmark (VitePress home layout omits one). -->
 <template>
-  <div class="home">
+  <main class="home">
     <Hero />
     <TryIt />
-  </div>
+  </main>
 </template>
 
 <style scoped>

--- a/website/client/components/Home/Hero.vue
+++ b/website/client/components/Home/Hero.vue
@@ -42,7 +42,7 @@ const { site } = useData();
 }
 
 .hero-description__accent {
-  color: var(--vp-c-brand-1);
+  color: var(--brand-text);
 }
 
 .hero-tagline {

--- a/website/client/components/Home/TryIt.vue
+++ b/website/client/components/Home/TryIt.vue
@@ -418,7 +418,7 @@ onMounted(() => {
 }
 
 .reset-button:hover {
-  color: var(--vp-c-brand-1);
+  color: var(--brand-text);
   border-color: var(--vp-c-brand-1);
   background: var(--vp-c-bg-soft);
 

--- a/website/client/components/Home/TryItLoading.vue
+++ b/website/client/components/Home/TryItLoading.vue
@@ -110,13 +110,13 @@ const detailMessage = computed(() => {
 .sponsor-section .sponsor-title {
   font-weight: bold;
   font-size: 1.1em;
-  color: var(--vp-c-brand-1);
+  color: var(--brand-text);
   text-decoration: underline;
 }
 
 .sponsor-section .sponsor-subtitle {
   font-size: 0.9em;
-  color: var(--vp-c-brand-1);
+  color: var(--brand-text);
   text-decoration: underline;
 }
 

--- a/website/client/components/Home/TryItPackOptions.vue
+++ b/website/client/components/Home/TryItPackOptions.vue
@@ -299,11 +299,7 @@ function handleCompressToggle(enabled: boolean) {
 }
 
 .option-label a {
-  color: var(--vp-c-brand-1);
-  text-decoration: none;
-}
-
-.option-label a:hover {
+  color: var(--brand-text);
   text-decoration: underline;
 }
 
@@ -335,8 +331,9 @@ function handleCompressToggle(enabled: boolean) {
 }
 
 .format-button.active {
-  background: var(--vp-c-brand-1);
-  border-color: var(--vp-c-brand-1);
+  /* Use the darker brand shade so white text meets WCAG AA contrast. */
+  background: var(--vp-c-brand-3);
+  border-color: var(--vp-c-brand-3);
   color: white;
 }
 

--- a/website/client/components/Home/TryItResult.vue
+++ b/website/client/components/Home/TryItResult.vue
@@ -171,7 +171,7 @@ const handleRepack = (selectedFiles: FileInfo[]) => {
 }
 
 .tab-button.active {
-  color: var(--vp-c-brand-1);
+  color: var(--brand-text);
   border-bottom-color: var(--vp-c-brand-1);
   background: var(--vp-c-bg);
 }

--- a/website/client/components/Home/TryItResultContent.vue
+++ b/website/client/components/Home/TryItResultContent.vue
@@ -444,7 +444,7 @@ dd {
 }
 
 .cli-banner-icon {
-  color: var(--vp-c-brand-1);
+  color: var(--brand-text);
   flex-shrink: 0;
 }
 
@@ -477,7 +477,7 @@ dd {
   border: 1px solid var(--vp-c-brand-1);
   border-radius: 6px;
   background: var(--vp-c-bg);
-  color: var(--vp-c-brand-1);
+  color: var(--brand-text);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;

--- a/website/client/components/Home/TryItResultErrorContent.vue
+++ b/website/client/components/Home/TryItResultErrorContent.vue
@@ -140,7 +140,7 @@ code {
 
 .copy-button:hover {
   border-color: var(--vp-c-brand-1);
-  color: var(--vp-c-brand-1);
+  color: var(--brand-text);
 }
 
 .copy-button.copied {
@@ -150,7 +150,7 @@ code {
 }
 
 .guide-link a {
-  color: var(--vp-c-brand-1);
+  color: var(--brand-text);
   text-decoration: none;
   font-weight: 500;
 }


### PR DESCRIPTION
## Summary

Running Lighthouse on https://repomix.com surfaced several accessibility issues. This raises the Lighthouse **Accessibility score from 93 to 100** (verified against the Cloudflare preview deploy), while keeping the bright brand orange (`#f97316`) intact for decorative/gradient use.

This PR also bundles a **CI fix** (see below) that unblocks the Website CI jobs, which have been red on `main` since the npm 12.0.1 bump.

### Accessibility — what was failing (WCAG AA contrast + landmarks)

- **Contrast**: hero accent text, active format button (white on `#f97316`), inline `<code>`, sponsor links, in-text links, `::: tip` block links, syntax-highlight comments (`#6A737D`), and brand-orange text in the Try It tool (cli banner, result tabs, error/reset buttons)
- **Missing `<main>` landmark**: VitePress's home layout renders only `<div class="VPContent">`
- **Links relying on color alone** in prose

### Accessibility — approach

- Introduce a `--brand-text` variable: darker orange (`#c2410c`) in light mode, `#f97316` in dark mode. Applied to accent text, links, inline code, tip-block links, and Try It tool text. The bright brand orange is untouched for gradients/borders/fills.
- Darken the active format button fill so white text meets contrast in both modes.
- Underline inline prose links so they don't rely on color alone.
- Wrap home content in `<main>` for a proper landmark.
- Raise the syntax-highlight comment color per mode via a case-insensitive attribute selector (avoids a full syntax-theme swap that would change every code block's look).

## CI fix (bundled)

Since the `npm 12.0.1` bump, the Website Server CI jobs fail at `npm ci`: `website/server` depends on `github:yamadashy/repomix#main` (a git dependency), and npm 12 prepares git deps with `--before`, which conflicts with the repo's `min-release-age` config.

- Downgrade to `npm 11.4.0` only for the `website/server` install (mirrors the existing `website/server/Dockerfile` workaround), keeping npm 12 + `min-release-age` for the root build.
- A scoped `npm_config_min_release_age: 0` env was tried first but does not work — the git-dep prep child re-reads `.npmrc` and `0` still counts as "provided".
- The zizmor `adhoc-packages` finding is exempted for `ci-website.yml` in `.github/zizmor.yml`, alongside the existing `action.yml` / `npm-publish.yml` exemptions.

### Notes

- Locale docs are unchanged; these are theme/component CSS and markup changes only, so no per-language doc updates are needed.
- Best Practices (deprecated third-party APIs) and Performance/LCP are largely bound to sponsor/analytics scripts and the VitePress bundle, and are out of scope here.

## Checklist

- [x] Run `npm run test` (N/A — website-only changes; verified with `npm run docs:build` in `website/client`)
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)