### PR TITLE
feat(mcp): Add --sandbox to confine the MCP server to a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,7 @@ Instruction
 
 #### MCP
 - `--mcp`: Run as Model Context Protocol server for AI tool integration
+- `--sandbox [dir]`: (with `--mcp`) confine the MCP server's file tools to a workspace directory (defaults to the working directory; e.g. `--sandbox path/to/project`) — every path is relative to that root, absolute/host paths are refused, and remote packing, skill generation, and attaching external outputs are disabled.
 
 #### Agent Skills Generation
 

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -47,9 +47,16 @@ export const buildMergedConfig = async (cwd: string, cliOptions: CliOptions): Pr
     await runMigrationAction(cwd);
   }
 
-  // Load the config file in main process
+  // Load the merged repomix.config.* — but callers that don't trust the config
+  // source suppress it: an untrusted remote repo passes skipLocalConfig (its own
+  // config is attacker-controlled), and the sandboxed MCP server passes BOTH, since
+  // any config it loaded (workspace or the operator's global one) could set
+  // output.instructionFilePath to read an out-of-workspace file into the
+  // agent-visible output, or input.processors to run commands. Both default off, so
+  // ordinary CLI/library runs load config as usual.
   const fileConfig: RepomixConfigFile = await loadFileConfig(cwd, cliOptions.config ?? null, {
     skipLocalConfig: cliOptions.skipLocalConfig,
+    skipGlobalConfig: cliOptions.skipGlobalConfig,
   });
   logger.trace('Loaded file config:', fileConfig);
 
@@ -146,7 +153,13 @@ export const runDefaultAction = async (
 
   try {
     const { skillName, skillDir, skillProjectName, skillSourceUrl } = cliOptions;
-    const packOptions = { skillName, skillDir, skillProjectName, skillSourceUrl };
+    const packOptions = {
+      skillName,
+      skillDir,
+      skillProjectName,
+      skillSourceUrl,
+      confineToBaseDir: cliOptions.confineToBaseDir,
+    };
 
     const targetPaths = stdinFilePaths ? [cwd] : directories.map((directory) => path.resolve(cwd, directory));
 

--- a/src/cli/actions/mcpAction.ts
+++ b/src/cli/actions/mcpAction.ts
@@ -1,7 +1,8 @@
 import { runMcpServer } from '../../mcp/mcpServer.js';
 import { logger } from '../../shared/logger.js';
 
-export const runMcpAction = async (): Promise<void> => {
-  logger.trace('Starting Repomix MCP server...');
-  await runMcpServer();
+export const runMcpAction = async (options: { sandboxed?: boolean; cwd?: string } = {}): Promise<void> => {
+  const root = options.cwd ?? process.cwd();
+  logger.trace(`Starting Repomix MCP server${options.sandboxed ? ' (sandboxed)' : ''}...`);
+  await runMcpServer({ sandboxed: options.sandboxed === true, root });
 };

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -196,6 +196,10 @@ export const run = async () => {
       // MCP
       .optionsGroup('MCP')
       .option('--mcp', 'Run as Model Context Protocol server for AI tool integration')
+      .option(
+        '--sandbox [dir]',
+        "With --mcp: confine the MCP server's file tools to a workspace directory (defaults to the working directory; e.g. --sandbox path/to/project). Every path is relative to that root, absolute/host paths are refused, and remote packing, skill generation, and attaching external outputs are disabled.",
+      )
       // Skill Generation
       .optionsGroup('Skill Generation (Experimental)')
       .option(
@@ -290,6 +294,44 @@ const validateWatchOptions = (directories: string[], options: CliOptions): void 
   }
 };
 
+/**
+ * Canonicalize the --sandbox workspace root for the always-on path guard. realpath
+ * resolves symlinks (e.g. macOS /tmp -> /private/tmp) so the guard, output
+ * virtualization, and error scrubbing all agree with the realpaths resolveWithinRoot
+ * returns; a lexical-only root would silently weaken every guard that compares
+ * canonical child paths against it.
+ *
+ * Windows quirk: fs.realpath throws EPERM on some perfectly accessible directories
+ * (notably the 8.3 short-name temp path C:\Users\RUNNER~1\...). resolveWithinRoot
+ * already tolerates this by falling back to the lexical root, so match it here: when
+ * realpath fails but the directory genuinely exists, use the lexical (already
+ * absolute) root instead of refusing to start. A truly missing/inaccessible root
+ * still fails closed. The kernel sandbox grants on the directory OBJECT, not its
+ * name, so a short-name lexical root is confined identically — and because the guard
+ * canonicalizes root and candidates with the same realpath+lexical-fallback, they
+ * stay consistent.
+ */
+export const canonicalizeSandboxRoot = async (
+  requestedRoot: string,
+  deps = { realpath: (p: string) => fs.realpath(p), stat: (p: string) => fs.stat(p) },
+): Promise<string> => {
+  try {
+    return await deps.realpath(requestedRoot);
+  } catch (realpathError) {
+    try {
+      if ((await deps.stat(requestedRoot)).isDirectory()) {
+        return path.resolve(requestedRoot);
+      }
+    } catch {
+      // Directory is genuinely missing/inaccessible — fall through to fail closed.
+    }
+    const message = realpathError instanceof Error ? realpathError.message : String(realpathError);
+    throw new RepomixError(
+      `--sandbox workspace directory could not be resolved (${message}). Ensure it exists and is accessible.`,
+    );
+  }
+};
+
 export const runCli = async (directories: string[], cwd: string, options: CliOptions) => {
   // Detect stdout mode
   // NOTE: For compatibility, currently not detecting pipe mode
@@ -319,9 +361,21 @@ export const runCli = async (directories: string[], cwd: string, options: CliOpt
   logger.trace('cwd:', cwd);
   logger.trace('options:', options);
 
+  const sandboxed = options.sandbox != null && options.sandbox !== false;
+
+  if (sandboxed && !options.mcp) {
+    logger.warn('--sandbox has no effect without --mcp; it only confines the MCP server.');
+  }
+
   if (options.mcp) {
+    // A string value of --sandbox is the workspace dir to confine to; otherwise use cwd.
+    const requestedRoot = typeof options.sandbox === 'string' ? path.resolve(cwd, options.sandbox) : cwd;
+    // Canonicalize the root so the guard/virtualization/error-scrubbing agree with the
+    // realpaths resolveWithinRoot returns. Runs before any agent connects, so surfacing
+    // the operator's own path in a resolution error is fine.
+    const sandboxRoot = sandboxed ? await canonicalizeSandboxRoot(requestedRoot) : requestedRoot;
     const { runMcpAction } = await import('./actions/mcpAction.js');
-    return await runMcpAction();
+    return await runMcpAction({ sandboxed, cwd: sandboxRoot });
   }
 
   if (options.version) {

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -46,6 +46,8 @@ export interface CliOptions extends OptionValues {
   remoteBranch?: string;
   remoteTrustConfig?: boolean;
   skipLocalConfig?: boolean; // Internal flag: skip loading config files from the working directory (e.g., untrusted remote repos)
+  skipGlobalConfig?: boolean; // Internal flag: also skip the operator's GLOBAL repomix config. Untrusted-agent contexts (--sandbox) set this because a config-driven output.instructionFilePath could read an out-of-workspace file into agent-visible output.
+  confineToBaseDir?: boolean; // Internal flag: drop any discovered file that resolves outside the base directory. Off by default (so documented ../ / absolute include patterns keep working); untrusted-agent contexts (--sandbox) set it as a syntax-agnostic escape backstop.
   skipMigration?: boolean; // Internal flag: never run the Repopack migration (e.g., a throwaway remote clone whose legacy files are attacker-controlled)
   enableFileProcessors?: boolean; // Internal flag: allow input.processors to run external commands. Injected only by the real CLI entry point (auto-on for local runs; gated by --remote-trust-config for remote)
   deferTokenBudgetCheck?: boolean; // Internal flag: skip the token-budget check inside runDefaultAction so the caller can enforce it after delivering output (e.g., remote runs copy out of the temp dir first)
@@ -65,6 +67,7 @@ export interface CliOptions extends OptionValues {
 
   // MCP
   mcp?: boolean;
+  sandbox?: boolean | string;
 
   // Skill Generation
   skillGenerate?: string | boolean;

--- a/src/config/configLoad.ts
+++ b/src/config/configLoad.ts
@@ -85,7 +85,7 @@ const defaultJitiImport = async (fileUrl: string): Promise<unknown> => {
 export const loadFileConfig = async (
   rootDir: string,
   argConfigPath: string | null,
-  options: { skipLocalConfig?: boolean } = {},
+  options: { skipLocalConfig?: boolean; skipGlobalConfig?: boolean } = {},
   deps = {
     jitiImport: defaultJitiImport,
   },
@@ -117,9 +117,12 @@ export const loadFileConfig = async (
     );
   }
 
-  // Try to find a global config file using the priority order
+  // Try to find a global config file using the priority order. skipGlobalConfig
+  // (set for untrusted-agent contexts like --sandbox) skips it too: even the
+  // operator's own global config can set output.instructionFilePath to read an
+  // out-of-workspace file into the output shown to the untrusted agent.
   const globalConfigPaths = getGlobalConfigPaths();
-  const globalConfigPath = await findConfigFile(globalConfigPaths, 'global');
+  const globalConfigPath = options.skipGlobalConfig ? null : await findConfigFile(globalConfigPaths, 'global');
 
   if (globalConfigPath) {
     return await loadAndValidateConfig(globalConfigPath, deps);

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -128,6 +128,7 @@ export const searchFiles = async (
   rootDir: string,
   config: RepomixConfigMerged,
   explicitFiles?: string[],
+  confineToBaseDir = false,
 ): Promise<FileSearchResult> => {
   // Check if the path exists and get its type
   let pathStats: Stats;
@@ -286,12 +287,37 @@ export const searchFiles = async (
       logger.debug(`[globby] Completed in ${globbyElapsedTime}ms, found ${filePaths.length} files`);
     }
 
-    logger.debug(`[result] Total files: ${filePaths.length}, empty directories: ${emptyDirPaths.length}`);
-    logger.trace(`Filtered ${filePaths.length} files`);
+    // Optional security backstop (confineToBaseDir; set by untrusted-agent callers
+    // such as the MCP --sandbox): drop any match resolving outside rootDir. Glob
+    // patterns (absolute, brace/extglob-expanded, …) can make fast-glob match paths
+    // outside rootDir regardless of cwd; this is syntax-agnostic, independent of any
+    // caller-side pattern guard. OFF by default so the documented ../ / absolute
+    // include-pattern behavior is unchanged for normal CLI and library callers.
+    let confinedFilePaths = filePaths;
+    let confinedEmptyDirPaths = emptyDirPaths;
+    if (confineToBaseDir) {
+      const rootAbs = path.resolve(rootDir);
+      const withinRoot = (rel: string): boolean => {
+        const abs = path.resolve(rootAbs, rel);
+        return abs === rootAbs || abs.startsWith(rootAbs + path.sep);
+      };
+      confinedFilePaths = filePaths.filter(withinRoot);
+      confinedEmptyDirPaths = emptyDirPaths.filter(withinRoot);
+      if (confinedFilePaths.length !== filePaths.length) {
+        logger.debug(
+          `[confine] dropped ${filePaths.length - confinedFilePaths.length} path(s) resolving outside ${rootAbs}`,
+        );
+      }
+    }
+
+    logger.debug(
+      `[result] Total files: ${confinedFilePaths.length}, empty directories: ${confinedEmptyDirPaths.length}`,
+    );
+    logger.trace(`Filtered ${confinedFilePaths.length} files`);
 
     return {
-      filePaths: sortPaths(filePaths),
-      emptyDirPaths: sortPaths(emptyDirPaths),
+      filePaths: sortPaths(confinedFilePaths),
+      emptyDirPaths: sortPaths(confinedEmptyDirPaths),
     };
   } catch (error: unknown) {
     // Re-throw PermissionError as is

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -67,6 +67,10 @@ export interface PackOptions {
   skillDir?: string;
   skillProjectName?: string;
   skillSourceUrl?: string;
+  // Drop any discovered file that resolves outside its base dir (untrusted-agent
+  // callers like the MCP --sandbox). Off by default so ../ / absolute include
+  // patterns keep working for normal CLI and library callers.
+  confineToBaseDir?: boolean;
 }
 
 export const pack = async (
@@ -100,7 +104,7 @@ export const pack = async (
   const searchResultsByDir = await withMemoryLogging('Search Files', async () =>
     Promise.all(
       rootDirs.map(async (rootDir) => {
-        const result = await deps.searchFiles(rootDir, config, explicitFiles);
+        const result = await deps.searchFiles(rootDir, config, explicitFiles, options.confineToBaseDir);
         return { rootDir, filePaths: result.filePaths, emptyDirPaths: result.emptyDirPaths };
       }),
     ),

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -15,54 +15,85 @@ import { registerReadRepomixOutputTool } from './tools/readRepomixOutputTool.js'
 /**
  * Instructions for the Repomix MCP Server that describe its capabilities and usage
  */
+const MCP_SERVER_INSTRUCTIONS_INTRO = 'Repomix MCP Server provides AI-optimized codebase analysis tools. ';
+const MCP_SERVER_INSTRUCTIONS_OUTRO = 'Includes security scanning and supports compression for token efficiency.';
+
 const MCP_SERVER_INSTRUCTIONS =
-  'Repomix MCP Server provides AI-optimized codebase analysis tools. ' +
+  MCP_SERVER_INSTRUCTIONS_INTRO +
   'Use pack_codebase or pack_remote_repository to consolidate code into a single XML file, ' +
   'use generate_skill to create Claude Agent Skills from codebases, ' +
   'use attach_packed_output to work with existing packed outputs, ' +
   'then read_repomix_output and grep_repomix_output to analyze it. ' +
   'Perfect for code reviews, documentation generation, bug investigation, GitHub repository analysis, and understanding large codebases. ' +
-  'Includes security scanning and supports compression for token efficiency.';
+  MCP_SERVER_INSTRUCTIONS_OUTRO;
 
-export const createMcpServer = async () => {
+export interface McpServerConfig {
+  /** When true (--sandbox), confine every tool to `root` and virtualize all paths. */
+  sandboxed: boolean;
+  /** The allowed directory (server cwd). All tool paths must resolve inside it. */
+  root: string;
+}
+
+const defaultMcpServerConfig = (): McpServerConfig => ({ sandboxed: false, root: process.cwd() });
+
+// Shares the intro/outro but names only the sandbox-available tools — the disabled
+// ones (remote pack, skill gen, attach) leave no trace for the agent — plus path rules.
+const SANDBOX_INSTRUCTIONS =
+  MCP_SERVER_INSTRUCTIONS_INTRO +
+  'Use pack_codebase to consolidate code into a single XML file, then read_repomix_output and ' +
+  'grep_repomix_output to analyze it; file_system_read_file and file_system_read_directory explore the tree. ' +
+  'Perfect for code reviews, documentation generation, bug investigation, and understanding large codebases. ' +
+  MCP_SERVER_INSTRUCTIONS_OUTRO +
+  ' SANDBOX MODE: locked to a single workspace = the root. Paths must be relative to workspace root ' +
+  '(e.g. "src/index.ts"; "." = whole workspace) — no absolute / "/" / "~/" / "../" / drive / ".." segment ' +
+  '(refused; retry relative). Results are relative too (root = "."), no host paths. Explore with ' +
+  'file_system_read_directory "." or pack_codebase ".", then feed returned paths to ' +
+  'read_repomix_output / grep_repomix_output / file_system_read_file.';
+
+export const createMcpServer = async (config: McpServerConfig = defaultMcpServerConfig()) => {
   const mcpServer = new McpServer(
     {
       name: 'repomix-mcp-server',
       version: await getVersion(),
     },
     {
-      instructions: MCP_SERVER_INSTRUCTIONS,
+      instructions: config.sandboxed ? SANDBOX_INSTRUCTIONS : MCP_SERVER_INSTRUCTIONS,
     },
   );
 
-  // Register the prompts
-  registerPackRemoteRepositoryPrompt(mcpServer);
+  // Always available (read-only, root-confinable) tools.
+  registerPackCodebaseTool(mcpServer, config);
+  registerReadRepomixOutputTool(mcpServer, config);
+  registerGrepRepomixOutputTool(mcpServer, config);
+  registerFileSystemReadFileTool(mcpServer, config);
+  registerFileSystemReadDirectoryTool(mcpServer, config);
 
-  // Register the tools
-  registerPackCodebaseTool(mcpServer);
-  registerPackRemoteRepositoryTool(mcpServer);
-  registerGenerateSkillTool(mcpServer);
-  registerAttachPackedOutputTool(mcpServer);
-  registerReadRepomixOutputTool(mcpServer);
-  registerGrepRepomixOutputTool(mcpServer);
-  registerFileSystemReadFileTool(mcpServer);
-  registerFileSystemReadDirectoryTool(mcpServer);
+  // Tools unavailable in sandbox mode: remote fetch (needs network),
+  // skill generation (writes), attach (arbitrary-path read of external files).
+  if (!config.sandboxed) {
+    registerPackRemoteRepositoryPrompt(mcpServer);
+    registerPackRemoteRepositoryTool(mcpServer);
+    registerGenerateSkillTool(mcpServer);
+    registerAttachPackedOutputTool(mcpServer);
+  }
 
   return mcpServer;
 };
 
-type Dependencies = {
+type RunMcpServerOptions = {
+  sandboxed?: boolean;
+  root?: string;
   processExit?: (code?: number) => never;
 };
 
-const defaultDependencies: Dependencies = {
-  processExit: process.exit,
-};
-
-export const runMcpServer = async (deps: Dependencies = defaultDependencies) => {
-  const server = await createMcpServer();
+export const runMcpServer = async (options: RunMcpServerOptions = {}) => {
+  const config: McpServerConfig = {
+    sandboxed: options.sandboxed === true,
+    root: options.root ?? process.cwd(),
+  };
+  const server = await createMcpServer(config);
   const transport = new StdioServerTransport();
-  const processExit = deps.processExit ?? process.exit;
+  const processExit = options.processExit ?? process.exit;
 
   const handleExit = async () => {
     try {

--- a/src/mcp/pathScope.ts
+++ b/src/mcp/pathScope.ts
@@ -1,0 +1,106 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * Raised when a caller-supplied path is not a valid plain-relative path inside
+ * the allowed directory. Tools translate this into a user-facing MCP error.
+ */
+export class PathScopeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PathScopeError';
+  }
+}
+
+const isInside = (root: string, candidate: string): boolean =>
+  candidate === root || candidate.startsWith(root + path.sep);
+
+/**
+ * True when `input` is not a plain relative path safely inside a root: an absolute
+ * path per the host OS (`path.isAbsolute` covers "/x" on POSIX and "C:\x" / "\x" /
+ * UNC on Windows), a "~" or "~/" home ref, or any ".." traversal segment (either
+ * separator). A filename that merely starts with "~" (e.g. "~$lock.docx") is
+ * allowed — only the home-ref forms are rejected. Shared by resolveWithinRoot and
+ * the sandbox pattern guard so both agree on what "escapes the workspace".
+ */
+export const isEscapingPath = (input: string): boolean =>
+  path.isAbsolute(input) ||
+  // Windows drive-RELATIVE (e.g. "C:foo", "C:"): a drive letter + colon NOT followed
+  // by a separator. path.isAbsolute misses this form, which on Windows resolves against
+  // that drive's own cwd (escaping root). Rooted "C:\x"/"C:/x" are already caught by
+  // isAbsolute on Windows and are legitimate relative filenames on POSIX, so exclude them.
+  /^[a-zA-Z]:(?![/\\])/.test(input) ||
+  input === '~' ||
+  input.startsWith('~/') ||
+  input === '..' ||
+  input.split(/[/\\]/).includes('..');
+
+// Narrow realpath type so tests can inject a simple string→string stub. Binding
+// to the full overloaded `fs.realpath` signature would make such stubs fail tsc.
+type RealpathFn = (path: string) => Promise<string>;
+
+/**
+ * Resolve a relative `input` against the allowed `root` and guarantee the result
+ * stays inside it. Paths must be relative (e.g. "src/index.ts", "a/b/file.txt");
+ * "." (or "") selects the root; a redundant leading "./" (or ".\") is tolerated
+ * but not recommended.
+ * Rejected: absolute paths ("/x", "C:\x", "\x", UNC), "~" home refs, and any
+ * ".." traversal segment (either separator). Symlink escapes are caught via
+ * realpath. Returns the resolved absolute path (realpath when the target exists).
+ */
+export const resolveWithinRoot = async (
+  root: string,
+  input: string,
+  deps: { realpath: RealpathFn } = { realpath: (p) => fs.realpath(p) },
+): Promise<string> => {
+  const rootResolved = path.resolve(root);
+
+  if (input === '' || input === '.') {
+    return rootResolved;
+  }
+
+  // Reject anything that escapes the workspace root — absolute/drive/UNC, a "~"
+  // home ref, or any ".." segment. A redundant leading "./" or ".\" is allowed.
+  if (isEscapingPath(input)) {
+    throw new PathScopeError(
+      `Path "${input}" must be relative to workspace root — no "/", "~/", "../", drive, or ".." segment. Use e.g. "src/index.ts" or "." for whole workspace.`,
+    );
+  }
+
+  const candidate = path.resolve(rootResolved, input);
+
+  if (!isInside(rootResolved, candidate)) {
+    throw new PathScopeError(`Path "${input}" resolves outside workspace root.`);
+  }
+
+  // Resolve symlinks to catch a link inside root that points back out. If a path
+  // can't be resolved via realpath (e.g. the target does not exist yet, or the
+  // root itself can't be stat'd), fall back to the lexical path — it is already
+  // confined lexically above.
+  let realRoot: string;
+  try {
+    realRoot = (await deps.realpath(rootResolved)) as string;
+  } catch {
+    realRoot = rootResolved;
+  }
+  let realCandidate: string;
+  try {
+    realCandidate = (await deps.realpath(candidate)) as string;
+  } catch {
+    return candidate;
+  }
+  if (!isInside(realRoot, realCandidate)) {
+    throw new PathScopeError(`Path "${input}" resolves outside workspace root.`);
+  }
+  return realCandidate;
+};
+
+/** Convert an absolute path inside `root` to a plain, root-relative path ("src/x.ts"); root itself → ".". */
+export const toVirtualPath = (root: string, absPath: string): string => {
+  const rootResolved = path.resolve(root);
+  const rel = path.relative(rootResolved, path.resolve(absPath));
+  if (rel === '') {
+    return '.';
+  }
+  return rel.split(path.sep).join('/');
+};

--- a/src/mcp/tools/fileSystemReadDirectoryTool.ts
+++ b/src/mcp/tools/fileSystemReadDirectoryTool.ts
@@ -4,10 +4,16 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { logger } from '../../shared/logger.js';
-import { buildMcpToolErrorResponse, buildMcpToolSuccessResponse } from './mcpToolRuntime.js';
+import type { McpServerConfig } from '../mcpServer.js';
+import {
+  buildMcpToolErrorResponse,
+  buildMcpToolSuccessResponse,
+  buildSandboxErrorResponse,
+  resolveToolPath,
+} from './mcpToolRuntime.js';
 
 const fileSystemReadDirectoryInputSchema = z.object({
-  path: z.string().describe('Absolute path to the directory to list'),
+  path: z.string(),
 });
 
 const fileSystemReadDirectoryOutputSchema = z.object({
@@ -21,14 +27,29 @@ const fileSystemReadDirectoryOutputSchema = z.object({
 /**
  * Register file system directory listing tool
  */
-export const registerFileSystemReadDirectoryTool = (mcpServer: McpServer) => {
+export const registerFileSystemReadDirectoryTool = (
+  mcpServer: McpServer,
+  config: McpServerConfig = { sandboxed: false, root: process.cwd() },
+) => {
+  const description = config.sandboxed
+    ? 'List the contents of a directory in the workspace, at a path relative to the workspace root (e.g. "." or "src"). Returns a formatted list showing files and subdirectories with clear [FILE]/[DIR] indicators. Useful for exploring project structure and understanding codebase organization.'
+    : 'List the contents of a directory using an absolute path. Returns a formatted list showing files and subdirectories with clear [FILE]/[DIR] indicators. Useful for exploring project structure and understanding codebase organization.';
+  const inputSchema = fileSystemReadDirectoryInputSchema.extend({
+    path: z
+      .string()
+      .describe(
+        config.sandboxed
+          ? 'Path to the directory to list, relative to the workspace root (e.g. "." or "src") — no "/", "~/", drive, or ".." segment.'
+          : 'Absolute path to the directory to list',
+      ),
+  });
+
   mcpServer.registerTool(
     'file_system_read_directory',
     {
       title: 'Read Directory',
-      description:
-        'List the contents of a directory using an absolute path. Returns a formatted list showing files and subdirectories with clear [FILE]/[DIR] indicators. Useful for exploring project structure and understanding codebase organization.',
-      inputSchema: fileSystemReadDirectoryInputSchema,
+      description,
+      inputSchema,
       outputSchema: fileSystemReadDirectoryOutputSchema,
       annotations: {
         readOnlyHint: true,
@@ -39,31 +60,36 @@ export const registerFileSystemReadDirectoryTool = (mcpServer: McpServer) => {
     },
     async ({ path: directoryPath }): Promise<CallToolResult> => {
       try {
-        logger.trace(`Listing directory at absolute path: ${directoryPath}`);
-
-        // Ensure path is absolute
-        if (!path.isAbsolute(directoryPath)) {
+        // Non-sandbox keeps the legacy absolute-path contract — guard it up front.
+        if (!config.sandboxed && !path.isAbsolute(directoryPath)) {
           return buildMcpToolErrorResponse({
             errorMessage: `Error: Path must be absolute. Received: ${directoryPath}`,
           });
         }
+        // Sandbox: plain-relative → confined + virtualized. Non-sandbox: as-is.
+        const { absPath, displayPath } = await resolveToolPath(config, directoryPath);
+
+        logger.trace(`Listing directory at path: ${displayPath}`);
 
         // Check if directory exists
         try {
-          const stats = await fs.stat(directoryPath);
+          const stats = await fs.stat(absPath);
           if (!stats.isDirectory()) {
             return buildMcpToolErrorResponse({
-              errorMessage: `Error: The specified path is not a directory: ${directoryPath}. Use file_system_read_file for files.`,
+              errorMessage: `Error: The specified path is not a directory: ${displayPath}. Use file_system_read_file for files.`,
             });
           }
-        } catch {
+        } catch (error) {
+          // Only a genuine "not found" maps to this message; other stat failures (e.g.
+          // EACCES) bubble to the outer catch so they're categorized/redacted correctly.
+          if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') throw error;
           return buildMcpToolErrorResponse({
-            errorMessage: `Error: Directory not found at path: ${directoryPath}`,
+            errorMessage: `Error: Directory not found at path: ${displayPath}`,
           });
         }
 
         // Read directory contents
-        const entries = await fs.readdir(directoryPath, { withFileTypes: true });
+        const entries = await fs.readdir(absPath, { withFileTypes: true });
         const contents = entries.map((entry) => `${entry.isDirectory() ? '[DIR]' : '[FILE]'} ${entry.name}`);
 
         const fileCount = entries.filter((entry) => entry.isFile()).length;
@@ -71,17 +97,20 @@ export const registerFileSystemReadDirectoryTool = (mcpServer: McpServer) => {
         const totalItems = entries.length;
 
         return buildMcpToolSuccessResponse({
-          path: directoryPath,
+          path: displayPath,
           contents: contents.length > 0 ? contents : ['(empty directory)'],
           totalItems,
           fileCount,
           directoryCount,
         } satisfies z.infer<typeof fileSystemReadDirectoryOutputSchema>);
       } catch (error) {
-        logger.error(`Error in file_system_read_directory tool: ${error}`);
-        return buildMcpToolErrorResponse({
-          errorMessage: `Error listing directory: ${error instanceof Error ? error.message : String(error)}`,
-        });
+        logger.error(`Error in file_system_read_directory tool: ${error}`); // full detail → operator (stderr)
+        // Sandbox: a whitelisted, path-free reason + the agent's own input path; the
+        // raw error.message (which can carry the absolute host path) is never
+        // forwarded, so no host path can leak. Non-sandbox: the raw message is fine.
+        if (config.sandboxed) return buildSandboxErrorResponse(error, directoryPath);
+        const message = error instanceof Error ? error.message : String(error);
+        return buildMcpToolErrorResponse({ errorMessage: `Error listing directory: ${message}` });
       }
     },
   );

--- a/src/mcp/tools/fileSystemReadFileTool.ts
+++ b/src/mcp/tools/fileSystemReadFileTool.ts
@@ -5,10 +5,16 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { createSecretLintConfig, runSecretLint } from '../../core/security/workers/securityCheckWorker.js';
 import { logger } from '../../shared/logger.js';
-import { buildMcpToolErrorResponse, buildMcpToolSuccessResponse } from './mcpToolRuntime.js';
+import type { McpServerConfig } from '../mcpServer.js';
+import {
+  buildMcpToolErrorResponse,
+  buildMcpToolSuccessResponse,
+  buildSandboxErrorResponse,
+  resolveToolPath,
+} from './mcpToolRuntime.js';
 
 const fileSystemReadFileInputSchema = z.object({
-  path: z.string().describe('Absolute path to the file to read'),
+  path: z.string(),
 });
 
 const fileSystemReadFileOutputSchema = z.object({
@@ -22,14 +28,29 @@ const fileSystemReadFileOutputSchema = z.object({
 /**
  * Register file system read file tool with security checks
  */
-export const registerFileSystemReadFileTool = (mcpServer: McpServer) => {
+export const registerFileSystemReadFileTool = (
+  mcpServer: McpServer,
+  config: McpServerConfig = { sandboxed: false, root: process.cwd() },
+) => {
+  const description = config.sandboxed
+    ? 'Read a file from the workspace, at a path relative to the workspace root (e.g. "src/index.ts"). Includes built-in security validation to detect and prevent access to files containing sensitive information (API keys, passwords, secrets).'
+    : 'Read a file from the local file system using an absolute path. Includes built-in security validation to detect and prevent access to files containing sensitive information (API keys, passwords, secrets).';
+  const inputSchema = fileSystemReadFileInputSchema.extend({
+    path: z
+      .string()
+      .describe(
+        config.sandboxed
+          ? 'Path to the file to read, relative to the workspace root (e.g. "src/index.ts") — no "/", "~/", drive, or ".." segment.'
+          : 'Absolute path to the file to read',
+      ),
+  });
+
   mcpServer.registerTool(
     'file_system_read_file',
     {
       title: 'Read File',
-      description:
-        'Read a file from the local file system using an absolute path. Includes built-in security validation to detect and prevent access to files containing sensitive information (API keys, passwords, secrets).',
-      inputSchema: fileSystemReadFileInputSchema,
+      description,
+      inputSchema,
       outputSchema: fileSystemReadFileOutputSchema,
       annotations: {
         readOnlyHint: true,
@@ -40,65 +61,65 @@ export const registerFileSystemReadFileTool = (mcpServer: McpServer) => {
     },
     async ({ path: filePath }): Promise<CallToolResult> => {
       try {
-        logger.trace(`Reading file at absolute path: ${filePath}`);
-
-        // Ensure path is absolute
-        if (!path.isAbsolute(filePath)) {
-          return buildMcpToolErrorResponse({
-            errorMessage: `Error: Path must be absolute. Received: ${filePath}`,
-          });
+        // Non-sandbox keeps the legacy absolute-path contract — guard it up front.
+        if (!config.sandboxed && !path.isAbsolute(filePath)) {
+          return buildMcpToolErrorResponse({ errorMessage: `Error: Path must be absolute. Received: ${filePath}` });
         }
+        // Sandbox: plain-relative → confined + virtualized. Non-sandbox: as-is.
+        const { absPath, displayPath } = await resolveToolPath(config, filePath);
+
+        logger.trace(`Reading file at path: ${displayPath}`);
 
         // Check if file exists
         try {
-          await fs.access(filePath);
+          await fs.access(absPath);
         } catch {
           return buildMcpToolErrorResponse({
-            errorMessage: `Error: File not found at path: ${filePath}`,
+            errorMessage: `Error: File not found at path: ${displayPath}`,
           });
         }
 
-        // Check if it's a directory
-        const stats = await fs.stat(filePath);
+        // Check if it's a directory (the same stat also carries the size below)
+        const stats = await fs.stat(absPath);
         if (stats.isDirectory()) {
           return buildMcpToolErrorResponse({
-            errorMessage: `Error: The specified path is a directory, not a file: ${filePath}. Use file_system_read_directory for directories.`,
+            errorMessage: `Error: The specified path is a directory, not a file: ${displayPath}. Use file_system_read_directory for directories.`,
           });
         }
 
-        // Get file stats
-        const fileStats = await fs.stat(filePath);
-
         // Read file content
-        const fileContent = await fs.readFile(filePath, 'utf8');
+        const fileContent = await fs.readFile(absPath, 'utf8');
 
         // Perform security check using the existing worker
-        const config = createSecretLintConfig();
-        const securityCheckResult = await runSecretLint(filePath, fileContent, 'file', config);
+        const secretLintConfig = createSecretLintConfig();
+        const securityCheckResult = await runSecretLint(absPath, fileContent, 'file', secretLintConfig);
 
         // If security check found issues, block the file
         if (securityCheckResult !== null) {
           return buildMcpToolErrorResponse({
-            errorMessage: `Error: Security check failed. The file at ${filePath} may contain sensitive information.`,
+            errorMessage: `Error: Security check failed. The file at ${displayPath} may contain sensitive information.`,
           });
         }
 
         // Calculate file metrics
         const lines = fileContent.split('\n').length;
-        const size = fileStats.size;
+        const size = stats.size;
 
         return buildMcpToolSuccessResponse({
-          path: filePath,
+          path: displayPath,
           content: fileContent,
           size,
           encoding: 'utf8',
           lines,
         } satisfies z.infer<typeof fileSystemReadFileOutputSchema>);
       } catch (error) {
-        logger.error(`Error in file_system_read_file tool: ${error}`);
-        return buildMcpToolErrorResponse({
-          errorMessage: `Error reading file: ${error instanceof Error ? error.message : String(error)}`,
-        });
+        logger.error(`Error in file_system_read_file tool: ${error}`); // full detail → operator (stderr)
+        // Sandbox: a whitelisted, path-free reason + the agent's own input path; the
+        // raw error.message (which can carry the absolute host path) is never
+        // forwarded, so no host path can leak. Non-sandbox: the raw message is fine.
+        if (config.sandboxed) return buildSandboxErrorResponse(error, filePath);
+        const message = error instanceof Error ? error.message : String(error);
+        return buildMcpToolErrorResponse({ errorMessage: `Error reading file: ${message}` });
       }
     },
   );

--- a/src/mcp/tools/grepRepomixOutputTool.ts
+++ b/src/mcp/tools/grepRepomixOutputTool.ts
@@ -4,9 +4,11 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { createSecretLintConfig, runSecretLint } from '../../core/security/workers/securityCheckWorker.js';
 import { logger } from '../../shared/logger.js';
+import type { McpServerConfig } from '../mcpServer.js';
 import {
   buildMcpToolErrorResponse,
   buildMcpToolSuccessResponse,
+  buildSandboxErrorResponse,
   convertErrorToJson,
   getOutputFilePath,
   requiresSecretScan,
@@ -79,7 +81,10 @@ interface SearchResult {
 /**
  * Register the tool to search Repomix output files with grep-like functionality
  */
-export const registerGrepRepomixOutputTool = (mcpServer: McpServer) => {
+export const registerGrepRepomixOutputTool = (
+  mcpServer: McpServer,
+  config: McpServerConfig = { sandboxed: false, root: process.cwd() },
+) => {
   mcpServer.registerTool(
     'grep_repomix_output',
     {
@@ -121,7 +126,9 @@ export const registerGrepRepomixOutputTool = (mcpServer: McpServer) => {
           await fs.access(filePath);
         } catch {
           return buildMcpToolErrorResponse({
-            errorMessage: `Error: Output file does not exist at path: ${filePath}. The temporary file may have been cleaned up.`,
+            errorMessage: config.sandboxed
+              ? `Error: Output ${outputId} is no longer available.`
+              : `Error: Output file does not exist at path: ${filePath}. The temporary file may have been cleaned up.`,
             details: {
               outputId,
               reason: 'FILE_ACCESS_ERROR',
@@ -138,7 +145,9 @@ export const registerGrepRepomixOutputTool = (mcpServer: McpServer) => {
           const securityCheckResult = await runSecretLint(filePath, content, 'file', createSecretLintConfig());
           if (securityCheckResult !== null) {
             return buildMcpToolErrorResponse({
-              errorMessage: `Error: Security check failed. The file at ${filePath} may contain sensitive information.`,
+              errorMessage: config.sandboxed
+                ? `Error: Security check failed. Output ${outputId} may contain sensitive information.`
+                : `Error: Security check failed. The file at ${filePath} may contain sensitive information.`,
               details: {
                 outputId,
                 reason: 'SECURITY_CHECK_FAILED',
@@ -162,6 +171,10 @@ export const registerGrepRepomixOutputTool = (mcpServer: McpServer) => {
             ignoreCase,
           });
         } catch (error) {
+          logger.error(`Error in grep_repomix_output search: ${error}`); // full detail → operator (stderr)
+          // Sandbox: a whitelisted, path-free reason — never forward raw error.message
+          // (it can carry an absolute host path), matching the outer catch below.
+          if (config.sandboxed) return buildSandboxErrorResponse(error, outputId);
           return buildMcpToolErrorResponse({
             errorMessage: `Error: ${error instanceof Error ? error.message : String(error)}`,
             details: {
@@ -191,6 +204,7 @@ export const registerGrepRepomixOutputTool = (mcpServer: McpServer) => {
         } satisfies z.infer<typeof grepRepomixOutputOutputSchema>);
       } catch (error) {
         logger.error(`Error in grep_repomix_output: ${error}`);
+        if (config.sandboxed) return buildSandboxErrorResponse(error, outputId);
         return buildMcpToolErrorResponse(convertErrorToJson(error));
       }
     },

--- a/src/mcp/tools/mcpToolRuntime.ts
+++ b/src/mcp/tools/mcpToolRuntime.ts
@@ -6,6 +6,60 @@ import { z } from 'zod';
 import { generateTreeString } from '../../core/file/fileTreeGenerate.js';
 import type { ProcessedFile } from '../../core/file/fileTypes.js';
 import { getRepomixTmpDir } from '../../shared/tmpDir.js';
+import { PathScopeError, resolveWithinRoot, toVirtualPath } from '../pathScope.js';
+
+/**
+ * Resolve a file-system tool's path argument for both modes (shared by the read
+ * file/directory tools). Sandbox: confine `input` to the workspace root — throws
+ * PathScopeError on escape — and virtualize it for display. Non-sandbox: the legacy
+ * absolute-path contract, where the caller's path is used and echoed as-is (the
+ * absolute-path requirement stays a guard clause in the tool).
+ */
+export const resolveToolPath = async (
+  config: { sandboxed: boolean; root: string },
+  input: string,
+): Promise<{ absPath: string; displayPath: string }> => {
+  if (!config.sandboxed) return { absPath: input, displayPath: input };
+  const absPath = await resolveWithinRoot(config.root, input);
+  return { absPath, displayPath: toVirtualPath(config.root, absPath) };
+};
+
+/**
+ * Map any caught error to a SAFE, path-free reason for the untrusted agent. This is
+ * the whitelist that makes sandbox errors leak-proof by construction: we NEVER
+ * forward error.message (it can embed the workspace root, the repomix install/worker
+ * path, the node runtime, or the operator's home dir). A PathScopeError is the one
+ * exception — its message is built from the agent's own input + the path rule, so it
+ * is safe and useful. Everything else collapses to a fixed reason derived only from
+ * the error CODE (an enum, never a string): an fs code maps to a specific reason, and
+ * anything without a recognised code (RepomixError, worker/WASM load failure, …) maps
+ * to a generic reason. The full error still reaches the operator via logger.error
+ * (stderr) — the tool catches log it before calling this.
+ */
+export const sandboxErrorReason = (error: unknown): string => {
+  if (error instanceof PathScopeError) return error.message;
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  switch (code) {
+    case 'ENOENT':
+      return 'not found';
+    case 'EACCES':
+    case 'EPERM':
+      return 'permission denied';
+    case 'EISDIR':
+      return 'path is a directory';
+    case 'ENOTDIR':
+      return 'path is not a directory';
+    case 'ELOOP':
+      return 'too many symbolic links';
+    case 'ENAMETOOLONG':
+      return 'path name too long';
+    case 'EMFILE':
+    case 'ENFILE':
+      return 'too many open files';
+    default:
+      return 'operation failed';
+  }
+};
 
 /**
  * Shared MCP input schema for per-file inclusion levels (output.patterns).
@@ -115,16 +169,14 @@ export const formatPackToolResponse = async (
   outputFilePath: string,
   topFilesLen = 5,
   requiresSecretScan = false,
+  scope?: { sandboxed: boolean; root: string },
 ): Promise<CallToolResult> => {
-  // Generate output ID and register the file
   const outputId = generateOutputId();
   registerOutputFile(outputId, outputFilePath, requiresSecretScan);
 
-  // Calculate total lines from the output file
   const outputContent = await fs.readFile(outputFilePath, 'utf8');
   const totalLines = outputContent.split('\n').length;
 
-  // Get top files by character count
   const topFiles = Object.entries(metrics.fileCharCounts)
     .map(([filePath, charCount]) => ({
       path: filePath,
@@ -134,15 +186,20 @@ export const formatPackToolResponse = async (
     .sort((a, b) => b.charCount - a.charCount)
     .slice(0, topFilesLen);
 
-  // Directory Structure
   const directoryStructure = generateTreeString(metrics.safeFilePaths, []);
 
-  // Create JSON string with all the metrics information
+  // In sandbox mode, never expose the host output path or the host directory.
+  const outputFilePathDisplay = scope?.sandboxed ? '' : outputFilePath;
+  const directoryDisplay =
+    context.directory !== undefined && scope?.sandboxed
+      ? toVirtualPath(scope.root, context.directory)
+      : context.directory;
+
   const jsonResult = JSON.stringify(
     {
-      ...(context.directory ? { directory: context.directory } : {}),
+      ...(directoryDisplay ? { directory: directoryDisplay } : {}),
       ...(context.repository ? { repository: context.repository } : {}),
-      outputFilePath,
+      outputFilePath: outputFilePathDisplay,
       outputId,
       metrics: {
         totalFiles: metrics.totalFiles,
@@ -156,12 +213,19 @@ export const formatPackToolResponse = async (
     2,
   );
 
+  // Only the "read the file directly using path" line exposes the host output
+  // path, so it is the sole part omitted in sandbox mode; everything else
+  // (including the path-free XML structure sample) is byte-for-byte identical to
+  // the non-sandboxed output.
+  const directAccessLine = scope?.sandboxed
+    ? ''
+    : `For environments with direct file system access, you can read the file directly using path: ${outputFilePath}\n`;
+
   return buildMcpToolSuccessResponse({
     description: `
 🎉 Successfully packed codebase!\nPlease review the metrics below and consider adjusting compress/includePatterns/ignorePatterns if the token count is too high and you need to reduce it before reading the file content.
 
-For environments with direct file system access, you can read the file directly using path: ${outputFilePath}
-For environments without direct file access (e.g., web browsers or sandboxed apps), use the \`read_repomix_output\` tool with this outputId: ${outputId} to access the packed codebase contents.
+${directAccessLine}For environments without direct file access (e.g., web browsers or sandboxed apps), use the \`read_repomix_output\` tool with this outputId: ${outputId} to access the packed codebase contents.
 
 The output retrieved with \`read_repomix_output\` has the following structure:
 
@@ -199,7 +263,7 @@ You can use grep with \`path="<file-path>"\` to locate specific files within the
     result: jsonResult,
     directoryStructure: directoryStructure,
     outputId: outputId,
-    outputFilePath: outputFilePath,
+    outputFilePath: outputFilePathDisplay,
     totalFiles: metrics.totalFiles,
     totalTokens: metrics.totalTokens,
   });
@@ -287,4 +351,21 @@ export const buildMcpToolErrorResponse = (structuredContent: McpToolStructuredCo
     // structuredContent is intentionally omitted for error responses
     // Error messages have different schema than success responses and may cause validation issues
   };
+};
+
+/**
+ * The single boundary for turning a caught error into a SANDBOX tool response. The
+ * message is built ONLY from a whitelisted reason ({@link sandboxErrorReason}) plus
+ * the agent's OWN input (`subject`, e.g. the relative path or outputId it supplied) —
+ * error.message is never forwarded — so no host path can reach the agent by
+ * construction. Note `subject` may legitimately be an absolute path the agent typed
+ * (e.g. "/etc/passwd" it tried to read); echoing it back is safe and helps the agent
+ * see what it sent, and it is NOT a host path. The no-host-path guarantee is enforced
+ * structurally (never forwarding error.message) and asserted end-to-end by the sandbox
+ * contract test. Non-sandbox callers never use this.
+ */
+export const buildSandboxErrorResponse = (error: unknown, subject?: string): CallToolResult => {
+  const reason = sandboxErrorReason(error);
+  const message = subject ? `Error: ${reason}: ${subject}` : `Error: ${reason}`;
+  return buildMcpToolErrorResponse({ errorMessage: message });
 };

--- a/src/mcp/tools/packCodebaseTool.ts
+++ b/src/mcp/tools/packCodebaseTool.ts
@@ -1,20 +1,45 @@
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { braceExpand } from 'minimatch';
 import { z } from 'zod';
 import { runCli } from '../../cli/cliRun.js';
 import type { CliOptions } from '../../cli/types.js';
 import { defaultFilePathMap } from '../../config/configSchema.js';
+import { logger } from '../../shared/logger.js';
+import { splitPatterns } from '../../shared/patternUtils.js';
+import type { McpServerConfig } from '../mcpServer.js';
+import { isEscapingPath, resolveWithinRoot } from '../pathScope.js';
 import {
   buildMcpToolErrorResponse,
+  buildSandboxErrorResponse,
   convertErrorToJson,
   createToolWorkspace,
   formatPackToolResponse,
   outputPatternsSchema,
 } from './mcpToolRuntime.js';
 
+/**
+ * True when a comma-separated include/ignore glob string contains any pattern that
+ * escapes the workspace root. Tokenize with splitPatterns (brace-aware, exactly as
+ * the packer does) and brace-expand each token before checking, because a brace
+ * alternative can smuggle an absolute or ".." path — "{/etc/**,x}" expands to
+ * "/etc/**", and fast-glob honors an absolute pattern regardless of cwd. A leading
+ * "!" (negation) is stripped before the check.
+ *
+ * This is an early, human-readable rejection, not the security boundary: syntaxes it
+ * cannot statically pre-expand (e.g. extglob) are still caught downstream by the
+ * syntax-agnostic confineToBaseDir backstop in searchFiles, which drops any match
+ * resolving outside the root.
+ */
+const patternsEscapeRoot = (patterns?: string): boolean =>
+  splitPatterns(patterns).some((token) =>
+    braceExpand(token).some((expanded) => isEscapingPath(expanded.trim().replace(/^!+/, ''))),
+  );
+
 const packCodebaseInputSchema = z.object({
-  directory: z.string().describe('Directory to pack (Absolute path)'),
+  directory: z.string(),
   compress: z
     .boolean()
     .default(false)
@@ -59,14 +84,27 @@ const packCodebaseOutputSchema = z.object({
   totalTokens: z.number().describe('Total token count of the content'),
 });
 
-export const registerPackCodebaseTool = (mcpServer: McpServer) => {
+export const registerPackCodebaseTool = (
+  mcpServer: McpServer,
+  config: McpServerConfig = { sandboxed: false, root: process.cwd() },
+) => {
+  const inputSchema = packCodebaseInputSchema.extend({
+    directory: z
+      .string()
+      .describe(
+        config.sandboxed
+          ? 'Directory to pack, relative to the workspace root (e.g. "." or "src").'
+          : 'Directory to pack (Absolute path)',
+      ),
+  });
+
   mcpServer.registerTool(
     'pack_codebase',
     {
       title: 'Pack Local Codebase',
       description:
         'Package a local code directory into a consolidated file for AI analysis. This tool analyzes the codebase structure, extracts relevant code content, and generates a comprehensive report including metrics, file tree, and formatted code content. Supports multiple output formats: XML (structured with <file> tags), Markdown (human-readable with ## headers and code blocks), JSON (machine-readable with files as key-value pairs), and Plain text (simple format with separators). Also supports Tree-sitter compression for efficient token usage.',
-      inputSchema: packCodebaseInputSchema,
+      inputSchema,
       outputSchema: packCodebaseOutputSchema,
       annotations: {
         readOnlyHint: true,
@@ -87,6 +125,33 @@ export const registerPackCodebaseTool = (mcpServer: McpServer) => {
       let tempDir = '';
 
       try {
+        let targetDirectory = directory;
+        if (config.sandboxed) {
+          // Confine include/ignore globs to the workspace (see patternsEscapeRoot:
+          // brace-aware tokenization + brace expansion, so "{/etc/**,x}" can't slip an
+          // absolute alternative past the check).
+          for (const patterns of [includePatterns, ignorePatterns]) {
+            if (patternsEscapeRoot(patterns)) {
+              return buildMcpToolErrorResponse({
+                errorMessage:
+                  'Error: include/ignore patterns must be relative to the workspace root in sandbox mode (no absolute, "~", drive, UNC, or ".." patterns).',
+              });
+            }
+          }
+          targetDirectory = await resolveWithinRoot(config.root, directory);
+          // Pre-check existence here so a mistyped directory gets an actionable
+          // reason: otherwise searchFiles throws a code-less RepomixError ("Target
+          // path does not exist"), which the sandbox error boundary can only render
+          // as the generic "operation failed". Mirrors the file_system_* tools.
+          try {
+            if (!(await fs.stat(targetDirectory)).isDirectory()) {
+              return buildMcpToolErrorResponse({ errorMessage: `Error: not a directory: ${directory}` });
+            }
+          } catch {
+            return buildMcpToolErrorResponse({ errorMessage: `Error: directory not found: ${directory}` });
+          }
+        }
+
         tempDir = await createToolWorkspace();
         const outputFileName = defaultFilePathMap[style as keyof typeof defaultFilePathMap];
         const outputFilePath = path.join(tempDir, outputFileName);
@@ -101,9 +166,26 @@ export const registerPackCodebaseTool = (mcpServer: McpServer) => {
           securityCheck: true,
           topFilesLen: topFilesLength,
           quiet: true,
+          // Untrusted-workspace lockdown — one set, all gated on --sandbox:
+          //  - skip EVERY config file: the workspace's repomix.config.* AND the
+          //    operator's global one, since either could set
+          //    output.instructionFilePath to read an out-of-workspace file into the
+          //    agent-visible output, or input.processors to run commands;
+          //  - confine the file search to the root, a syntax-agnostic backstop behind
+          //    the include/ignore pattern guard.
+          ...(config.sandboxed ? { skipLocalConfig: true, skipGlobalConfig: true, confineToBaseDir: true } : {}),
         } as CliOptions;
 
-        const result = await runCli(['.'], directory, cliOptions);
+        // cliOptions.quiet makes runCli set the SHARED logger to SILENT and never
+        // restore it — which would permanently blind the operator's stderr error
+        // logging for the rest of the MCP session. Save + restore around the call.
+        const logLevelBeforePack = logger.getLogLevel();
+        let result: Awaited<ReturnType<typeof runCli>>;
+        try {
+          result = await runCli(['.'], targetDirectory, cliOptions);
+        } finally {
+          logger.setLogLevel(logLevelBeforePack);
+        }
         if (!result) {
           return buildMcpToolErrorResponse({
             errorMessage: 'Failed to return a result',
@@ -113,8 +195,22 @@ export const registerPackCodebaseTool = (mcpServer: McpServer) => {
         // Extract metrics information from the pack result
         const { packResult } = result;
 
-        return await formatPackToolResponse({ directory }, packResult, outputFilePath, topFilesLength);
+        return await formatPackToolResponse(
+          { directory: targetDirectory },
+          packResult,
+          outputFilePath,
+          topFilesLength,
+          false,
+          {
+            sandboxed: config.sandboxed,
+            root: config.root,
+          },
+        );
       } catch (error) {
+        // Sandbox: a whitelisted, path-free reason built from the error code + the
+        // agent's own `directory` input — error.message is never forwarded, so no
+        // host path can leak. Non-sandbox: full detail (host paths are fine locally).
+        if (config.sandboxed) return buildSandboxErrorResponse(error, directory);
         return buildMcpToolErrorResponse(convertErrorToJson(error));
       }
     },

--- a/src/mcp/tools/packCodebaseTool.ts
+++ b/src/mcp/tools/packCodebaseTool.ts
@@ -172,8 +172,14 @@ export const registerPackCodebaseTool = (
           //    output.instructionFilePath to read an out-of-workspace file into the
           //    agent-visible output, or input.processors to run commands;
           //  - confine the file search to the root, a syntax-agnostic backstop behind
-          //    the include/ignore pattern guard.
-          ...(config.sandboxed ? { skipLocalConfig: true, skipGlobalConfig: true, confineToBaseDir: true } : {}),
+          //    the include/ignore pattern guard;
+          //  - disable git-based sort: sortByChanges (on by default) runs
+          //    `git -C <workspace> log`, which reads the untrusted workspace's
+          //    .git/config (e.g. gpg.program via log.showSignature) — a host
+          //    command-execution vector.
+          ...(config.sandboxed
+            ? { skipLocalConfig: true, skipGlobalConfig: true, confineToBaseDir: true, gitSortByChanges: false }
+            : {}),
         } as CliOptions;
 
         // cliOptions.quiet makes runCli set the SHARED logger to SILENT and never

--- a/src/mcp/tools/readRepomixOutputTool.ts
+++ b/src/mcp/tools/readRepomixOutputTool.ts
@@ -4,9 +4,11 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { createSecretLintConfig, runSecretLint } from '../../core/security/workers/securityCheckWorker.js';
 import { logger } from '../../shared/logger.js';
+import type { McpServerConfig } from '../mcpServer.js';
 import {
   buildMcpToolErrorResponse,
   buildMcpToolSuccessResponse,
+  buildSandboxErrorResponse,
   convertErrorToJson,
   getOutputFilePath,
   requiresSecretScan,
@@ -35,7 +37,10 @@ const readRepomixOutputOutputSchema = z.object({
 /**
  * Register the tool to read Repomix output files
  */
-export const registerReadRepomixOutputTool = (mcpServer: McpServer) => {
+export const registerReadRepomixOutputTool = (
+  mcpServer: McpServer,
+  config: McpServerConfig = { sandboxed: false, root: process.cwd() },
+) => {
   mcpServer.registerTool(
     'read_repomix_output',
     {
@@ -68,7 +73,9 @@ export const registerReadRepomixOutputTool = (mcpServer: McpServer) => {
           await fs.access(filePath);
         } catch {
           return buildMcpToolErrorResponse({
-            errorMessage: `Error: Output file does not exist at path: ${filePath}. The temporary file may have been cleaned up.`,
+            errorMessage: config.sandboxed
+              ? `Error: Output ${outputId} is no longer available.`
+              : `Error: Output file does not exist at path: ${filePath}. The temporary file may have been cleaned up.`,
           });
         }
 
@@ -82,7 +89,9 @@ export const registerReadRepomixOutputTool = (mcpServer: McpServer) => {
           const securityCheckResult = await runSecretLint(filePath, content, 'file', createSecretLintConfig());
           if (securityCheckResult !== null) {
             return buildMcpToolErrorResponse({
-              errorMessage: `Error: Security check failed. The file at ${filePath} may contain sensitive information.`,
+              errorMessage: config.sandboxed
+                ? `Error: Security check failed. Output ${outputId} may contain sensitive information.`
+                : `Error: Security check failed. The file at ${filePath} may contain sensitive information.`,
             });
           }
         }
@@ -140,6 +149,7 @@ export const registerReadRepomixOutputTool = (mcpServer: McpServer) => {
         } satisfies z.infer<typeof readRepomixOutputOutputSchema>);
       } catch (error) {
         logger.error(`Error reading Repomix output: ${error}`);
+        if (config.sandboxed) return buildSandboxErrorResponse(error, outputId);
         return buildMcpToolErrorResponse(convertErrorToJson(error));
       }
     },

--- a/tests/cli/cliRun.test.ts
+++ b/tests/cli/cliRun.test.ts
@@ -1,11 +1,13 @@
+import type { Stats } from 'node:fs';
 import * as fs from 'node:fs/promises';
+import path from 'node:path';
 import { program } from 'commander';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as defaultAction from '../../src/cli/actions/defaultAction.js';
 import * as initAction from '../../src/cli/actions/initAction.js';
 import * as remoteAction from '../../src/cli/actions/remoteAction.js';
 import * as versionAction from '../../src/cli/actions/versionAction.js';
-import { run, runCli } from '../../src/cli/cliRun.js';
+import { canonicalizeSandboxRoot, run, runCli } from '../../src/cli/cliRun.js';
 import type { CliOptions } from '../../src/cli/types.js';
 import * as gitRemoteHandle from '../../src/core/git/gitRemoteHandle.js';
 import type { PackResult } from '../../src/core/packager.js';
@@ -566,5 +568,58 @@ describe('cliRun', () => {
         }),
       );
     });
+  });
+});
+
+describe('canonicalizeSandboxRoot', () => {
+  const dirStat = { isDirectory: () => true } as Stats;
+  const fileStat = { isDirectory: () => false } as Stats;
+  const eperm = () => {
+    const e = new Error("EPERM: operation not permitted, realpath 'C:\\Users\\RUNNER~1\\Temp\\ws'");
+    return Object.assign(e, { code: 'EPERM' });
+  };
+
+  test('returns the realpath-resolved root when realpath succeeds (symlink canonicalization)', async () => {
+    const root = await canonicalizeSandboxRoot('/tmp/ws', {
+      realpath: async () => '/private/tmp/ws',
+      stat: async () => dirStat,
+    });
+    expect(root).toBe('/private/tmp/ws');
+  });
+
+  test('falls back to the lexical root when realpath fails but the directory exists (Windows EPERM quirk)', async () => {
+    const requested = path.resolve('/tmp/ws');
+    const root = await canonicalizeSandboxRoot(requested, {
+      realpath: async () => {
+        throw eperm();
+      },
+      stat: async () => dirStat,
+    });
+    // no refusal to start — the lexical (already absolute) root is used
+    expect(root).toBe(path.resolve(requested));
+  });
+
+  test('fails closed when realpath fails and the directory is missing/inaccessible', async () => {
+    await expect(
+      canonicalizeSandboxRoot('/tmp/gone', {
+        realpath: async () => {
+          throw eperm();
+        },
+        stat: async () => {
+          throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        },
+      }),
+    ).rejects.toThrow('--sandbox workspace directory could not be resolved');
+  });
+
+  test('fails closed when realpath fails and the path is not a directory', async () => {
+    await expect(
+      canonicalizeSandboxRoot('/tmp/file', {
+        realpath: async () => {
+          throw eperm();
+        },
+        stat: async () => fileStat,
+      }),
+    ).rejects.toThrow('--sandbox workspace directory could not be resolved');
   });
 });

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -163,6 +163,31 @@ describe('fileSearch', () => {
       expect(result.emptyDirPaths).toEqual([]);
       expect(globby).toHaveBeenCalledTimes(1);
     });
+
+    test('confineToBaseDir drops matches that resolve outside rootDir', async () => {
+      // A glob pattern (absolute, brace-expanded, extglob, …) can make fast-glob
+      // return paths outside rootDir regardless of cwd. With confineToBaseDir=true
+      // (set by the MCP sandbox) searchFiles must drop them so no pattern trick can
+      // surface a file outside the searched directory — the syntax-agnostic backstop
+      // behind the sandbox's pattern guard.
+      const mockConfig = createMockConfig({ output: { includeEmptyDirectories: false } });
+      vi.mocked(globby).mockResolvedValue(['src/a.ts', '/etc/passwd', '../sibling/secret.txt'] as never);
+
+      const result = await searchFiles('/mock/root', mockConfig, undefined, true);
+
+      expect(result.filePaths).toEqual(['src/a.ts']);
+    });
+
+    test('without confineToBaseDir, out-of-root matches are preserved (default CLI/library behavior)', async () => {
+      // confineToBaseDir defaults to false so the documented ../ / absolute
+      // include-pattern behavior is unchanged for normal CLI and library callers.
+      const mockConfig = createMockConfig({ output: { includeEmptyDirectories: false } });
+      vi.mocked(globby).mockResolvedValue(['src/a.ts', '../sibling/secret.txt'] as never);
+
+      const result = await searchFiles('/mock/root', mockConfig);
+
+      expect(result.filePaths).toEqual(['../sibling/secret.txt', 'src/a.ts']);
+    });
   });
 
   describe('getIgnorePatterns', () => {

--- a/tests/core/packager.test.ts
+++ b/tests/core/packager.test.ts
@@ -81,7 +81,7 @@ describe('packager', () => {
     const progressCallback = vi.fn();
     const result = await pack(['root'], mockConfig, progressCallback, mockDeps);
 
-    expect(mockDeps.searchFiles).toHaveBeenCalledWith('root', mockConfig, undefined);
+    expect(mockDeps.searchFiles).toHaveBeenCalledWith('root', mockConfig, undefined, undefined);
     expect(mockDeps.collectFiles).toHaveBeenCalledWith(mockFilePaths, 'root', mockConfig, progressCallback);
     expect(mockDeps.validateFileSafety).toHaveBeenCalled();
     expect(mockDeps.processFiles).toHaveBeenCalled();

--- a/tests/mcp/mcpServer.test.ts
+++ b/tests/mcp/mcpServer.test.ts
@@ -179,6 +179,50 @@ describe('MCP Server', () => {
       );
       expect(server).toBeDefined();
     });
+
+    test('registers all 8 tools by default (non-sandboxed)', async () => {
+      const server = await createMcpServer();
+      const registerTool = (server as unknown as { registerTool: ReturnType<typeof vi.fn> }).registerTool;
+      const names = registerTool.mock.calls.map((c) => c[0]);
+      expect(names).toEqual(
+        expect.arrayContaining([
+          'pack_codebase',
+          'pack_remote_repository',
+          'generate_skill',
+          'attach_packed_output',
+          'read_repomix_output',
+          'grep_repomix_output',
+          'file_system_read_file',
+          'file_system_read_directory',
+        ]),
+      );
+      expect(names).toHaveLength(8);
+    });
+
+    test('registers only the 5 read-only tools when sandboxed', async () => {
+      const server = await createMcpServer({ sandboxed: true, root: '/allowed/dir' });
+      const registerTool = (server as unknown as { registerTool: ReturnType<typeof vi.fn> }).registerTool;
+      const names = registerTool.mock.calls.map((c) => c[0]);
+      expect(names.sort()).toEqual(
+        [
+          'file_system_read_directory',
+          'file_system_read_file',
+          'grep_repomix_output',
+          'pack_codebase',
+          'read_repomix_output',
+        ].sort(),
+      );
+      expect(names).not.toContain('pack_remote_repository');
+      expect(names).not.toContain('generate_skill');
+      expect(names).not.toContain('attach_packed_output');
+    });
+
+    test('sandboxed instructions tell the agent paths are relative to the workspace root', async () => {
+      await createMcpServer({ sandboxed: true, root: '/allowed/dir' });
+      expect(McpServer).toHaveBeenCalledWith(expect.any(Object), {
+        instructions: expect.stringContaining('relative to workspace root'),
+      });
+    });
   });
 
   describe('runMcpServer', () => {

--- a/tests/mcp/pathScope.test.ts
+++ b/tests/mcp/pathScope.test.ts
@@ -1,0 +1,156 @@
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+import { PathScopeError, resolveWithinRoot, toVirtualPath } from '../../src/mcp/pathScope.js';
+
+// Resolve to a platform-native absolute root (D:\allowed\dir on Windows,
+// /allowed/dir on POSIX) so assertions match resolveWithinRoot's path.resolve.
+const ROOT = path.resolve('/allowed/dir');
+const idRealpath = async (p: string) => p as unknown as string;
+
+describe('resolveWithinRoot', () => {
+  test('"." selects the root', async () => {
+    await expect(resolveWithinRoot(ROOT, '.', { realpath: idRealpath })).resolves.toBe(ROOT);
+  });
+
+  test('"" also selects the root', async () => {
+    await expect(resolveWithinRoot(ROOT, '', { realpath: idRealpath })).resolves.toBe(ROOT);
+  });
+
+  test('accepts a plain relative subpath', async () => {
+    await expect(resolveWithinRoot(ROOT, 'src/index.ts', { realpath: idRealpath })).resolves.toBe(
+      path.join(ROOT, 'src/index.ts'),
+    );
+  });
+
+  test('accepts a deep plain relative path', async () => {
+    await expect(resolveWithinRoot(ROOT, 'hehe/haha/file.txt', { realpath: idRealpath })).resolves.toBe(
+      path.join(ROOT, 'hehe/haha/file.txt'),
+    );
+  });
+
+  test('rejects a leading slash', async () => {
+    await expect(resolveWithinRoot(ROOT, '/etc/passwd', { realpath: idRealpath })).rejects.toBeInstanceOf(
+      PathScopeError,
+    );
+  });
+
+  test('rejects a "~" home prefix', async () => {
+    await expect(resolveWithinRoot(ROOT, '~/secrets', { realpath: idRealpath })).rejects.toBeInstanceOf(PathScopeError);
+  });
+
+  test('accepts a redundant "./" prefix (still relative)', async () => {
+    await expect(resolveWithinRoot(ROOT, './src/x.ts', { realpath: idRealpath })).resolves.toBe(
+      path.join(ROOT, 'src/x.ts'),
+    );
+  });
+
+  test('rejects ".." traversal', async () => {
+    await expect(resolveWithinRoot(ROOT, '../../etc/passwd', { realpath: idRealpath })).rejects.toBeInstanceOf(
+      PathScopeError,
+    );
+  });
+
+  test('rejects an embedded ".." segment', async () => {
+    await expect(resolveWithinRoot(ROOT, 'src/../../etc', { realpath: idRealpath })).rejects.toBeInstanceOf(
+      PathScopeError,
+    );
+  });
+
+  test('rejects a ".." segment even mid-path that would still resolve inside', async () => {
+    // Conservative: any ".." is refused, not just net-escapes (a/b/../c stays in
+    // root but is still rejected — no need to reason about resolution).
+    await expect(resolveWithinRoot(ROOT, 'a/b/../c', { realpath: idRealpath })).rejects.toBeInstanceOf(PathScopeError);
+  });
+
+  test('rejects backslash traversal on every platform (split covers both separators)', async () => {
+    await expect(resolveWithinRoot(ROOT, '..\\..\\secret', { realpath: idRealpath })).rejects.toBeInstanceOf(
+      PathScopeError,
+    );
+    await expect(resolveWithinRoot(ROOT, 'src\\..\\..\\secret', { realpath: idRealpath })).rejects.toBeInstanceOf(
+      PathScopeError,
+    );
+  });
+
+  test('rejects a bare ".."', async () => {
+    await expect(resolveWithinRoot(ROOT, '..', { realpath: idRealpath })).rejects.toBeInstanceOf(PathScopeError);
+  });
+
+  test('UNC path: rejected on Windows, a literal in-root name on POSIX (backslash is not a separator there)', async () => {
+    const unc = '\\\\server\\share';
+    if (process.platform === 'win32') {
+      await expect(resolveWithinRoot(ROOT, unc, { realpath: idRealpath })).rejects.toBeInstanceOf(PathScopeError);
+    } else {
+      await expect(resolveWithinRoot(ROOT, unc, { realpath: idRealpath })).resolves.toBe(path.join(ROOT, unc));
+    }
+  });
+
+  test('rejects a Windows drive-relative path ("C:foo") on every platform (path.isAbsolute misses it)', async () => {
+    // Drive-relative (drive letter + colon, no separator) resolves against that drive's
+    // own cwd on Windows — an escape path.isAbsolute does not catch. Rooted "C:\\x"/"C:/x"
+    // stay allowed on POSIX (covered elsewhere); only the drive-RELATIVE form is refused.
+    for (const p of ['C:foo', 'C:', 'C:..\\x']) {
+      await expect(resolveWithinRoot(ROOT, p, { realpath: idRealpath })).rejects.toBeInstanceOf(PathScopeError);
+    }
+  });
+
+  test('does NOT over-reject legitimate dotted filenames (only an exact ".." segment is traversal)', async () => {
+    for (const ok of ['..foo', 'foo..bar', '...', '.hidden', 'a/...b/c', 'weird..', '~notes', '~$Report.docx']) {
+      await expect(resolveWithinRoot(ROOT, ok, { realpath: idRealpath })).resolves.toBe(path.join(ROOT, ok));
+    }
+  });
+
+  test('rejects a symlink that resolves to a SIBLING sharing the root as a string prefix', async () => {
+    // "<root>evil" shares the prefix but is not inside "<root>/" — the boundary
+    // check (root + separator) must not be fooled by the bare string prefix.
+    const siblingRealpath = async (p: string) => (p === ROOT ? ROOT : (`${ROOT}evil` as unknown as string));
+    await expect(resolveWithinRoot(ROOT, 'link', { realpath: siblingRealpath })).rejects.toBeInstanceOf(PathScopeError);
+  });
+
+  test('accepts a symlink that resolves to a real child inside root', async () => {
+    const child = path.join(ROOT, 'sub', 'real.ts');
+    const childRealpath = async (p: string) => (p === ROOT ? ROOT : (child as unknown as string));
+    await expect(resolveWithinRoot(ROOT, 'link', { realpath: childRealpath })).resolves.toBe(child);
+  });
+
+  test('tolerates realpath failing on the root itself (falls back to the lexical root)', async () => {
+    // If realpath can't resolve the root, fall back to the lexical root — the
+    // candidate still resolves and the lexical guard already confined it.
+    const candidate = path.join(ROOT, 'src', 'x.ts');
+    const rootFailsRealpath = async (p: string) => {
+      if (p === ROOT) throw new Error('EACCES');
+      return candidate as unknown as string;
+    };
+    await expect(resolveWithinRoot(ROOT, 'src/x.ts', { realpath: rootFailsRealpath })).resolves.toBe(candidate);
+  });
+
+  test('rejects a symlink that escapes root (realpath resolves outside)', async () => {
+    const escapingRealpath = async (p: string) => (p === ROOT ? ROOT : ('/etc/secret' as unknown as string));
+    await expect(resolveWithinRoot(ROOT, 'link', { realpath: escapingRealpath })).rejects.toBeInstanceOf(
+      PathScopeError,
+    );
+  });
+
+  test('returns the lexical candidate when the target does not exist yet', async () => {
+    const missingRealpath = async (p: string) => {
+      if (p === ROOT) return ROOT;
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    };
+    await expect(resolveWithinRoot(ROOT, 'new-file.ts', { realpath: missingRealpath })).resolves.toBe(
+      path.join(ROOT, 'new-file.ts'),
+    );
+  });
+});
+
+describe('toVirtualPath', () => {
+  test('root maps to "."', () => {
+    expect(toVirtualPath(ROOT, ROOT)).toBe('.');
+  });
+  test('subpath maps to a plain relative path', () => {
+    expect(toVirtualPath(ROOT, path.join(ROOT, 'src/index.ts'))).toBe('src/index.ts');
+  });
+
+  test('always emits forward slashes, even for a deep path on Windows separators', () => {
+    const abs = path.join(ROOT, 'a', 'b', 'c', 'd.ts');
+    expect(toVirtualPath(ROOT, abs)).toBe('a/b/c/d.ts');
+  });
+});

--- a/tests/mcp/tools/fileSystemReadDirectoryTool.sandbox.test.ts
+++ b/tests/mcp/tools/fileSystemReadDirectoryTool.sandbox.test.ts
@@ -1,0 +1,39 @@
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { registerFileSystemReadDirectoryTool } from '../../../src/mcp/tools/fileSystemReadDirectoryTool.js';
+
+// No module mocks: the sandboxed branch relies on real fs + realpath.
+describe('FileSystemReadDirectoryTool (sandboxed)', () => {
+  let root = '';
+  let handler: (args: { path: string }) => Promise<CallToolResult>;
+
+  beforeEach(async () => {
+    root = await fsp.realpath(await fsp.mkdtemp(path.join(os.tmpdir(), 'iso-dir-')));
+    await fsp.mkdir(path.join(root, 'src'));
+    await fsp.writeFile(path.join(root, 'README.md'), '# hi\n');
+    const server = { registerTool: vi.fn().mockReturnThis() } as unknown as McpServer;
+    registerFileSystemReadDirectoryTool(server, { sandboxed: true, root });
+    handler = (server.registerTool as ReturnType<typeof vi.fn>).mock.calls[0][2];
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  test('lists the root as "." and returns entry names', async () => {
+    const result = await handler({ path: '.' });
+    expect(result.structuredContent?.path).toBe('.');
+    expect(result.structuredContent?.contents).toEqual(expect.arrayContaining(['[DIR] src', '[FILE] README.md']));
+    expect(JSON.stringify(result)).not.toContain(root);
+  });
+
+  test('rejects a prefixed path', async () => {
+    const result = await handler({ path: '/etc' });
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('relative to workspace root');
+  });
+});

--- a/tests/mcp/tools/fileSystemReadDirectoryTool.test.ts
+++ b/tests/mcp/tools/fileSystemReadDirectoryTool.test.ts
@@ -52,7 +52,11 @@ describe('FileSystemReadDirectoryTool', () => {
   test('should handle non-existent directory', async () => {
     const testPath = '/non/existent/dir';
     vi.mocked(path.isAbsolute).mockReturnValue(true);
-    vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+    // Realistic ENOENT (with .code) — a missing dir maps to "not found"; other stat
+    // errors (e.g. EACCES) now bubble to the outer catch instead of being masked.
+    vi.mocked(fs.stat).mockRejectedValue(
+      Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' }),
+    );
 
     const result = await toolHandler({ path: testPath });
 

--- a/tests/mcp/tools/fileSystemReadFileTool.sandbox.test.ts
+++ b/tests/mcp/tools/fileSystemReadFileTool.sandbox.test.ts
@@ -1,0 +1,46 @@
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { registerFileSystemReadFileTool } from '../../../src/mcp/tools/fileSystemReadFileTool.js';
+
+// No module mocks here: the sandboxed branch relies on real fs + realpath so
+// resolveWithinRoot's containment checks exercise the actual filesystem.
+describe('FileSystemReadFileTool (sandboxed)', () => {
+  let root = '';
+  let handler: (args: { path: string }) => Promise<CallToolResult>;
+
+  beforeEach(async () => {
+    root = await fsp.realpath(await fsp.mkdtemp(path.join(os.tmpdir(), 'iso-read-')));
+    await fsp.writeFile(path.join(root, 'a.ts'), 'const x = 1;\n');
+    const server = { registerTool: vi.fn().mockReturnThis() } as unknown as McpServer;
+    registerFileSystemReadFileTool(server, { sandboxed: true, root });
+    handler = (server.registerTool as ReturnType<typeof vi.fn>).mock.calls[0][2];
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  test('reads a plain-relative file and echoes a plain-relative path', async () => {
+    const result = await handler({ path: 'a.ts' });
+    expect(result.structuredContent?.path).toBe('a.ts');
+    expect(result.structuredContent?.content).toBe('const x = 1;\n');
+    expect(JSON.stringify(result)).not.toContain(root);
+  });
+
+  test('rejects a prefixed/escaping path', async () => {
+    const result = await handler({ path: '../../etc/passwd' });
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('relative to workspace root');
+    expect((result.content[0] as { text: string }).text).not.toContain(root);
+  });
+
+  test('rejects a leading-slash path', async () => {
+    const result = await handler({ path: '/etc/passwd' });
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('relative to workspace root');
+  });
+});

--- a/tests/mcp/tools/fileSystemReadFileTool.test.ts
+++ b/tests/mcp/tools/fileSystemReadFileTool.test.ts
@@ -111,13 +111,10 @@ describe('FileSystemReadFileTool', () => {
     const fileContent = 'Line 1\nLine 2\nLine 3';
     vi.mocked(path.isAbsolute).mockReturnValue(true);
     vi.mocked(fs.access).mockResolvedValueOnce(undefined);
-    vi.mocked(fs.stat)
-      .mockResolvedValueOnce({
-        isDirectory: () => false,
-      } as unknown as Awaited<ReturnType<typeof fs.stat>>)
-      .mockResolvedValueOnce({
-        size: 21,
-      } as unknown as Awaited<ReturnType<typeof fs.stat>>);
+    vi.mocked(fs.stat).mockResolvedValueOnce({
+      isDirectory: () => false,
+      size: 21,
+    } as unknown as Awaited<ReturnType<typeof fs.stat>>);
     vi.mocked(fs.readFile).mockResolvedValueOnce(fileContent);
     vi.mocked(runSecretLint).mockResolvedValueOnce(null);
 
@@ -146,13 +143,10 @@ describe('FileSystemReadFileTool', () => {
     const fileContent = 'API_KEY=secret123';
     vi.mocked(path.isAbsolute).mockReturnValue(true);
     vi.mocked(fs.access).mockResolvedValueOnce(undefined);
-    vi.mocked(fs.stat)
-      .mockResolvedValueOnce({
-        isDirectory: () => false,
-      } as unknown as Awaited<ReturnType<typeof fs.stat>>)
-      .mockResolvedValueOnce({
-        size: 17,
-      } as unknown as Awaited<ReturnType<typeof fs.stat>>);
+    vi.mocked(fs.stat).mockResolvedValueOnce({
+      isDirectory: () => false,
+      size: 17,
+    } as unknown as Awaited<ReturnType<typeof fs.stat>>);
     vi.mocked(fs.readFile).mockResolvedValueOnce(fileContent);
     vi.mocked(runSecretLint).mockResolvedValueOnce({
       filePath: testPath,

--- a/tests/mcp/tools/formatPackToolResponse.sandbox.test.ts
+++ b/tests/mcp/tools/formatPackToolResponse.sandbox.test.ts
@@ -1,0 +1,68 @@
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { formatPackToolResponse, type McpToolMetrics } from '../../../src/mcp/tools/mcpToolRuntime.js';
+
+// Real modules (no path/fs mocks): exercises the sandbox virtualization branch of
+// formatPackToolResponse end to end — the host output path and the absolute
+// directory must never appear in the response when sandboxed.
+
+const metrics = (): McpToolMetrics => ({
+  totalFiles: 1,
+  totalCharacters: 10,
+  totalTokens: 3,
+  fileCharCounts: { 'src/a.ts': 10 },
+  fileTokenCounts: { 'src/a.ts': 3 },
+  processedFiles: [],
+  safeFilePaths: ['src/a.ts'],
+});
+
+const structured = (r: { structuredContent?: unknown }): Record<string, unknown> =>
+  r.structuredContent as Record<string, unknown>;
+const descOf = (r: { structuredContent?: unknown }): string => String(structured(r).description ?? '');
+
+describe('formatPackToolResponse virtualization', () => {
+  let root = '';
+  let outputFilePath = '';
+
+  beforeEach(async () => {
+    root = await fsp.realpath(await fsp.mkdtemp(path.join(os.tmpdir(), 'fmt-scope-')));
+    outputFilePath = path.join(root, 'repomix-output.xml');
+    await fsp.writeFile(outputFilePath, 'line1\nline2\n');
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  test('sandboxed: blanks the host output path and virtualizes the directory', async () => {
+    const directory = path.join(root, 'src');
+    const result = await formatPackToolResponse({ directory }, metrics(), outputFilePath, 10, false, {
+      sandboxed: true,
+      root,
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(root); // no host path anywhere
+    expect(structured(result).outputFilePath).toBe('');
+
+    const parsed = JSON.parse(structured(result).result as string);
+    expect(parsed.directory).toBe('src'); // virtualized, not the absolute path
+    expect(parsed.outputFilePath).toBe('');
+
+    // the only line that echoes the host output path is dropped in sandbox mode
+    expect(descOf(result)).not.toContain('read the file directly using path');
+  });
+
+  test('non-sandboxed: keeps the real output path and the direct-access hint', async () => {
+    const directory = path.join(root, 'src');
+    const result = await formatPackToolResponse({ directory }, metrics(), outputFilePath, 10, false);
+
+    expect(structured(result).outputFilePath).toBe(outputFilePath);
+    const parsed = JSON.parse(structured(result).result as string);
+    expect(parsed.directory).toBe(directory); // absolute path preserved
+    expect(parsed.outputFilePath).toBe(outputFilePath);
+    expect(descOf(result)).toContain('read the file directly using path');
+  });
+});

--- a/tests/mcp/tools/mcpToolRuntime.test.ts
+++ b/tests/mcp/tools/mcpToolRuntime.test.ts
@@ -231,6 +231,59 @@ describe('mcpToolRuntime', () => {
       expect(result.metrics.topFiles[2].path).toBe('file3.js');
       expect(result.metrics.totalLines).toBe(5);
     });
+
+    it('sandboxed scope omits host paths from the pack response', async () => {
+      // real fs read of the output file is needed by formatPackToolResponse;
+      // create a tmp output file with known content.
+      const os = await import('node:os');
+      const fsp = await import('node:fs/promises');
+      const path = await import('node:path');
+
+      // node:os/node:path/node:fs/promises are automocked for this whole test file
+      // (see the vi.mock calls above). This test needs genuine temp files and real
+      // path math to verify that host paths are actually scrubbed from the response,
+      // so delegate the mocked functions to their real implementations here.
+      const realOs = await vi.importActual<typeof import('node:os')>('node:os');
+      const realFsp = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+      const realPath = await vi.importActual<typeof import('node:path')>('node:path');
+      vi.mocked(os.tmpdir).mockImplementation(realOs.tmpdir);
+      vi.mocked(path.join).mockImplementation(realPath.join);
+      vi.mocked(path.resolve).mockImplementation(realPath.resolve);
+      vi.mocked(path.relative).mockImplementation(realPath.relative);
+      vi.mocked(fsp.mkdtemp).mockImplementation(realFsp.mkdtemp);
+      vi.mocked(fsp.writeFile).mockImplementation(realFsp.writeFile);
+      vi.mocked(fsp.readFile).mockImplementation(realFsp.readFile);
+      vi.mocked(fsp.rm).mockImplementation(realFsp.rm); // else the cleanup rm hits the stub and leaks temp dirs
+
+      const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'iso-root-'));
+      const outDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'iso-out-'));
+      const outputFilePath = path.join(outDir, 'repomix-output.xml');
+      await fsp.writeFile(outputFilePath, '<files>\n<file path="src/a.ts">x</file>\n</files>\n');
+
+      const metrics = {
+        totalFiles: 1,
+        totalCharacters: 1,
+        totalTokens: 1,
+        fileCharCounts: { 'src/a.ts': 1 },
+        fileTokenCounts: { 'src/a.ts': 1 },
+        processedFiles: [],
+        safeFilePaths: ['src/a.ts'],
+      };
+
+      const result = await formatPackToolResponse({ directory: root }, metrics, outputFilePath, 5, false, {
+        sandboxed: true,
+        root,
+      });
+
+      const text = JSON.stringify(result);
+      expect(text).not.toContain(root); // no host workspace path
+      expect(text).not.toContain(outDir); // no host output path
+      expect(result.structuredContent?.outputFilePath).toBe('');
+      expect(result.structuredContent?.description).not.toContain('read the file directly using path');
+
+      await fsp.rm(root, { recursive: true, force: true });
+      await fsp.rm(outDir, { recursive: true, force: true });
+    });
   });
 
   describe('buildMcpToolSuccessResponse', () => {

--- a/tests/mcp/tools/outputToolsSandbox.test.ts
+++ b/tests/mcp/tools/outputToolsSandbox.test.ts
@@ -1,0 +1,45 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { describe, expect, test, vi } from 'vitest';
+import { registerGrepRepomixOutputTool } from '../../../src/mcp/tools/grepRepomixOutputTool.js';
+import { registerOutputFile } from '../../../src/mcp/tools/mcpToolRuntime.js';
+import { registerReadRepomixOutputTool } from '../../../src/mcp/tools/readRepomixOutputTool.js';
+
+// No fs mock: the outputId resolves (via the real registry) to a host temp path
+// that does not exist, so the real fs.access fails and we assert the sandboxed
+// error message carries the opaque outputId but never the host path.
+const HOST_PATH = '/tmp/repomix/mcp-outputs/xxxxxx/repomix-output.xml';
+
+const captureHandler = (
+  register: (s: McpServer, c: { sandboxed: boolean; root: string }) => void,
+): ((args: Record<string, unknown>) => Promise<CallToolResult>) => {
+  const server = { registerTool: vi.fn().mockReturnThis() } as unknown as McpServer;
+  register(server, { sandboxed: true, root: '/allowed/dir' });
+  return (server.registerTool as ReturnType<typeof vi.fn>).mock.calls[0][2];
+};
+
+describe('read/grep output tools (sandboxed) omit host temp paths from errors', () => {
+  test('read_repomix_output: missing-file error omits the host path', async () => {
+    const handler = captureHandler(registerReadRepomixOutputTool);
+    registerOutputFile('deadbeef01', HOST_PATH);
+
+    const result = await handler({ outputId: 'deadbeef01' });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).not.toContain('/tmp/repomix');
+    expect(text).toContain('deadbeef01');
+  });
+
+  test('grep_repomix_output: missing-file error omits the host path', async () => {
+    const handler = captureHandler(registerGrepRepomixOutputTool);
+    registerOutputFile('deadbeef02', HOST_PATH);
+
+    const result = await handler({ outputId: 'deadbeef02', pattern: 'x' });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).not.toContain('/tmp/repomix');
+    expect(text).toContain('deadbeef02');
+  });
+});

--- a/tests/mcp/tools/packCodebaseTool.test.ts
+++ b/tests/mcp/tools/packCodebaseTool.test.ts
@@ -202,4 +202,15 @@ describe('PackCodebaseTool', () => {
     const parsedResult = JSON.parse((content as { type: 'text'; text: string }).text);
     expect(parsedResult.errorMessage).toBe('Workspace creation failed');
   });
+
+  test('rejects a directory outside the allowed root when sandboxed', async () => {
+    const server = { registerTool: vi.fn().mockReturnThis() } as unknown as McpServer;
+    registerPackCodebaseTool(server, { sandboxed: true, root: '/allowed/dir' });
+    const handler = (server.registerTool as ReturnType<typeof vi.fn>).mock.calls[0][2];
+
+    const result = await handler({ directory: '../../etc', compress: false, topFilesLength: 10, style: 'xml' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('relative to workspace root');
+  });
 });

--- a/tests/mcp/tools/sandbox.contract.test.ts
+++ b/tests/mcp/tools/sandbox.contract.test.ts
@@ -1,0 +1,284 @@
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { registerFileSystemReadDirectoryTool } from '../../../src/mcp/tools/fileSystemReadDirectoryTool.js';
+import { registerFileSystemReadFileTool } from '../../../src/mcp/tools/fileSystemReadFileTool.js';
+import { registerGrepRepomixOutputTool } from '../../../src/mcp/tools/grepRepomixOutputTool.js';
+import { registerOutputFile } from '../../../src/mcp/tools/mcpToolRuntime.js';
+import { registerPackCodebaseTool } from '../../../src/mcp/tools/packCodebaseTool.js';
+import { registerReadRepomixOutputTool } from '../../../src/mcp/tools/readRepomixOutputTool.js';
+import { logger, repomixLogLevels } from '../../../src/shared/logger.js';
+
+// BLACKBOX CONTRACT for --sandbox. Drives the five tool handlers on a REAL temp
+// workspace (no path/fs mocks) and asserts only observable request→response
+// behavior. `runCli` is mocked ONLY to (a) prove the pattern/path guard rejects
+// BEFORE the pack runs and (b) inject a failure for the error-leak assertions —
+// the real pack pipeline needs the built lib and is exercised in the e2e suite.
+//
+// This suite must remain valid before AND after the internal boundary refactor.
+// If an assertion here breaks without an observable behavior change, THIS test was
+// coupled to implementation — fix the test, not the contract.
+vi.mock('../../../src/cli/cliRun.js', () => ({ runCli: vi.fn() }));
+
+import { runCli } from '../../../src/cli/cliRun.js';
+
+// ── escape variants the guard MUST reject (host-aware) ────────────────────────
+// Cross-platform: absolute-by-POSIX-and-Windows, "~" home refs, and any ".."
+// segment on either separator.
+const ESCAPING = [
+  '/etc/passwd', // leading slash (absolute on every OS)
+  '/', // bare root
+  '..', // exact parent
+  '../x',
+  '../../etc/passwd',
+  'a/../../b', // ".." segment in the middle
+  'src/../../etc/passwd',
+  'a/b/../../../c',
+  '..\\x', // backslash ".." (Windows-style separator)
+  'a\\..\\b',
+  '~', // home ref
+  '~/',
+  '~/.ssh/id_rsa',
+];
+// Absolute only on Windows (drive / UNC / rooted-backslash). On POSIX these are
+// harmless relative filenames, so only assert rejection on win32.
+const WINDOWS_ONLY_ESCAPING = ['C:\\Windows\\System32', 'C:/Windows', '\\\\server\\share\\x', '\\x'];
+
+// Look-alike names that are VALID filenames and must NOT be over-rejected: a leading
+// "~" that is not a home ref, and dots that are not a ".." segment.
+// (trailing-dot names like "foo.." / "..." are omitted: Windows strips trailing dots, so
+// they can't be written to disk on a Windows runner — the escaping logic is orthogonal to them)
+const ALLOWED_TRICKY = ['~weird.txt', '~$lock.docx', '..foo', 'a..b'];
+
+// Pattern-specific smuggles the include/ignore guard MUST reject (brace expansion,
+// comma lists, negation prefix — on top of the plain forms).
+const ESCAPING_PATTERNS = [
+  '/etc/passwd',
+  '../x',
+  '..',
+  '~/x',
+  '~',
+  '{/etc/passwd,readme.md}', // brace hides an absolute alternative
+  '{../secret,x}', // brace hides a ".."
+  'src/**,/etc/passwd', // comma list, one absolute
+  'src/**,../../*.env', // comma list, one ".."
+  '!/etc/passwd', // negation prefix over an absolute
+  '..\\secrets\\**',
+];
+const ALLOWED_PATTERNS = ['**/*.{js,ts}', 'src/**,docs/**', '!node_modules/**', 'a..b/**'];
+
+type Handler = (args: Record<string, unknown>) => Promise<CallToolResult>;
+const capture = (register: (s: McpServer, c: { sandboxed: boolean; root: string }) => void, root: string): Handler => {
+  const server = { registerTool: vi.fn().mockReturnThis() } as unknown as McpServer;
+  register(server, { sandboxed: true, root });
+  return (server.registerTool as ReturnType<typeof vi.fn>).mock.calls[0][2];
+};
+const textOf = (r: CallToolResult): string => (r.content?.[0] as { text?: string })?.text ?? '';
+const rejectedAsEscape = (r: CallToolResult): boolean => r.isError === true && /workspace root/i.test(textOf(r));
+
+describe('sandbox contract', () => {
+  let root = '';
+  let readFile: Handler;
+  let readDir: Handler;
+  let pack: Handler;
+
+  beforeEach(async () => {
+    root = await fsp.realpath(await fsp.mkdtemp(path.join(os.tmpdir(), 'sbx-contract-')));
+    await fsp.mkdir(path.join(root, 'src'));
+    await fsp.writeFile(path.join(root, 'src', 'a.ts'), 'const x = 1;\n');
+    readFile = capture(registerFileSystemReadFileTool, root);
+    readDir = capture(registerFileSystemReadDirectoryTool, root);
+    pack = capture(registerPackCodebaseTool, root);
+  });
+  afterEach(async () => {
+    vi.resetAllMocks();
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  // No response — success or error — may echo the host workspace root. (Echoing the
+  // agent's OWN input path, e.g. "/etc/passwd" in a rejection message, is safe: it's
+  // the agent's literal string, not a host path. So we assert on `root`, not on any
+  // absolute-looking token.)
+  const assertNoHostPath = (r: CallToolResult): void => {
+    expect(JSON.stringify(r)).not.toContain(root);
+  };
+
+  describe('confinement: file/dir path input rejects every escape variant', () => {
+    test.each(ESCAPING)('read_file rejects %j', async (p) => {
+      const r = await readFile({ path: p });
+      expect(rejectedAsEscape(r), `read_file should reject ${p}`).toBe(true);
+      assertNoHostPath(r);
+    });
+    test.each(ESCAPING)('read_directory rejects %j', async (p) => {
+      const r = await readDir({ path: p });
+      expect(rejectedAsEscape(r), `read_directory should reject ${p}`).toBe(true);
+      assertNoHostPath(r);
+    });
+    test.each(WINDOWS_ONLY_ESCAPING)('read_file rejects %j on Windows (relative filename on POSIX)', async (p) => {
+      const r = await readFile({ path: p });
+      if (process.platform === 'win32') {
+        expect(rejectedAsEscape(r)).toBe(true);
+      } else {
+        // Not an escape on POSIX: resolves to a (non-existent) in-root filename.
+        expect(rejectedAsEscape(r)).toBe(false);
+      }
+      assertNoHostPath(r);
+    });
+
+    test('a rejection echoes the agent’s OWN input back (not blanked), so it sees what it sent', async () => {
+      // The rejection message must show the exact path the agent supplied — that is
+      // the agent's own string, not a host path, and blanking it (e.g. to "<path>")
+      // would leave the agent unable to tell which argument was refused.
+      const r = await readFile({ path: '/etc/passwd' });
+      expect(rejectedAsEscape(r)).toBe(true);
+      expect(textOf(r)).toContain('/etc/passwd');
+      expect(textOf(r)).not.toContain('<path>');
+    });
+  });
+
+  describe('confinement: valid look-alike filenames are NOT over-rejected', () => {
+    test.each(ALLOWED_TRICKY)('read_file reads %j (tilde/dots that are not escapes)', async (name) => {
+      await fsp.writeFile(path.join(root, name), `body:${name}`);
+      const r = await readFile({ path: name });
+      expect(rejectedAsEscape(r), `${name} must not be rejected as an escape`).toBe(false);
+      expect(r.isError ?? false).toBe(false);
+      expect(r.structuredContent?.content).toBe(`body:${name}`);
+      expect(r.structuredContent?.path).toBe(name); // echoed relative, not absolute
+      assertNoHostPath(r);
+    });
+  });
+
+  describe('confinement: pack directory + include/ignore patterns', () => {
+    test.each(ESCAPING)('pack rejects escaping directory %j (guard runs before runCli)', async (p) => {
+      const r = await pack({ directory: p, compress: false, topFilesLength: 10, style: 'xml' });
+      expect(rejectedAsEscape(r), `pack should reject directory ${p}`).toBe(true);
+      expect(runCli).not.toHaveBeenCalled();
+      assertNoHostPath(r);
+    });
+    test.each(ESCAPING_PATTERNS)('pack rejects includePatterns %j', async (pattern) => {
+      const r = await pack({
+        directory: '.',
+        includePatterns: pattern,
+        compress: false,
+        topFilesLength: 10,
+        style: 'xml',
+      });
+      expect(rejectedAsEscape(r), `includePatterns ${pattern} should be rejected`).toBe(true);
+      expect(runCli).not.toHaveBeenCalled();
+      assertNoHostPath(r);
+    });
+    test.each(ESCAPING_PATTERNS)('pack rejects ignorePatterns %j', async (pattern) => {
+      const r = await pack({
+        directory: '.',
+        ignorePatterns: pattern,
+        compress: false,
+        topFilesLength: 10,
+        style: 'xml',
+      });
+      expect(rejectedAsEscape(r), `ignorePatterns ${pattern} should be rejected`).toBe(true);
+      expect(runCli).not.toHaveBeenCalled();
+      assertNoHostPath(r);
+    });
+    test.each(ALLOWED_PATTERNS)('pack ACCEPTS relative pattern %j (reaches runCli)', async (pattern) => {
+      await pack({ directory: '.', includePatterns: pattern, compress: false, topFilesLength: 10, style: 'xml' });
+      expect(runCli, `${pattern} should pass the guard`).toHaveBeenCalled();
+    });
+    test('pack on a mistyped in-root directory → actionable "directory not found", not "operation failed"', async () => {
+      // "scr" (typo for "src") resolves in-root but does not exist; the pre-check
+      // must give the agent a specific reason (not the generic code-less fallback)
+      // and short-circuit before ever invoking the pack pipeline.
+      const r = await pack({ directory: 'scr', compress: false, topFilesLength: 10, style: 'xml' });
+      expect(r.isError).toBe(true);
+      expect(textOf(r)).toContain('directory not found');
+      expect(textOf(r)).toContain('scr');
+      expect(textOf(r)).not.toContain('operation failed');
+      expect(runCli).not.toHaveBeenCalled();
+      assertNoHostPath(r);
+    });
+    test('a pack restores the log level — it does not permanently silence the operator’s stderr', async () => {
+      // runCli sets the shared logger to SILENT for quiet:true; a pack must not leave
+      // it there, or every later tool's logger.error (the operator's only diagnostic
+      // channel) is suppressed for the rest of the MCP session.
+      logger.setLogLevel(repomixLogLevels.INFO);
+      vi.mocked(runCli).mockImplementationOnce(async () => {
+        logger.setLogLevel(repomixLogLevels.SILENT); // mimic quiet:true inside runCli
+        return undefined as unknown as Awaited<ReturnType<typeof runCli>>;
+      });
+      await pack({ directory: '.', compress: false, topFilesLength: 10, style: 'xml' });
+      expect(logger.getLogLevel()).toBe(repomixLogLevels.INFO);
+    });
+  });
+
+  describe('no-leak: forced failures never surface a host path', () => {
+    test('read_file on an unreadable in-root file leaks nothing', async () => {
+      if (process.platform === 'win32') return; // chmod semantics differ on Windows
+      const p = path.join(root, 'locked.txt');
+      await fsp.writeFile(p, 'secret');
+      await fsp.chmod(p, 0o000);
+      const r = await readFile({ path: 'locked.txt' });
+      // EACCES surfaces the absolute path in the raw error; the tool must not leak it.
+      assertNoHostPath(r);
+      await fsp.chmod(p, 0o600);
+    });
+
+    test('pack failure carrying an OUT-OF-workspace install path leaks nothing', async () => {
+      // The real leak: pack workers / tree-sitter WASM load from the repomix install
+      // dir, which in a real deployment lies OUTSIDE the workspace.
+      const install = '/opt/fake-install/repomix/lib/core/x.js';
+      const err = new Error(`ENOENT: no such file or directory, open '${install}'`);
+      err.stack = `Error\n    at f (${install}:1:1)`;
+      vi.mocked(runCli).mockRejectedValueOnce(err);
+      const r = await pack({ directory: '.', compress: false, topFilesLength: 10, style: 'xml' });
+      expect(r.isError).toBe(true);
+      assertNoHostPath(r);
+      expect(JSON.stringify(r)).not.toContain('/opt/fake-install');
+    });
+
+    test('pack failure with an out-of-workspace path CONTAINING SPACES leaks no fragment', async () => {
+      // The gap that motivates the boundary refactor: string-level redaction cannot
+      // cleanly cut a path with spaces (it stops at the first space), so a dir/user
+      // name fragment survives. Not forwarding error.message at all closes it.
+      const install = '/opt/fake install/repomix lib/core/x.js';
+      const err = new Error(`ENOENT: no such file or directory, open '${install}'`);
+      vi.mocked(runCli).mockRejectedValueOnce(err);
+      const r = await pack({ directory: '.', compress: false, topFilesLength: 10, style: 'xml' });
+      expect(r.isError).toBe(true);
+      expect(JSON.stringify(r)).not.toContain('repomix lib'); // no surviving path fragment
+      expect(JSON.stringify(r)).not.toContain('fake install');
+    });
+
+    test('read_output / grep_output on a stale outputId leak neither the temp path nor the host', async () => {
+      const readOut = capture(registerReadRepomixOutputTool, root);
+      const grepOut = capture(registerGrepRepomixOutputTool, root);
+      registerOutputFile('deadbeefcontract', '/tmp/repomix/mcp-outputs/zzz/repomix-output.xml');
+      for (const r of [
+        await readOut({ outputId: 'deadbeefcontract' }),
+        await grepOut({ outputId: 'deadbeefcontract', pattern: 'x' }),
+      ]) {
+        expect(r.isError).toBe(true);
+        expect(textOf(r)).not.toContain('/tmp/repomix');
+        expect(textOf(r)).toContain('deadbeefcontract'); // opaque id is safe to echo
+      }
+    });
+  });
+
+  describe('functionality: valid ops return correct relative results', () => {
+    test('read_file returns content + a relative path', async () => {
+      const r = await readFile({ path: 'src/a.ts' });
+      expect(r.isError ?? false).toBe(false);
+      expect(r.structuredContent?.path).toBe('src/a.ts');
+      expect(r.structuredContent?.content).toBe('const x = 1;\n');
+      assertNoHostPath(r);
+    });
+    test('read_directory "." lists entries with a relative path', async () => {
+      const r = await readDir({ path: '.' });
+      expect(r.isError ?? false).toBe(false);
+      expect(r.structuredContent?.path).toBe('.');
+      expect((r.structuredContent as { contents: string[] }).contents.some((c) => c.includes('src'))).toBe(true);
+      assertNoHostPath(r);
+    });
+  });
+});


### PR DESCRIPTION
## Discussion
https://github.com/yamadashy/repomix/issues/1754

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
