### PR TITLE
fix(website): Use privacy-enhanced YouTube embed domain

### DIFF
--- a/website/client/components/YouTubeVideo.vue
+++ b/website/client/components/YouTubeVideo.vue
@@ -12,7 +12,7 @@ defineProps<{
     <iframe
       width="560"
       height="315"
-      :src="`https://www.youtube.com/embed/${videoId}${start ? `?start=${start}` : ''}`"
+      :src="`https://www.youtube-nocookie.com/embed/${videoId}${start ? `?start=${start}` : ''}`"
       title="YouTube video player"
       frameborder="0"
       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
Switches the YouTube embed in `YouTubeVideo.vue` from `www.youtube.com` to `www.youtube-nocookie.com`, YouTube's official privacy-enhanced mode. Tracking cookies are deferred until the user actually plays the video, which also clears the third-party-cookie flag in Lighthouse's best-practices audit. The player's appearance and behavior are unchanged, and this is the only embed usage in the site (all pages use this shared component).

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)