### PR TITLE
fix(core): normalize output file path to POSIX separators before ignoring

### DIFF
--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -425,7 +425,10 @@ export const getIgnorePatterns = async (rootDir: string, config: RepomixConfigMe
   // Add repomix output file
   if (config.output.filePath) {
     const absoluteOutputPath = path.resolve(config.cwd, config.output.filePath);
-    const relativeToTargetPath = path.relative(rootDir, absoluteOutputPath);
+    // Normalize to POSIX separators: globby matches ignore patterns against
+    // forward-slash paths, so a nested output path (e.g. `docs/out.xml`) would
+    // stay as `docs\out.xml` on Windows and fail to self-ignore the output file.
+    const relativeToTargetPath = toPosixPath(path.relative(rootDir, absoluteOutputPath));
 
     logger.trace('Adding output file to ignore patterns:', relativeToTargetPath);
 

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -241,6 +241,28 @@ temp-files/
       expect(patterns).toContain('*.ignored');
       expect(patterns).toContain('temp-files/');
     });
+
+    test('should use POSIX separators for a nested output file path (Windows)', async () => {
+      const mockConfig = createMockConfig({
+        cwd: '/mock/root',
+        output: { filePath: 'docs/repomix-output.xml' },
+        ignore: {
+          useGitignore: true,
+          useDefaultPatterns: false,
+          customPatterns: [],
+        },
+      });
+
+      // Simulate Windows: path.relative returns backslash-separated paths there.
+      // globby matches ignore patterns against forward-slash paths, so the raw
+      // value would never match the output file and it would leak into itself.
+      vi.spyOn(path, 'relative').mockReturnValueOnce('docs\\repomix-output.xml');
+
+      const patterns = await getIgnorePatterns('/mock/root', mockConfig);
+
+      expect(patterns).toContain('docs/repomix-output.xml');
+      expect(patterns).not.toContain('docs\\repomix-output.xml');
+    });
   });
 
   describe('parseIgnoreContent', () => {


### PR DESCRIPTION
The output file is self-ignored by adding `path.relative(rootDir, outputPath)` to the ignore set in `getIgnorePatterns`. globby matches ignore patterns against forward-slash paths, but `path.relative` uses the OS separator — so on Windows a nested output path like `--output docs/out.xml` becomes `docs\\out.xml` and never matches, leaving the output file un-ignored and re-packed into itself on the next run. The default flat `repomix-output.xml` isn't affected since it has no separator.

Wrapped the relative path with the existing `toPosixPath` helper so the ignore pattern is always forward-slash, same normalization already used for the deferred ignore-control paths in this file. Added a test that mocks `path.relative` to return a backslash path and asserts the pattern comes out POSIX.