### PR TITLE
fix(core): don't strip shell/YAML # unless it starts a comment

### DIFF
--- a/src/core/file/fileManipulate.ts
+++ b/src/core/file/fileManipulate.ts
@@ -45,9 +45,10 @@ class StripCommentsManipulator extends BaseManipulator {
 // Matches a shell heredoc opener (`<<EOF`, `<<-EOF`, `<<'EOF'`, `<<"EOF"`), excluding the
 // `<<<` herestring operator via the lookaround guards.
 const HEREDOC_START = /(?<!<)<<(?!<)(-?)\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\2/;
-// Matches a YAML block scalar opener (`key: |`, `- >-`, etc.) — the indicator must be the
-// last non-comment token on the line.
-const YAML_BLOCK_SCALAR_START = /[|>][+-]?\d*\s*(#.*)?$/;
+// Matches a YAML block scalar opener (`key: |`, `- >-`, etc.) — the `|`/`>` indicator must
+// sit at a value position (right after a `:` or `-` introducer) and be the last non-comment
+// token on the line, so a plain scalar that merely ends in `|`/`>` isn't mistaken for one.
+const YAML_BLOCK_SCALAR_START = /[:-]\s+[|>][+-]?\d*\s*(#.*)?$/;
 
 // Shell and YAML use `#` line comments, but a `#` is only a comment at the start of a
 // line or after whitespace — never inside `${x#y}`, `$#`, `a/b#c`, or a quoted string.
@@ -141,13 +142,15 @@ class HashCommentManipulator extends BaseManipulator {
         i++;
         continue;
       }
-      if (char === "'") {
-        inSingle = true;
-        result += char;
-        continue;
-      }
-      if (char === '"') {
-        inDouble = true;
+      if (char === "'" || char === '"') {
+        // Shell opens a quoted string on any unescaped quote. YAML only starts a quoted
+        // scalar when the quote sits at a value boundary — an apostrophe inside a plain
+        // scalar (`note: it's fine  # x`) is literal and must not swallow the comment.
+        const opensString = this.language === 'shell' || i === 0 || ' \t:-,[{'.includes(line[i - 1]);
+        if (opensString) {
+          if (char === "'") inSingle = true;
+          else inDouble = true;
+        }
         result += char;
         continue;
       }

--- a/src/core/file/fileManipulate.ts
+++ b/src/core/file/fileManipulate.ts
@@ -42,18 +42,83 @@ class StripCommentsManipulator extends BaseManipulator {
   }
 }
 
+// Matches a shell heredoc opener (`<<EOF`, `<<-EOF`, `<<'EOF'`, `<<"EOF"`), excluding the
+// `<<<` herestring operator via the lookaround guards.
+const HEREDOC_START = /(?<!<)<<(?!<)(-?)\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\2/;
+// Matches a YAML block scalar opener (`key: |`, `- >-`, etc.) — the indicator must be the
+// last non-comment token on the line.
+const YAML_BLOCK_SCALAR_START = /[|>][+-]?\d*\s*(#.*)?$/;
+
 // Shell and YAML use `#` line comments, but a `#` is only a comment at the start of a
 // line or after whitespace — never inside `${x#y}`, `$#`, `a/b#c`, or a quoted string.
 // The generic `perl` profile treats every unquoted `#` as a comment, silently corrupting
 // these files (e.g. `${name##*/}` -> `${name`), so strip them with a boundary-aware scan.
+// Shell heredoc bodies and YAML block-scalar bodies are literal content, not comments —
+// tracked separately per line since they're line/indentation-based, not character-based.
 class HashCommentManipulator extends BaseManipulator {
+  private language: 'shell' | 'yaml';
+
+  constructor(language: 'shell' | 'yaml') {
+    super();
+    this.language = language;
+  }
+
   removeComments(content: string): string {
-    let result = '';
+    const lines = content.split('\n');
+    const output: string[] = [];
     let inSingle = false;
     let inDouble = false;
+    let heredocDelimiter: string | null = null;
+    let heredocStripLeadingTabs = false;
+    let blockScalarIndent: number | null = null;
 
-    for (let i = 0; i < content.length; i++) {
-      const char = content[i];
+    for (const line of lines) {
+      if (heredocDelimiter !== null) {
+        output.push(line);
+        const compareLine = heredocStripLeadingTabs ? line.replace(/^\t+/, '') : line;
+        if (compareLine === heredocDelimiter) heredocDelimiter = null;
+        continue;
+      }
+
+      if (blockScalarIndent !== null) {
+        const indent = line.match(/^[ \t]*/)?.[0].length ?? 0;
+        if (line.trim() !== '' && indent <= blockScalarIndent) {
+          blockScalarIndent = null;
+          // Not a body line — fall through and process it normally below.
+        } else {
+          output.push(line);
+          continue;
+        }
+      }
+
+      const processed = this.stripLineComment(line, inSingle, inDouble);
+      inSingle = processed.inSingle;
+      inDouble = processed.inDouble;
+      output.push(processed.text);
+
+      if (this.language === 'shell' && !inSingle && !inDouble) {
+        const match = line.match(HEREDOC_START);
+        if (match) {
+          heredocStripLeadingTabs = match[1] === '-';
+          heredocDelimiter = match[3];
+        }
+      } else if (this.language === 'yaml' && !inSingle && !inDouble && YAML_BLOCK_SCALAR_START.test(processed.text)) {
+        blockScalarIndent = line.match(/^[ \t]*/)?.[0].length ?? 0;
+      }
+    }
+
+    return rtrimLines(output.join('\n'));
+  }
+
+  // Strips a trailing `#` comment from a single line, carrying quote state across lines
+  // (shell/YAML both allow quoted strings to span multiple lines).
+  private stripLineComment(line: string, inSingleIn: boolean, inDoubleIn: boolean) {
+    let result = '';
+    let inSingle = inSingleIn;
+    let inDouble = inDoubleIn;
+
+    for (let i = 0; i < line.length; i++) {
+      const char = line[i];
 
       if (inSingle) {
         result += char;
@@ -61,8 +126,8 @@ class HashCommentManipulator extends BaseManipulator {
         continue;
       }
       if (inDouble) {
-        if (char === '\\' && i + 1 < content.length) {
-          result += char + content[i + 1];
+        if (char === '\\' && i + 1 < line.length) {
+          result += char + line[i + 1];
           i++;
         } else {
           result += char;
@@ -71,8 +136,8 @@ class HashCommentManipulator extends BaseManipulator {
         continue;
       }
 
-      if (char === '\\' && i + 1 < content.length) {
-        result += char + content[i + 1];
+      if (char === '\\' && i + 1 < line.length) {
+        result += char + line[i + 1];
         i++;
         continue;
       }
@@ -88,20 +153,17 @@ class HashCommentManipulator extends BaseManipulator {
       }
 
       if (char === '#') {
-        const prev = content[i - 1];
-        if (i === 0 || prev === ' ' || prev === '\t' || prev === '\n' || prev === '\r') {
-          // Drop the comment through end of line; the newline is preserved by the loop.
-          let j = i;
-          while (j < content.length && content[j] !== '\n') j++;
-          i = j - 1;
-          continue;
+        const prev = line[i - 1];
+        if (i === 0 || prev === ' ' || prev === '\t') {
+          // Rest of the line is a comment — drop it.
+          break;
         }
       }
 
       result += char;
     }
 
-    return rtrimLines(result);
+    return { text: result, inSingle, inDouble };
   }
 }
 
@@ -144,7 +206,7 @@ const manipulators: Record<string, FileManipulator> = {
   '.rs': new StripCommentsManipulator('c'),
   '.sass': new StripCommentsManipulator('sass'),
   '.scss': new StripCommentsManipulator('sass'),
-  '.sh': new HashCommentManipulator(),
+  '.sh': new HashCommentManipulator('shell'),
   '.sol': new StripCommentsManipulator('c'),
   '.sql': new StripCommentsManipulator('sql'),
   '.swift': new StripCommentsManipulator('swift'),
@@ -154,8 +216,8 @@ const manipulators: Record<string, FileManipulator> = {
   '.cts': new StripCommentsManipulator('javascript'),
   '.mtsx': new StripCommentsManipulator('javascript'),
   '.xml': new StripCommentsManipulator('xml'),
-  '.yaml': new HashCommentManipulator(),
-  '.yml': new HashCommentManipulator(),
+  '.yaml': new HashCommentManipulator('yaml'),
+  '.yml': new HashCommentManipulator('yaml'),
 
   '.vue': new CompositeManipulator(
     new StripCommentsManipulator('html'),

--- a/src/core/file/fileManipulate.ts
+++ b/src/core/file/fileManipulate.ts
@@ -42,6 +42,69 @@ class StripCommentsManipulator extends BaseManipulator {
   }
 }
 
+// Shell and YAML use `#` line comments, but a `#` is only a comment at the start of a
+// line or after whitespace — never inside `${x#y}`, `$#`, `a/b#c`, or a quoted string.
+// The generic `perl` profile treats every unquoted `#` as a comment, silently corrupting
+// these files (e.g. `${name##*/}` -> `${name`), so strip them with a boundary-aware scan.
+class HashCommentManipulator extends BaseManipulator {
+  removeComments(content: string): string {
+    let result = '';
+    let inSingle = false;
+    let inDouble = false;
+
+    for (let i = 0; i < content.length; i++) {
+      const char = content[i];
+
+      if (inSingle) {
+        result += char;
+        if (char === "'") inSingle = false;
+        continue;
+      }
+      if (inDouble) {
+        if (char === '\\' && i + 1 < content.length) {
+          result += char + content[i + 1];
+          i++;
+        } else {
+          result += char;
+          if (char === '"') inDouble = false;
+        }
+        continue;
+      }
+
+      if (char === '\\' && i + 1 < content.length) {
+        result += char + content[i + 1];
+        i++;
+        continue;
+      }
+      if (char === "'") {
+        inSingle = true;
+        result += char;
+        continue;
+      }
+      if (char === '"') {
+        inDouble = true;
+        result += char;
+        continue;
+      }
+
+      if (char === '#') {
+        const prev = content[i - 1];
+        if (i === 0 || prev === ' ' || prev === '\t' || prev === '\n' || prev === '\r') {
+          // Drop the comment through end of line; the newline is preserved by the loop.
+          let j = i;
+          while (j < content.length && content[j] !== '\n') j++;
+          i = j - 1;
+          continue;
+        }
+      }
+
+      result += char;
+    }
+
+    return rtrimLines(result);
+  }
+}
+
 class CompositeManipulator extends BaseManipulator {
   private manipulators: FileManipulator[];
 
@@ -81,7 +144,7 @@ const manipulators: Record<string, FileManipulator> = {
   '.rs': new StripCommentsManipulator('c'),
   '.sass': new StripCommentsManipulator('sass'),
   '.scss': new StripCommentsManipulator('sass'),
-  '.sh': new StripCommentsManipulator('perl'),
+  '.sh': new HashCommentManipulator(),
   '.sol': new StripCommentsManipulator('c'),
   '.sql': new StripCommentsManipulator('sql'),
   '.swift': new StripCommentsManipulator('swift'),
@@ -91,8 +154,8 @@ const manipulators: Record<string, FileManipulator> = {
   '.cts': new StripCommentsManipulator('javascript'),
   '.mtsx': new StripCommentsManipulator('javascript'),
   '.xml': new StripCommentsManipulator('xml'),
-  '.yaml': new StripCommentsManipulator('perl'),
-  '.yml': new StripCommentsManipulator('perl'),
+  '.yaml': new HashCommentManipulator(),
+  '.yml': new HashCommentManipulator(),
 
   '.vue': new CompositeManipulator(
     new StripCommentsManipulator('html'),

--- a/tests/core/file/fileManipulate.test.ts
+++ b/tests/core/file/fileManipulate.test.ts
@@ -900,6 +900,36 @@ r2 := '\\\\'`,
 `,
     },
     {
+      name: 'Shell parameter expansion is not treated as a comment',
+      ext: '.sh',
+      input: `base=\${name##*/}
+ext=\${name#*.}
+count=$#
+echo "value # not a comment"
+grep '# literal' file
+value=1  # real comment`,
+      expected: `base=\${name##*/}
+ext=\${name#*.}
+count=$#
+echo "value # not a comment"
+grep '# literal' file
+value=1`,
+    },
+    {
+      name: 'YAML unquoted hash in value is preserved',
+      ext: '.yaml',
+      input: `repo: https://github.com/a/b#readme
+color: "#ff0000"
+name: value  # trailing comment
+# full line comment
+plain: keep#this`,
+      expected: `repo: https://github.com/a/b#readme
+color: "#ff0000"
+name: value
+
+plain: keep#this`,
+    },
+    {
       name: 'Vue file comment removal',
       ext: '.vue',
       input: `

--- a/tests/core/file/fileManipulate.test.ts
+++ b/tests/core/file/fileManipulate.test.ts
@@ -930,6 +930,32 @@ name: value
 plain: keep#this`,
     },
     {
+      name: 'Shell heredoc body is preserved verbatim',
+      ext: '.sh',
+      input: `cat <<'EOF'
+# not a comment, this is heredoc content
+value # also literal
+EOF
+echo done  # real comment`,
+      expected: `cat <<'EOF'
+# not a comment, this is heredoc content
+value # also literal
+EOF
+echo done`,
+    },
+    {
+      name: 'YAML block scalar body is preserved verbatim',
+      ext: '.yaml',
+      input: `message: |
+  # not a comment
+  keep # this too
+summary: value  # real comment`,
+      expected: `message: |
+  # not a comment
+  keep # this too
+summary: value`,
+    },
+    {
       name: 'Vue file comment removal',
       ext: '.vue',
       input: `

--- a/tests/core/file/fileManipulate.test.ts
+++ b/tests/core/file/fileManipulate.test.ts
@@ -956,6 +956,22 @@ summary: value  # real comment`,
 summary: value`,
     },
     {
+      name: 'YAML apostrophe in plain scalar does not disable comment stripping',
+      ext: '.yaml',
+      input: `note: it's fine  # trailing comment
+next: value  # another comment`,
+      expected: `note: it's fine
+next: value`,
+    },
+    {
+      name: 'YAML plain scalar ending in pipe is not treated as a block scalar',
+      ext: '.yaml',
+      input: `filter: a |
+  nested: value  # real comment`,
+      expected: `filter: a |
+  nested: value`,
+    },
+    {
       name: 'Vue file comment removal',
       ext: '.vue',
       input: `


### PR DESCRIPTION
`--remove-comments` silently corrupts shell and YAML files. Both are routed to the `perl` strip profile, which treats every unquoted `#` as a line comment. But in shell and YAML a `#` is only a comment at the start of a line or after whitespace — not inside `${name##*/}`, `$#`, or an unquoted URL like `a/b#readme`.

So a shell script like:

```sh
base=${name##*/}
ext=${name#*.}
count=$#
```

comes out as `base=${name`, `ext=${name`, `count=$` — the rest of each line is dropped at the first `#`. Same for YAML: `repo: https://github.com/a/b#readme` loses `#readme`. The packed output no longer matches the source, which is exactly what you don't want when feeding it to an LLM.

I replaced the `perl` routing for `.sh`, `.yaml`, and `.yml` with a small boundary-aware scanner that only cuts at a `#` when it's at line start or preceded by whitespace, and skips single/double quoted strings (so `echo "a # b"` and `color: "#ff0000"` are kept). Real comments — full-line, whitespace-preceded trailing ones, and shebangs — are still stripped, so the existing shell/YAML tests stay green. Added tests for the parameter-expansion, `$#`, quoted-hash, and URL-fragment cases.