### PR TITLE
fix(output): Resolve Markdown language hint for extensionless filenames in subdirectories

### DIFF
--- a/src/core/output/outputStyleUtils.ts
+++ b/src/core/output/outputStyleUtils.ts
@@ -219,7 +219,13 @@ const extensionToLanguageMap: Record<string, string> = {
  * @returns The language name for syntax highlighting, or empty string if unknown
  */
 export const getLanguageFromFilePath = (filePath: string): string => {
-  const extension = filePath.split('.').pop()?.toLowerCase();
+  // Match against the basename, not the whole path: the map holds a few
+  // extensionless whole-filename keys (dockerfile, makefile, cmake). A path
+  // like `docker/Dockerfile` has no dot, so splitting the full path on '.'
+  // keeps the directory prefix and misses the map (root-level `Dockerfile`
+  // matched, subdirectory ones silently fell back to no language hint).
+  const basename = filePath.split(/[\\/]/).pop() ?? '';
+  const extension = basename.split('.').pop()?.toLowerCase();
   return extension ? extensionToLanguageMap[extension] || '' : '';
 };
 

--- a/tests/core/output/outputStyles/markdownStyle.test.ts
+++ b/tests/core/output/outputStyles/markdownStyle.test.ts
@@ -235,5 +235,17 @@ describe('markdownStyle', () => {
       expect(getExtension('file.unknown')).toBe(''); // Unknown extension
       expect(getExtension('path/to/file.js')).toBe('javascript'); // Path with directory
     });
+
+    // Extensionless whole-filename keys (Dockerfile, Makefile) must resolve in
+    // subdirectories too, not only at the repo root.
+    test('should handle extensionless filenames regardless of directory depth', () => {
+      expect(getExtension('Dockerfile')).toBe('dockerfile');
+      expect(getExtension('docker/Dockerfile')).toBe('dockerfile');
+      expect(getExtension('services/api/Dockerfile')).toBe('dockerfile');
+      expect(getExtension('Makefile')).toBe('makefile');
+      expect(getExtension('src/Makefile')).toBe('makefile');
+      expect(getExtension('my.dir/Dockerfile')).toBe('dockerfile'); // dot in a directory segment
+      expect(getExtension('path\\to\\Dockerfile')).toBe('dockerfile'); // Windows separator
+    });
   });
 });


### PR DESCRIPTION
In Markdown output the code-fence language hint is dropped for `Dockerfile`, `Makefile` and similar files whenever they sit in a subdirectory, while the same file at the repo root gets it right.

`getLanguageFromFilePath` builds the hint by splitting the path on `.` and looking up the last piece. The extension map has a few extensionless whole-filename keys (`dockerfile`, `makefile`, `cmake`), which only work when the path has no directory prefix — `docker/Dockerfile` has no dot at all, so `split(".")` keeps the whole path and the lookup misses:

```
getLanguageFromFilePath("Dockerfile")         // "dockerfile"
getLanguageFromFilePath("docker/Dockerfile")  // "" (should be "dockerfile")
getLanguageFromFilePath("src/Makefile")       // "" (should be "makefile")
```

So `docker/Dockerfile` renders as a bare fence with no language, but a root `Dockerfile` renders as ```` ```dockerfile ````. Fixed by matching against the basename before splitting on the dot. Files with normal extensions, dotfiles, and unknown types are unchanged.

Added regression tests for the subdirectory cases (plus a dotted directory segment and a Windows separator).