### PR TITLE
fix(website): Restore bright brand orange for buttons and text

### DIFF
--- a/website/client/.vitepress/theme/custom.css
+++ b/website/client/.vitepress/theme/custom.css
@@ -4,23 +4,6 @@
   --vp-c-brand-3: #c2410c;
   --vp-c-brand-soft: rgba(249, 115, 22, 0.1);
 
-  /*
-   * Accessible brand color for text/links.
-   * The brand orange (#f97316) fails WCAG AA contrast as text on light
-   * backgrounds, so use the darker shade in light mode. On dark backgrounds
-   * the lighter orange has enough contrast, so .dark keeps #f97316.
-   */
-  --brand-text: var(--vp-c-brand-3);
-
-  /* Inline code text: default is the brand orange, which fails contrast on the
-     light code background. Use the accessible brand color instead. */
-  --vp-code-color: var(--brand-text);
-  /* Linked inline code (<a><code>) uses its own token, also the brand orange. */
-  --vp-code-link-color: var(--brand-text);
-  --vp-code-link-hover-color: var(--brand-text);
-  /* Code block language label: default (--vp-c-text-3) is too faint. */
-  --vp-code-lang-color: var(--vp-c-text-2);
-
   --vp-c-danger: #f44336;
 
   --vp-home-hero-name-color: transparent;
@@ -39,43 +22,9 @@
   order: 1;
 }
 
-.dark {
-  --brand-text: var(--vp-c-brand-1);
+.hero-description__accent {
+  color: var(--vp-c-brand-1);
 }
-
-/* Content links: use the accessible brand color, and underline inline links
-   inside prose so they are distinguishable without relying on color alone. */
-.vp-doc a {
-  color: var(--brand-text);
-}
-/* Default hover shifts to the lighter brand-2, which drops below AA on white. */
-.vp-doc a:hover {
-  color: var(--brand-text);
-}
-.vp-doc p a,
-.vp-doc li a {
-  text-decoration: underline;
-}
-
-/* Links/code inside tip blocks default to the brand orange, which fails
-   contrast on the tinted tip background. Use the accessible brand color. */
-.custom-block.tip a,
-.custom-block.tip code,
-.custom-block.tip a:hover,
-.custom-block.tip a:hover > code {
-  color: var(--brand-text);
-}
-
-/* Syntax highlighting comments use #6A737D for both light and dark themes,
-   which fails WCAG AA contrast on the code block background. Raise the contrast
-   per mode by targeting the inline shiki color the tokens carry. */
-html:not(.dark) .vp-code span[style*="#6a737d" i] {
-  color: #57606a;
-}
-.dark .vp-code span[style*="#6a737d" i] {
-  color: #8b949e;
-}
-
 .cli-section {
   margin-bottom: 32px;
   max-width: 800px;

--- a/website/client/components/Home/Hero.vue
+++ b/website/client/components/Home/Hero.vue
@@ -42,7 +42,7 @@ const { site } = useData();
 }
 
 .hero-description__accent {
-  color: var(--brand-text);
+  color: var(--vp-c-brand-1);
 }
 
 .hero-tagline {

--- a/website/client/components/Home/TryIt.vue
+++ b/website/client/components/Home/TryIt.vue
@@ -418,7 +418,7 @@ onMounted(() => {
 }
 
 .reset-button:hover {
-  color: var(--brand-text);
+  color: var(--vp-c-brand-1);
   border-color: var(--vp-c-brand-1);
   background: var(--vp-c-bg-soft);
 

--- a/website/client/components/Home/TryItLoading.vue
+++ b/website/client/components/Home/TryItLoading.vue
@@ -110,13 +110,13 @@ const detailMessage = computed(() => {
 .sponsor-section .sponsor-title {
   font-weight: bold;
   font-size: 1.1em;
-  color: var(--brand-text);
+  color: var(--vp-c-brand-1);
   text-decoration: underline;
 }
 
 .sponsor-section .sponsor-subtitle {
   font-size: 0.9em;
-  color: var(--brand-text);
+  color: var(--vp-c-brand-1);
   text-decoration: underline;
 }
 

--- a/website/client/components/Home/TryItPackOptions.vue
+++ b/website/client/components/Home/TryItPackOptions.vue
@@ -299,7 +299,11 @@ function handleCompressToggle(enabled: boolean) {
 }
 
 .option-label a {
-  color: var(--brand-text);
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+}
+
+.option-label a:hover {
   text-decoration: underline;
 }
 
@@ -331,9 +335,8 @@ function handleCompressToggle(enabled: boolean) {
 }
 
 .format-button.active {
-  /* Use the darker brand shade so white text meets WCAG AA contrast. */
-  background: var(--vp-c-brand-3);
-  border-color: var(--vp-c-brand-3);
+  background: var(--vp-c-brand-1);
+  border-color: var(--vp-c-brand-1);
   color: white;
 }
 

--- a/website/client/components/Home/TryItResult.vue
+++ b/website/client/components/Home/TryItResult.vue
@@ -171,7 +171,7 @@ const handleRepack = (selectedFiles: FileInfo[]) => {
 }
 
 .tab-button.active {
-  color: var(--brand-text);
+  color: var(--vp-c-brand-1);
   border-bottom-color: var(--vp-c-brand-1);
   background: var(--vp-c-bg);
 }

--- a/website/client/components/Home/TryItResultContent.vue
+++ b/website/client/components/Home/TryItResultContent.vue
@@ -444,7 +444,7 @@ dd {
 }
 
 .cli-banner-icon {
-  color: var(--brand-text);
+  color: var(--vp-c-brand-1);
   flex-shrink: 0;
 }
 
@@ -477,7 +477,7 @@ dd {
   border: 1px solid var(--vp-c-brand-1);
   border-radius: 6px;
   background: var(--vp-c-bg);
-  color: var(--brand-text);
+  color: var(--vp-c-brand-1);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;

--- a/website/client/components/Home/TryItResultErrorContent.vue
+++ b/website/client/components/Home/TryItResultErrorContent.vue
@@ -140,7 +140,7 @@ code {
 
 .copy-button:hover {
   border-color: var(--vp-c-brand-1);
-  color: var(--brand-text);
+  color: var(--vp-c-brand-1);
 }
 
 .copy-button.copied {
@@ -150,7 +150,7 @@ code {
 }
 
 .guide-link a {
-  color: var(--brand-text);
+  color: var(--vp-c-brand-1);
   text-decoration: none;
   font-weight: 500;
 }


### PR DESCRIPTION
Reverts the color changes from the Lighthouse accessibility work (#1712 follow-ups: ca43614d, 1ceee292, 7e9bc579). The darker `#c2410c` shade used for WCAG AA contrast changed the site's look more than expected, so this restores the original bright brand orange (`#f97316`) for:

- Output format buttons (active state) on the Try It tool
- "AI-friendly" hero accent text
- Doc links, inline code, and tip-block links (including the added underlines)
- Try It tool text colors (sponsor banner, result tabs, reset button, error links)

The non-visual parts of that work are kept: the `<main>` landmark and the CI `min-release-age` fix. The Lighthouse accessibility score is expected to drop back from 100 to ~93; this is an intentional trade-off favoring the brand look.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)