### PR TITLE
fix(output): keep non-included files in --include-full-directory-structure tree

### DIFF
--- a/src/core/output/outputGenerate.ts
+++ b/src/core/output/outputGenerate.ts
@@ -425,7 +425,13 @@ export const buildOutputGeneratorContext = async (
   // Generate tree string - use multi-root format if filePathsByRoot is provided
   // generateTreeStringWithRoots handles single root case internally
   let treeString: string;
-  if (filePathsByRoot) {
+  if (shouldUseFullTree) {
+    // Full-tree mode already merged every repo file (included + the rest) and every
+    // directory into filePathsForTree/directoryPathsForTree above. Render those directly:
+    // filePathsByRoot only carries the included files, so it would drop the non-included
+    // ones and defeat the purpose of --include-full-directory-structure.
+    treeString = generateTreeString(filePathsForTree, directoryPathsForTree);
+  } else if (filePathsByRoot) {
     treeString = generateTreeStringWithRoots(filePathsByRoot, directoryPathsForTree);
   } else {
     // Fallback for when root info is not available

--- a/tests/core/output/flagFullDirectoryStructure.test.ts
+++ b/tests/core/output/flagFullDirectoryStructure.test.ts
@@ -124,6 +124,43 @@ describe('includeFullDirectoryStructure flag', () => {
     expect(ctx.treeString).not.toContain('repo/');
   });
 
+  test('keeps non-included files in the full tree when a realistic filePathsByRoot is provided', async () => {
+    // pack() always passes filePathsByRoot for the default target-relative style, and it
+    // only holds the included files. Full-tree mode must still surface the rest of the repo.
+    const config = createMockConfig();
+    const processedFiles: ProcessedFile[] = [{ path: 'src/a/index.ts', content: 'export const a = 1;\n' }];
+    const allFilePaths = processedFiles.map((f) => f.path);
+
+    const deps = {
+      listDirectories: async () => ['src', 'src/a', 'src/b', 'docs', 'docs/guide'],
+      listFiles: async () => ['README.md', 'src/a/index.ts', 'src/b/other.ts', 'docs/guide/intro.md'],
+      searchFiles: async () => ({ filePaths: allFilePaths, emptyDirPaths: [] }),
+    };
+
+    const filePathsByRoot = [{ rootLabel: 'repo', files: allFilePaths }];
+
+    const ctx = await buildOutputGeneratorContext(
+      ['/repo'],
+      config,
+      allFilePaths,
+      processedFiles,
+      undefined,
+      undefined,
+      filePathsByRoot,
+      undefined,
+      deps,
+    );
+
+    // The included file and directories still show up...
+    expect(ctx.treeString).toContain('index.ts');
+    expect(ctx.treeString).toContain('src/');
+    expect(ctx.treeString).toContain('docs/');
+    // ...and so do the files that were not part of the include patterns.
+    expect(ctx.treeString).toContain('README.md');
+    expect(ctx.treeString).toContain('other.ts');
+    expect(ctx.treeString).toContain('intro.md');
+  });
+
   test('does not render full tree when include is empty even if flag is enabled', async () => {
     const config = createMockConfig({ include: [] });
     const processedFiles: ProcessedFile[] = [{ path: 'src/a/index.ts', content: 'export const a = 1;\n' }];


### PR DESCRIPTION
When `--include-full-directory-structure` is used together with `--include`, the Directory Structure section is supposed to show the entire repository tree, with only the included files having their contents packed. But non-included files were silently dropped from the tree.

The full-tree branch in `buildOutputGeneratorContext` correctly merges every repo file into `filePathsForTree` (included files plus everything else from `listFiles`), yet the tree was actually rendered from `filePathsByRoot`, which only carries the included files. Since `pack()` always passes `filePathsByRoot` for the default `target-relative` style, the merged `filePathsForTree` was dead code in that path and the extra files never made it into the output.

Repro — a repo with `README.md`, `src/index.ts`, `src/b/other.ts`, `docs/guide/intro.md`:

```
repomix --include "src/**/*.ts" --include-full-directory-structure
```

Before, the tree listed the `docs/` and `docs/guide/` directories but not `README.md` or `docs/guide/intro.md` — only the included `.ts` files. Now the whole tree shows up, and just the `src/**/*.ts` files get content blocks.

The fix renders the already-merged `filePathsForTree`/`directoryPathsForTree` directly in full-tree mode instead of the included-only `filePathsByRoot`. The existing root-label test only asserted directories and the included file, so it missed this — I extended coverage to assert the non-included files appear too (it fails without the fix).