### PR TITLE
fix(deps): Update website/server repomix to patched 1.16.1

### DIFF
--- a/website/server/.npmrc
+++ b/website/server/.npmrc
@@ -1,1 +1,0 @@
-min-release-age=7

--- a/website/server/package-lock.json
+++ b/website/server/package-lock.json
@@ -729,9 +729,9 @@
       }
     },
     "node_modules/@repomix/tree-sitter-wasms": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@repomix/tree-sitter-wasms/-/tree-sitter-wasms-0.1.16.tgz",
-      "integrity": "sha512-CIINozBWFwjhH4DQALN/b4n1S08fHhXQOdjX2G7s4w+Urew37aLU0AHVyCjHM5Pbnh63tDYt4YyUkS6vRUV38A==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@repomix/tree-sitter-wasms/-/tree-sitter-wasms-0.1.17.tgz",
+      "integrity": "sha512-tc3HnFqdMF1pXhIMzG3aTaBDpIiHK2tPfn3fwqA6P3WTbHa+1EuuTubbKshvmN7xCHP5Ojz0/VW4R+XvR88KOw==",
       "license": "Unlicense"
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1462,42 +1462,42 @@
       "peer": true
     },
     "node_modules/@secretlint/core": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@secretlint/core/-/core-11.5.0.tgz",
-      "integrity": "sha512-fVbYXsWz5kHuEsXpfbannAm8gC8nH741NRlOXb8wgwxumwiPqKVlyreu7JKTfQFFNrwHGSoY2Wx4NKD25s8WTQ==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/core/-/core-13.0.2.tgz",
+      "integrity": "sha512-15vg+zCmjQuDFVoOPNt0TyEu0Z95eir2MO19++wG82yM/vbPtFu/m9qd6oh54ZOBXgMcchdGDTxMwJNDnCLxcA==",
       "license": "MIT",
       "dependencies": {
-        "@secretlint/profiler": "11.5.0",
-        "@secretlint/types": "11.5.0",
+        "@secretlint/profiler": "13.0.2",
+        "@secretlint/types": "13.0.2",
         "debug": "^4.4.3",
         "structured-source": "^4.0.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@secretlint/profiler": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-11.5.0.tgz",
-      "integrity": "sha512-o7lZEA4NTJWzNoO3evTZ0luanV0EQlEbjzREIijM1/O1Bfpuy4P+mgAY3+S7CXlrC4I8RApCV2sP2qPiHQtNMA==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-13.0.2.tgz",
+      "integrity": "sha512-vGaLZCoi9KewOF+sM0iIEBviWaH9mls1HmQFBgEPq4fnvmVO4PfKIkVr4CcAFm3Msg4NjzFE2RBAGwRR+5HEmQ==",
       "license": "MIT"
     },
     "node_modules/@secretlint/secretlint-rule-preset-recommend": {
-      "version": "11.4.1",
-      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-11.4.1.tgz",
-      "integrity": "sha512-htejVuXSTVOlhZhJ9XqdKXBtWTuL+EbG2LdQQk0pfQFJfZLpeNUTjI8fE9ZCuFejuUJiGv1jUi1/rqT64M0Dvg==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-13.0.2.tgz",
+      "integrity": "sha512-D03Kw51qOgffj9zNlJFZUarVmP8zGcCZNi7A14+vZtHskbbBPEsS/f09idb48rrlMSaRMBN29IkqfbmPyL9xtw==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@secretlint/types": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@secretlint/types/-/types-11.5.0.tgz",
-      "integrity": "sha512-Y2fq597Z2iHa8ZP2XwpGCJd70OA8opgytMfqESNVb7lDvRac2++wIp72vW7Azk3xKycFvBkpxnQppjThgMauTA==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/types/-/types-13.0.2.tgz",
+      "integrity": "sha512-cAZjr6ZTKgSuJMLyTGDrUEtK3XEZa+JStIkD+DmdkT32VGAN+dQJiYr1So3XJopsKSrqhP5kjZKT8WWtftZIpQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@sindresorhus/merge-streams": {
@@ -2528,6 +2528,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -2584,12 +2599,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/content-disposition": {
@@ -2973,9 +2988,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
       "funding": [
         {
           "type": "github",
@@ -2984,8 +2999,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
       }
     },
     "node_modules/fastq": {
@@ -3190,9 +3205,9 @@
       }
     },
     "node_modules/globby": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
-      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.2.tgz",
+      "integrity": "sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==",
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
@@ -3318,9 +3333,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -3462,9 +3477,9 @@
       "license": "ISC"
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -3894,12 +3909,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4079,9 +4094,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
       "funding": [
         {
           "type": "github",
@@ -4293,43 +4308,58 @@
         "node": ">= 6"
       }
     },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/repomix": {
-      "version": "1.13.1",
-      "resolved": "git+ssh://git@github.com/yamadashy/repomix.git#513d62ac9c6aa86d9ec8c426dc1371cc338bb837",
+      "version": "1.16.1",
+      "resolved": "git+ssh://git@github.com/yamadashy/repomix.git#44457c890236440bc683e9e5d84499a0a4911550",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0",
-        "@modelcontextprotocol/sdk": "^1.28.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@repomix/strip-comments": "^2.4.2",
-        "@repomix/tree-sitter-wasms": "^0.1.16",
-        "@secretlint/core": "^11.4.0",
-        "@secretlint/secretlint-rule-preset-recommend": "^11.4.0",
-        "commander": "^14.0.3",
-        "fast-xml-builder": "^1.1.4",
+        "@repomix/tree-sitter-wasms": "^0.1.17",
+        "@secretlint/core": "^13.0.2",
+        "@secretlint/secretlint-rule-preset-recommend": "^13.0.2",
+        "chokidar": "^5.0.0",
+        "commander": "^15.0.0",
+        "fast-xml-builder": "^1.3.0",
         "git-url-parse": "^16.1.0",
-        "globby": "^16.2.0",
+        "globby": "^16.2.1",
         "gpt-tokenizer": "^3.4.0",
         "handlebars": "^4.7.9",
         "iconv-lite": "^0.7.0",
         "is-binary-path": "^3.0.0",
         "isbinaryfile": "^5.0.2",
-        "jiti": "^2.6.1",
+        "jiti": "^2.7.0",
         "jschardet": "^3.1.4",
         "json5": "^2.2.3",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "picocolors": "^1.1.1",
         "picospinner": "^3.0.0",
-        "tar": "^7.5.13",
-        "tinyclip": "^0.1.12",
+        "tar": "^7.5.20",
+        "tinyclip": "^0.1.15",
         "tinypool": "^2.1.0",
-        "web-tree-sitter": "^0.26.7",
-        "zod": "^4.3.6"
+        "valibot": "^1.4.2",
+        "web-tree-sitter": "^0.26.10",
+        "zod": "^4.4.3"
       },
       "bin": {
         "repomix": "bin/repomix.cjs"
       },
       "engines": {
-        "node": ">=20.0.0",
+        "node": ">=22.0.0",
         "yarn": ">=1.22.22"
       }
     },
@@ -4809,9 +4839,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -4838,9 +4868,9 @@
       "license": "MIT"
     },
     "node_modules/tinyclip": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.12.tgz",
-      "integrity": "sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.15.tgz",
+      "integrity": "sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==",
       "license": "MIT",
       "engines": {
         "node": "^16.14.0 || >= 17.3.0"
@@ -5619,9 +5649,9 @@
       }
     },
     "node_modules/web-tree-sitter": {
-      "version": "0.26.7",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.7.tgz",
-      "integrity": "sha512-KiZhelTvBA/ziUHEO7Emb75cGVAq8iGZNabYaZm53Zpy50NsXyOW+xSHlwHt5CVg/TRPZBfeVLTTobF0LjFJ1w==",
+      "version": "0.26.11",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.11.tgz",
+      "integrity": "sha512-Q5Dm3YTIXSXuH6FxX6RuzX2Qwpc4DPGiYMU87Wg5Z8OIStiQFiUex4zMDc0vBTw78EphaYJacncJghCHzbZptg==",
       "license": "MIT"
     },
     "node_modules/which": {
@@ -5705,9 +5735,9 @@
       "license": "ISC"
     },
     "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
       "funding": [
         {
           "type": "github",
@@ -5729,9 +5759,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
## Summary

Resolves the two Dependabot alerts on `website/server` for the bundled `repomix` (#283 High RCE, #282 Moderate). The workspace pins repomix via a `github:#main` git dependency, but its lockfile was stuck at an old commit (1.13.1, `< 1.14.1`). Re-resolving the git ref bumps it to current main (**1.16.1**) and clears both alerts.

To reinstall the git dependency, `min-release-age` had to be removed from `website/server/.npmrc`: npm's git-dependency preparation injects `--before`, which is mutually exclusive with `min-release-age`, so any git-dep reinstall in this workspace fails outright regardless of release age. This workspace intentionally tracks `main` to ship unreleased features to the website, so the cooldown cannot coexist with the git dep here.

- The `min-release-age` supply-chain cooldown stays in place for the root package and the other workspaces (`browser`, `website/client`, `scripts/memory`).
- Renovate's `stability-days` cooldown still gates version bumps.
- Diff limited to `website/server/package-lock.json` + the `.npmrc` removal (the npm devDependencies key reorder was reverted to keep the change surgical).

## Checklist

- [x] Run `npm run test` — `website/server`: 101 passed
- [x] Run `npm run lint` — `website/server`: clean (tsc)