### PR TITLE
chore(renovate): Remove PR creation rate limits

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,10 @@
   ],
   "schedule": ["on saturday", "before 1pm on sunday"],
   "rangeStrategy": "bump",
+  // Updates are grouped per area (root/browser/website/scripts/actions),
+  // so open-PR count stays small even without rate limits.
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0,
   "dependencyDashboard": false,
   "labels": ["dependencies", "renovate"],
   "packageRules": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,8 +5,9 @@
   ],
   "schedule": ["on saturday", "before 1pm on sunday"],
   "rangeStrategy": "bump",
-  // Updates are grouped per area (root/browser/website/scripts/actions),
-  // so open-PR count stays small even without rate limits.
+  // Updates are grouped per area (root/browser/website/scripts/actions/
+  // dockerfile/nix), each split into major and non-major groups, so the
+  // open-PR count stays small even without rate limits.
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "dependencyDashboard": false,


### PR DESCRIPTION
Remove Renovate PR rate limits (`prHourlyLimit: 0`, `prConcurrentLimit: 0`) so a single Renovate run opens all grouped update PRs at once, instead of drip-feeding two per hour with the default `prHourlyLimit=2`.

Updates are already grouped per area (root/browser/website/scripts/actions), so the open-PR count stays small even without limits.

## Checklist

- [x] Config-only change — verified `.github/renovate.json5` parses as valid JSON5 (`npm run test` / `npm run lint` do not cover this file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)