### PR TITLE
fix(output): Widen Markdown fence so git diffs can't break it

### DIFF
--- a/src/core/output/outputGenerate.ts
+++ b/src/core/output/outputGenerate.ts
@@ -52,9 +52,14 @@ const getCompiledTemplate = (style: string): Handlebars.TemplateDelegate => {
   return compiled;
 };
 
-const calculateMarkdownDelimiter = (files: ReadonlyArray<ProcessedFile>): string => {
-  const maxBackticks = files
-    .flatMap((file) => file.content.match(/`+/g) ?? [])
+// The Markdown template wraps file contents, the directory structure, and git
+// diffs in the same code fence, so the delimiter has to be longer than the
+// longest backtick run across all of them. A diff of a Markdown file, for
+// example, carries bare ``` context lines that would otherwise close the fence
+// early and corrupt the output.
+const calculateMarkdownDelimiter = (contents: ReadonlyArray<string | undefined>): string => {
+  const maxBackticks = contents
+    .flatMap((content) => content?.match(/`+/g) ?? [])
     .reduce((max, match) => Math.max(max, match.length), 0);
   return '`'.repeat(Math.max(3, maxBackticks + 1));
 };
@@ -95,7 +100,12 @@ export const createRenderContext = (outputGeneratorContext: OutputGeneratorConte
     directoryStructureEnabled: outputGeneratorContext.config.output.directoryStructure,
     filesEnabled: outputGeneratorContext.config.output.files,
     escapeFileContent: outputGeneratorContext.config.output.parsableStyle,
-    markdownCodeBlockDelimiter: calculateMarkdownDelimiter(outputGeneratorContext.processedFiles),
+    markdownCodeBlockDelimiter: calculateMarkdownDelimiter([
+      ...outputGeneratorContext.processedFiles.map((file) => file.content),
+      outputGeneratorContext.treeString,
+      outputGeneratorContext.gitDiffResult?.workTreeDiffContent,
+      outputGeneratorContext.gitDiffResult?.stagedDiffContent,
+    ]),
     gitDiffEnabled: outputGeneratorContext.config.output.git?.includeDiffs,
     gitDiffWorkTree: outputGeneratorContext.gitDiffResult?.workTreeDiffContent,
     gitDiffStaged: outputGeneratorContext.gitDiffResult?.stagedDiffContent,

--- a/src/core/output/outputStyles/markdownStyle.ts
+++ b/src/core/output/outputStyles/markdownStyle.ts
@@ -33,9 +33,9 @@ export const getMarkdownTemplate = () => {
 {{/if}}
 {{#if directoryStructureEnabled}}
 # Directory Structure
-\`\`\`
+{{{markdownCodeBlockDelimiter}}}
 {{{treeString}}}
-\`\`\`
+{{{markdownCodeBlockDelimiter}}}
 
 {{/if}}
 {{#if filesEnabled}}
@@ -53,14 +53,14 @@ export const getMarkdownTemplate = () => {
 {{#if gitDiffEnabled}}
 # Git Diffs
 ## Git Diffs Working Tree
-\`\`\`diff
+{{{markdownCodeBlockDelimiter}}}diff
 {{{gitDiffWorkTree}}}
-\`\`\`
+{{{markdownCodeBlockDelimiter}}}
 
 ## Git Diffs Staged
-\`\`\`diff
+{{{markdownCodeBlockDelimiter}}}diff
 {{{gitDiffStaged}}}
-\`\`\`
+{{{markdownCodeBlockDelimiter}}}
 
 {{/if}}
 

--- a/tests/core/output/outputGenerate.test.ts
+++ b/tests/core/output/outputGenerate.test.ts
@@ -233,6 +233,34 @@ describe('outputGenerate', () => {
     expect(output).toContain('diff --git b/staged.txt');
   });
 
+  test('generateOutput (markdown) widens the code fence so backticks in a git diff cannot close it early', async () => {
+    const fence = '```';
+    const mockConfig = createMockConfig({
+      output: {
+        filePath: 'output.md',
+        style: 'markdown',
+        git: { includeDiffs: true },
+      },
+    });
+    const mockProcessedFiles: ProcessedFile[] = [{ path: 'file1.txt', content: 'content1' }];
+    // A unified diff of a Markdown file carries bare ``` context lines (space-prefixed),
+    // which are valid Markdown closing fences and would break a plain ```diff block.
+    const mockGitDiffResult = {
+      workTreeDiffContent: `diff --git a/README.md b/README.md\n@@ -1,3 +1,3 @@\n ${fence}\n-old\n+new\n ${fence}`,
+      stagedDiffContent: '',
+    };
+
+    const output = await generateOutput([process.cwd()], mockConfig, mockProcessedFiles, [], mockGitDiffResult);
+
+    // The diff fence must be longer than the ``` inside it, so the whole diff stays in one block.
+    const section = output.slice(output.indexOf('## Git Diffs Working Tree'));
+    const openFence = section.match(/^(`+)diff$/m);
+    expect(openFence).not.toBeNull();
+    expect(openFence?.[1].length ?? 0).toBeGreaterThan(fence.length);
+    expect(section).toContain('-old');
+    expect(section).toContain('+new');
+  });
+
   test('generateOutput should include git logs when enabled', async () => {
     const mockConfig = createMockConfig({
       output: {


### PR DESCRIPTION
The Markdown fence delimiter is computed only from file contents (`calculateMarkdownDelimiter`), but the template also wraps the directory structure and git diffs in a fixed triple-backtick fence. That's fine until a git diff contains backticks — which happens whenever you diff a Markdown file. A unified diff keeps the file's own fence lines as context, space-indented, and a space-indented bare triple backtick is a valid Markdown closing fence, so it ends the diff block early and the rest of the diff spills out as broken markup.

Repro with `--style markdown --include-diffs` on a repo with an uncommitted change near a code block in a Markdown file — the context line closes the diff block:

    ## Git Diffs Working Tree
    ```diff
    diff --git a/README.md b/README.md
    @@ -1,3 +1,3 @@
     ```        <- this closing fence in the diff ends the block early
    -old
    +new
    ```

The fix mirrors what's already done for file contents: fold the tree and diff text into the delimiter calculation so the fence is longer than any backtick run inside them, and use that delimiter for the directory-structure and git-diff fences instead of a fixed one. Added a regression test with a diff that carries a bare fence context line.