### PR TITLE
fix(website): Reserve layout space for sponsor images and nav star button

### DIFF
--- a/website/client/components/Home/TryItLoading.vue
+++ b/website/client/components/Home/TryItLoading.vue
@@ -37,7 +37,7 @@ const detailMessage = computed(() => {
     <div class="sponsor-section">
       <p class="sponsor-header">Special thanks to:</p>
       <a href="https://go.warp.dev/repomix" target="_blank" rel="noopener noreferrer">
-        <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
+        <img alt="Warp sponsorship" width="400" height="225" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
       </a>
       <p class="sponsor-title">
         <a href="https://go.warp.dev/repomix" target="_blank" rel="noopener noreferrer">

--- a/website/client/components/NavBarGitHubStar.vue
+++ b/website/client/components/NavBarGitHubStar.vue
@@ -20,8 +20,12 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div v-if="isDesktop" class="nav-github-star">
+  <!-- The wrapper is always rendered (hidden below 960px via CSS) so the navbar
+       reserves the button's width before the client-side mount inserts the
+       iframe; gating the wrapper itself with v-if shifts the navbar (CLS). -->
+  <div class="nav-github-star">
     <iframe
+      v-if="isDesktop"
       title="Star yamadashy/repomix on GitHub"
       src="https://unpkg.com/github-buttons@2.29.1/dist/buttons.html#href=https%3A%2F%2Fgithub.com%2Fyamadashy%2Frepomix&data-text=Star&data-size=large&data-show-count=true&data-color-scheme=no-preference%3A+light%3B+light%3A+light%3B+dark%3A+dark%3B"
       sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
@@ -33,11 +37,21 @@ onUnmounted(() => {
 
 <style scoped>
 .nav-github-star {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: var(--vp-nav-height);
-  padding: 0 12px;
+  display: none;
+}
+
+/* Match the JS breakpoint (min-width: 960px) that gates the iframe. */
+@media (min-width: 960px) {
+  .nav-github-star {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    height: var(--vp-nav-height);
+    /* 130px iframe + 12px padding on each side */
+    width: 154px;
+    padding: 0 12px;
+  }
 }
 
 .github-star-button {

--- a/website/client/src/shared/sponsors-section.md
+++ b/website/client/src/shared/sponsors-section.md
@@ -3,8 +3,11 @@
    <br>
    <br>
 
+<!-- Image width/height attributes reserve layout space before load (CLS).
+     The values only need to match the source image's aspect ratio;
+     style="height: auto" keeps the ratio when max-width shrinks the image. -->
    <a href="https://go.warp.dev/repomix" target="_blank">
-      <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
+      <img alt="Warp sponsorship" width="400" height="225" style="height: auto" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
    </a>
 
   [Warp, built for coding with multiple AI agents](https://go.warp.dev/repomix)  
@@ -16,7 +19,7 @@
    <a href="https://coderabbit.link/repomix" target="_blank">
       <picture>
          <source media="(prefers-color-scheme: dark)" srcset="/images/sponsors/coderabbit/dark.png">
-         <img alt="CodeRabbit sponsorship" width="400" src="/images/sponsors/coderabbit/light.png">
+         <img alt="CodeRabbit sponsorship" width="400" height="58" style="height: auto" src="/images/sponsors/coderabbit/light.png">
       </picture>
    </a>
 
@@ -26,7 +29,11 @@
 
 </div>
 
-[![Sponsors](https://cdn.jsdelivr.net/gh/yamadashy/sponsor-list/sponsors/sponsors.png)](https://github.com/sponsors/yamadashy)
+<!-- sponsors.png is auto-generated and its size changes as sponsors change;
+     the width/height here only need to stay roughly in sync for space reservation. -->
+<a href="https://github.com/sponsors/yamadashy">
+  <img alt="Sponsors" width="1667" height="819" style="height: auto" src="https://cdn.jsdelivr.net/gh/yamadashy/sponsor-list/sponsors/sponsors.png">
+</a>
 
 <div align="center" style="margin: 8px 0 0;">
   <p style="margin: 0 0 12px;">Please consider sponsoring me.</p>


### PR DESCRIPTION
Fixes the field CLS of 0.12 on repomix.com (the only metric failing Core Web Vitals; the "good" threshold is 0.1) by reserving layout space before images and client-only components load. No visual changes.

- Add `height` attributes (with `height: auto`) to the sponsor images in `sponsors-section.md` and `TryItLoading.vue` so browsers reserve space from the aspect ratio before the images load
- Always render the `NavBarGitHubStar` wrapper and hide it below 960px via CSS media query, keeping `v-if` only on the iframe — mobile still skips the request, but the navbar reserves the 154px slot during SSR instead of shifting after mount

The Warp sponsor image intentionally stays on `raw.githubusercontent.com` (so asset updates propagate automatically), which leaves PageSpeed's cache-lifetime / image-delivery suggestions unaddressed — those are lab-only insights and do not affect the Core Web Vitals assessment.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)