### PR TITLE
fix(website): Improve sponsor image caching and lazy-load below-fold images

### DIFF
--- a/website/client/.vitepress/config/configShard.ts
+++ b/website/client/.vitepress/config/configShard.ts
@@ -256,6 +256,14 @@ export const configShard = defineConfig({
   cleanUrls: true,
   metaChunk: true,
 
+  markdown: {
+    image: {
+      // Defer loading of markdown images until they approach the viewport.
+      // Page LCP elements are text, so this does not delay LCP.
+      lazyLoading: true,
+    },
+  },
+
   sitemap: {
     hostname: `${siteUrl}/`,
   },

--- a/website/client/components/Home/TryItLoading.vue
+++ b/website/client/components/Home/TryItLoading.vue
@@ -37,7 +37,8 @@ const detailMessage = computed(() => {
     <div class="sponsor-section">
       <p class="sponsor-header">Special thanks to:</p>
       <a href="https://go.warp.dev/repomix" target="_blank" rel="noopener noreferrer">
-        <img alt="Warp sponsorship" width="400" height="225" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
+        <!-- jsDelivr mirror of the sponsor's repo: auto-updates with long-lived cache headers. -->
+        <img alt="Warp sponsorship" width="400" height="225" src="https://cdn.jsdelivr.net/gh/warpdotdev/brand-assets/Github/Sponsor/Warp-Github-LG-01.png">
       </a>
       <p class="sponsor-title">
         <a href="https://go.warp.dev/repomix" target="_blank" rel="noopener noreferrer">

--- a/website/client/src/shared/sponsors-section.md
+++ b/website/client/src/shared/sponsors-section.md
@@ -6,8 +6,11 @@
 <!-- Image width/height attributes reserve layout space before load (CLS).
      The values only need to match the source image's aspect ratio;
      style="height: auto" keeps the ratio when max-width shrinks the image. -->
+<!-- Served via jsDelivr instead of raw.githubusercontent.com: it still tracks
+     the sponsor's repo (updates propagate automatically, with up to ~12h of
+     CDN cache delay) but with proper long-lived cache headers. -->
    <a href="https://go.warp.dev/repomix" target="_blank">
-      <img alt="Warp sponsorship" width="400" height="225" style="height: auto" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Sponsor/Warp-Github-LG-01.png">
+      <img alt="Warp sponsorship" width="400" height="225" style="height: auto" loading="lazy" src="https://cdn.jsdelivr.net/gh/warpdotdev/brand-assets/Github/Sponsor/Warp-Github-LG-01.png">
    </a>
 
   [Warp, built for coding with multiple AI agents](https://go.warp.dev/repomix)  
@@ -19,7 +22,7 @@
    <a href="https://coderabbit.link/repomix" target="_blank">
       <picture>
          <source media="(prefers-color-scheme: dark)" srcset="/images/sponsors/coderabbit/dark.png">
-         <img alt="CodeRabbit sponsorship" width="400" height="58" style="height: auto" src="/images/sponsors/coderabbit/light.png">
+         <img alt="CodeRabbit sponsorship" width="400" height="58" style="height: auto" loading="lazy" src="/images/sponsors/coderabbit/light.png">
       </picture>
    </a>
 
@@ -32,7 +35,7 @@
 <!-- sponsors.png is auto-generated and its size changes as sponsors change;
      the width/height here only need to stay roughly in sync for space reservation. -->
 <a href="https://github.com/sponsors/yamadashy">
-  <img alt="Sponsors" width="1667" height="819" style="height: auto" src="https://cdn.jsdelivr.net/gh/yamadashy/sponsor-list/sponsors/sponsors.png">
+  <img alt="Sponsors" width="1667" height="819" style="height: auto" loading="lazy" src="https://cdn.jsdelivr.net/gh/yamadashy/sponsor-list/sponsors/sponsors.png">
 </a>
 
 <div align="center" style="margin: 8px 0 0;">


### PR DESCRIPTION
Addresses the two remaining image-related PageSpeed insights on the home page — "efficient cache lifetimes" (630 KiB) and "improve image delivery" (705 KiB) — without any visual change.

- Serve the Warp sponsor image via jsDelivr's GitHub mirror (`cdn.jsdelivr.net/gh/warpdotdev/brand-assets/...`) instead of `raw.githubusercontent.com`. It still tracks the sponsor's repo, so asset updates propagate automatically (with up to ~12h of CDN cache delay), but now with 7-day cache headers instead of 5 minutes — the same approach already used for `sponsors.png`.
- Add `loading="lazy"` to the below-fold sponsor images and enable VitePress's markdown image lazy loading site-wide (`markdown.image.lazyLoading`), keeping ~800 KB of below-fold images out of the initial page load. LCP elements are text on these pages, so LCP is unaffected. Space is already reserved via width/height (#1731), so lazy loading introduces no layout shift.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)