### PR TITLE
fix(cli): Skip migrations for untrusted remote repos

### DIFF
--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -35,8 +35,11 @@ export interface DefaultActionRunnerResult {
  * default and watch actions so the config pipeline lives in one place.
  */
 export const buildMergedConfig = async (cwd: string, cliOptions: CliOptions): Promise<RepomixConfigMerged> => {
-  // Run migration before loading config
-  await runMigrationAction(cwd);
+  // A remote repository can opt out of its local config. Its legacy files must
+  // not then trigger an interactive migration or mutate the temporary clone.
+  if (!cliOptions.skipLocalConfig) {
+    await runMigrationAction(cwd);
+  }
 
   // Load the config file in main process
   const fileConfig: RepomixConfigFile = await loadFileConfig(cwd, cliOptions.config ?? null, {

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -1,6 +1,7 @@
 import process from 'node:process';
 import { afterEach, beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest';
-import { buildCliConfig, runDefaultAction } from '../../../src/cli/actions/defaultAction.js';
+import { buildCliConfig, buildMergedConfig, runDefaultAction } from '../../../src/cli/actions/defaultAction.js';
+import * as migrationAction from '../../../src/cli/actions/migrationAction.js';
 import type { CliOptions } from '../../../src/cli/types.js';
 import * as configLoader from '../../../src/config/configLoad.js';
 import * as fileStdin from '../../../src/core/file/fileStdin.js';
@@ -14,6 +15,7 @@ vi.mock('../../../src/config/configLoad');
 vi.mock('../../../src/core/file/packageJsonParse');
 vi.mock('../../../src/core/file/fileStdin');
 vi.mock('../../../src/shared/logger');
+vi.mock('../../../src/cli/actions/migrationAction');
 
 const mockSpinner = {
   start: vi.fn() as MockedFunction<() => void>,
@@ -118,6 +120,21 @@ describe('defaultAction', () => {
     expect(packager.pack).toHaveBeenCalled();
     expect(mockSpinner.start).toHaveBeenCalled();
     expect(mockSpinner.succeed).toHaveBeenCalled();
+  });
+
+  it('should not migrate legacy files when local config is skipped', async () => {
+    await buildMergedConfig('/tmp/remote-repository', { skipLocalConfig: true });
+
+    expect(migrationAction.runMigrationAction).not.toHaveBeenCalled();
+    expect(configLoader.loadFileConfig).toHaveBeenCalledWith('/tmp/remote-repository', null, {
+      skipLocalConfig: true,
+    });
+  });
+
+  it('should migrate legacy files when local config is used', async () => {
+    await buildMergedConfig('/tmp/local-repository', {});
+
+    expect(migrationAction.runMigrationAction).toHaveBeenCalledWith('/tmp/local-repository');
   });
 
   it('should handle custom include patterns', async () => {


### PR DESCRIPTION
## Summary

- Skip legacy migration when the config pipeline is explicitly told not to load local repository config.
- Keep untrusted `--remote` clones from prompting for migration or rewriting legacy files.

## Root cause

`runRemoteAction` passed `skipLocalConfig: true`, but `buildMergedConfig` ran the migration before observing that flag.

## Tests

- `npm test -- --run` (1,523 passed, 14 skipped)
- `npm run lint`
