### PR TITLE
fix(core): subdivide oversized directories when splitting output

### DIFF
--- a/src/core/output/outputSplit.ts
+++ b/src/core/output/outputSplit.ts
@@ -222,15 +222,20 @@ export const generateSplitOutputParts = async ({
     currentBytes = 0;
   };
 
-  // Note: This algorithm has O(N²) complexity where N is the number of groups.
-  // For each group, we render all accumulated groups to measure the exact output size.
-  // This approach is intentional because:
+  // Note: Measuring each part exactly means rendering all groups accumulated so far, giving a
+  // base cost of O(N²) in the number of groups N. N is not fixed: a group that cannot fit even
+  // on its own is subdivided one directory level deeper and re-queued (see below), so on
+  // pathological inputs (e.g. a single huge top-level directory) N — and the number of renders —
+  // grows until each part fits, bottoming out at individual files. This exact-render approach is
+  // intentional because:
   // 1. The final output size cannot be predicted by simple addition - the output includes
   //    a file tree structure and template formatting (XML/Markdown) that vary non-linearly.
   // 2. Headers, footers, and file tree size change based on the combination of groups.
   // 3. For typical repositories with ~10-20 top-level directories, this is acceptable.
-  // If performance becomes an issue, consider caching individual group content sizes
-  // and estimating combined sizes with a safety margin.
+  // If performance becomes an issue, consider caching each group's standalone render size (their
+  // sum is an upper bound on the combined size, since shared tree structure and fixed overhead
+  // are only counted once when combined) to skip the exact render when a part clearly fits, and
+  // fall back to an exact render only near the limit so correctness is preserved.
   while (queue.length > 0) {
     const group = queue.shift() as OutputSplitGroup;
     const partIndex = parts.length + 1;

--- a/src/core/output/outputSplit.ts
+++ b/src/core/output/outputSplit.ts
@@ -31,6 +31,50 @@ export const getRootEntry = (relativeFilePath: string): string => {
   return first || normalized;
 };
 
+// Returns the first `depth` path segments joined with '/'. Used to key a group at a
+// deeper directory level than its current one when a single group is too large to fit.
+const getPathPrefix = (relativeFilePath: string, depth: number): string => {
+  const normalized = relativeFilePath.replaceAll(path.win32.sep, path.posix.sep);
+  return normalized.split('/').slice(0, depth).join('/');
+};
+
+// Re-partition an oversized group one directory level deeper. A group keyed by 'src'
+// becomes groups keyed by 'src/a', 'src/b', 'src/file.ts', and so on. Returns null when
+// the group can no longer be divided (a single file, which cannot be split across parts).
+export const subdivideSplitGroup = (group: OutputSplitGroup): OutputSplitGroup[] | null => {
+  const childDepth = group.rootEntry.split('/').length + 1;
+  const childrenByKey = new Map<string, OutputSplitGroup>();
+
+  for (const processedFile of group.processedFiles) {
+    const key = getPathPrefix(processedFile.path, childDepth);
+    const existing = childrenByKey.get(key);
+    if (existing) {
+      existing.processedFiles.push(processedFile);
+    } else {
+      childrenByKey.set(key, { rootEntry: key, processedFiles: [processedFile], allFilePaths: [] });
+    }
+  }
+
+  for (const filePath of group.allFilePaths) {
+    const key = getPathPrefix(filePath, childDepth);
+    const existing = childrenByKey.get(key);
+    if (existing) {
+      existing.allFilePaths.push(filePath);
+    } else {
+      childrenByKey.set(key, { rootEntry: key, processedFiles: [], allFilePaths: [filePath] });
+    }
+  }
+
+  const children = [...childrenByKey.values()].sort((a, b) => a.rootEntry.localeCompare(b.rootEntry));
+
+  // No progress: every path already resolves to the group's own key (a single file), so
+  // there is nothing finer to split into.
+  if (children.length === 1 && children[0].rootEntry === group.rootEntry) {
+    return null;
+  }
+  return children;
+};
+
 export const buildOutputSplitGroups = (processedFiles: ProcessedFile[], allFilePaths: string[]): OutputSplitGroup[] => {
   const groupsByRootEntry = new Map<string, OutputSplitGroup>();
 
@@ -161,6 +205,23 @@ export const generateSplitOutputParts = async ({
   let currentContent = '';
   let currentBytes = 0;
 
+  // Groups are processed via a queue so an oversized group can be replaced in place by its
+  // finer-grained subdivisions (see below) and re-evaluated without special-casing the loop.
+  const queue: OutputSplitGroup[] = [...groups];
+
+  const finalizeCurrentPart = () => {
+    parts.push({
+      index: parts.length + 1,
+      filePath: buildSplitOutputFilePath(baseConfig.output.filePath, parts.length + 1),
+      content: currentContent,
+      byteLength: currentBytes,
+      groups: currentGroups,
+    });
+    currentGroups = [];
+    currentContent = '';
+    currentBytes = 0;
+  };
+
   // Note: This algorithm has O(N²) complexity where N is the number of groups.
   // For each group, we render all accumulated groups to measure the exact output size.
   // This approach is intentional because:
@@ -170,7 +231,8 @@ export const generateSplitOutputParts = async ({
   // 3. For typical repositories with ~10-20 top-level directories, this is acceptable.
   // If performance becomes an issue, consider caching individual group content sizes
   // and estimating combined sizes with a safety margin.
-  for (const group of groups) {
+  while (queue.length > 0) {
+    const group = queue.shift() as OutputSplitGroup;
     const partIndex = parts.length + 1;
     const nextGroups = [...currentGroups, group];
     progressCallback(`Generating output... (part ${partIndex}) ${pc.dim(`evaluating ${group.rootEntry}`)}`);
@@ -194,57 +256,31 @@ export const generateSplitOutputParts = async ({
       continue;
     }
 
-    if (currentGroups.length === 0) {
-      throw new RepomixError(
-        `Cannot split output: root entry '${group.rootEntry}' exceeds max size. ` +
-          `Part size ${nextBytes.toLocaleString()} bytes > limit ${maxBytesPerPart.toLocaleString()} bytes.`,
-      );
+    // The group does not fit alongside what is already accumulated: flush the current part
+    // and retry this group on a fresh part.
+    if (currentGroups.length > 0) {
+      finalizeCurrentPart();
+      queue.unshift(group);
+      continue;
     }
 
-    // Finalize current part and start a new one with the current group.
-    parts.push({
-      index: partIndex,
-      filePath: buildSplitOutputFilePath(baseConfig.output.filePath, partIndex),
-      content: currentContent,
-      byteLength: currentBytes,
-      groups: currentGroups,
-    });
+    // The group does not fit even on its own. Split it one directory level deeper and retry
+    // the finer-grained groups. Only a single file cannot be divided further.
+    const subGroups = subdivideSplitGroup(group);
+    if (subGroups) {
+      queue.unshift(...subGroups);
+      continue;
+    }
 
-    const newPartIndex = parts.length + 1;
-    progressCallback(`Generating output... (part ${newPartIndex}) ${pc.dim(`evaluating ${group.rootEntry}`)}`);
-    const singleGroupContent = await renderGroups(
-      [group],
-      newPartIndex,
-      rootDirs,
-      baseConfig,
-      gitDiffResult,
-      gitLogResult,
-      filePathsByRoot,
-      emptyDirPaths,
-      deps.generateOutput,
+    throw new RepomixError(
+      `Cannot split output: '${group.rootEntry}' exceeds max size on its own. ` +
+        `Size ${nextBytes.toLocaleString()} bytes > limit ${maxBytesPerPart.toLocaleString()} bytes. ` +
+        'A single file cannot be split across parts.',
     );
-    const singleGroupBytes = getUtf8ByteLength(singleGroupContent);
-    if (singleGroupBytes > maxBytesPerPart) {
-      throw new RepomixError(
-        `Cannot split output: root entry '${group.rootEntry}' exceeds max size. ` +
-          `Part size ${singleGroupBytes.toLocaleString()} bytes > limit ${maxBytesPerPart.toLocaleString()} bytes.`,
-      );
-    }
-
-    currentGroups = [group];
-    currentContent = singleGroupContent;
-    currentBytes = singleGroupBytes;
   }
 
   if (currentGroups.length > 0) {
-    const finalIndex = parts.length + 1;
-    parts.push({
-      index: finalIndex,
-      filePath: buildSplitOutputFilePath(baseConfig.output.filePath, finalIndex),
-      content: currentContent,
-      byteLength: currentBytes,
-      groups: currentGroups,
-    });
+    finalizeCurrentPart();
   }
 
   return parts;

--- a/tests/core/output/outputSplit.test.ts
+++ b/tests/core/output/outputSplit.test.ts
@@ -4,6 +4,7 @@ import {
   buildSplitOutputFilePath,
   generateSplitOutputParts,
   getRootEntry,
+  subdivideSplitGroup,
 } from '../../../src/core/output/outputSplit.js';
 
 describe('outputSplit', () => {
@@ -49,6 +50,45 @@ describe('outputSplit', () => {
     });
   });
 
+  describe('subdivideSplitGroup', () => {
+    it('splits a root-entry group one directory level deeper', () => {
+      const group = {
+        rootEntry: 'src',
+        processedFiles: [
+          { path: 'src/a.ts', content: 'a' },
+          { path: 'src/sub/b.ts', content: 'b' },
+          { path: 'src/sub/c.ts', content: 'c' },
+        ],
+        allFilePaths: ['src/a.ts', 'src/sub/b.ts', 'src/sub/c.ts', 'src/sub/ignored.txt'],
+      };
+
+      const children = subdivideSplitGroup(group);
+
+      expect(children?.map((c) => c.rootEntry)).toEqual(['src/a.ts', 'src/sub']);
+      const sub = children?.find((c) => c.rootEntry === 'src/sub');
+      expect(sub?.processedFiles.map((f) => f.path).sort()).toEqual(['src/sub/b.ts', 'src/sub/c.ts']);
+      expect(sub?.allFilePaths.sort()).toEqual(['src/sub/b.ts', 'src/sub/c.ts', 'src/sub/ignored.txt']);
+    });
+
+    it('returns null for a single indivisible file', () => {
+      expect(
+        subdivideSplitGroup({
+          rootEntry: 'README.md',
+          processedFiles: [{ path: 'README.md', content: 'readme' }],
+          allFilePaths: ['README.md'],
+        }),
+      ).toBeNull();
+
+      expect(
+        subdivideSplitGroup({
+          rootEntry: 'src/large.ts',
+          processedFiles: [{ path: 'src/large.ts', content: 'large' }],
+          allFilePaths: ['src/large.ts'],
+        }),
+      ).toBeNull();
+    });
+  });
+
   describe('buildSplitOutputFilePath', () => {
     it('inserts part index before extension', () => {
       expect(buildSplitOutputFilePath('repomix-output.xml', 1)).toBe('repomix-output.1.xml');
@@ -76,7 +116,9 @@ describe('outputSplit', () => {
       generateOutput: async () => 'x'.repeat(outputSize),
     });
 
-    it('throws error when single root entry exceeds maxBytesPerPart', async () => {
+    it('throws error when a single indivisible file exceeds maxBytesPerPart', async () => {
+      // A lone file cannot be split across parts, so once subdivision bottoms out at it the
+      // output still cannot be produced.
       const processedFiles = [{ path: 'src/large.ts', content: 'large content' }];
       const allFilePaths = ['src/large.ts'];
 
@@ -93,6 +135,45 @@ describe('outputSplit', () => {
           deps: createMockDeps(100), // Output larger than limit
         }),
       ).rejects.toThrow(/exceeds max size/);
+    });
+
+    it('subdivides a single oversized root entry into multiple parts instead of throwing', async () => {
+      // All files live under one root entry 'src', so the whole group is far larger than the
+      // limit. Previously this threw "root entry 'src' exceeds max size" (issue #1134); now the
+      // group is split one level deeper until each part fits.
+      const processedFiles = [
+        { path: 'src/a.ts', content: 'a' },
+        { path: 'src/b.ts', content: 'b' },
+        { path: 'src/sub/c.ts', content: 'c' },
+        { path: 'src/sub/d.ts', content: 'd' },
+      ];
+      const allFilePaths = processedFiles.map((f) => f.path);
+
+      // Size grows with the number of processed files in the chunk, so one file fits but the
+      // full 'src' group does not.
+      const mockGenerateOutput = async (_rootDirs: string[], _config: unknown, files: Array<{ path: string }>) =>
+        'x'.repeat(30 + files.length * 50);
+
+      const result = await generateSplitOutputParts({
+        rootDirs: ['/test'],
+        baseConfig: createMockConfig(),
+        processedFiles,
+        allFilePaths,
+        maxBytesPerPart: 100, // fits one file (80), not two (130)
+        gitDiffResult: undefined,
+        gitLogResult: undefined,
+        progressCallback: () => {},
+        deps: { generateOutput: mockGenerateOutput as ReturnType<typeof createMockDeps>['generateOutput'] },
+      });
+
+      expect(result.length).toBeGreaterThan(1);
+      for (const part of result) {
+        expect(part.byteLength).toBeLessThanOrEqual(100);
+      }
+
+      // Every file is covered exactly once across all parts, none dropped or duplicated.
+      const packedFiles = result.flatMap((p) => p.groups.flatMap((g) => g.processedFiles.map((f) => f.path)));
+      expect(packedFiles.sort()).toEqual(['src/a.ts', 'src/b.ts', 'src/sub/c.ts', 'src/sub/d.ts']);
     });
 
     it('throws error for invalid maxBytesPerPart', async () => {


### PR DESCRIPTION
Closes #1134. `repomix --split-output 1mb` fails with `Cannot split output: root entry 'src' exceeds max size` on any repo where a single top-level directory is bigger than the part limit — which is most real projects, where `src` dominates.

The split logic groups files by their top-level entry and treats each group as atomic: if one group doesn't fit in a part even on its own, it throws. So the flag only works when no single top-level directory exceeds the limit.

This re-partitions an oversized group one directory level deeper (`src` → `src/a`, `src/b`, `src/file.ts`, …) and retries, recursing until each part fits. It bottoms out at individual files — a lone file still can't be split across parts, and that case keeps throwing with a clearer message. Groups that already fit are packed exactly as before, so normal splitting is unchanged.

Verified end to end on a repo whose only top-level dir is ~29KB with an 8KB limit: main throws `root entry 'src' exceeds max size`, this branch produces 5 parts each under the limit with every file covered once. Added unit coverage for the subdivision and updated the single-file case; full output + packager suites green.