### PR TITLE
fix(mcp): Close a symlink escape in the sandbox pack confinement

### DIFF
--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -297,15 +297,28 @@ export const searchFiles = async (
     let confinedEmptyDirPaths = emptyDirPaths;
     if (confineToBaseDir) {
       const rootAbs = path.resolve(rootDir);
-      const withinRoot = (rel: string): boolean => {
-        const abs = path.resolve(rootAbs, rel);
-        return abs === rootAbs || abs.startsWith(rootAbs + path.sep);
+      // Compare realpaths, not the lexical path: a lexically in-root match can still
+      // point outside when an intermediate component is a symlink — a glob whose
+      // static base names a symlinked dir (e.g. "gateway/x" with gateway -> /etc) is
+      // read through by fast-glob even with followSymbolicLinks:false. Canonicalize
+      // each match and drop anything outside the canonical root, or that cannot be
+      // resolved at all (fail closed — an unresolvable path is never safe to pack).
+      const realRoot = await fs.realpath(rootAbs).catch(() => rootAbs);
+      const withinRealRoot = async (rel: string): Promise<boolean> => {
+        try {
+          const real = await fs.realpath(path.resolve(rootAbs, rel));
+          return real === realRoot || real.startsWith(realRoot + path.sep);
+        } catch {
+          return false;
+        }
       };
-      confinedFilePaths = filePaths.filter(withinRoot);
-      confinedEmptyDirPaths = emptyDirPaths.filter(withinRoot);
+      const fileKeep = await Promise.all(filePaths.map(withinRealRoot));
+      const emptyKeep = await Promise.all(emptyDirPaths.map(withinRealRoot));
+      confinedFilePaths = filePaths.filter((_, i) => fileKeep[i]);
+      confinedEmptyDirPaths = emptyDirPaths.filter((_, i) => emptyKeep[i]);
       if (confinedFilePaths.length !== filePaths.length) {
         logger.debug(
-          `[confine] dropped ${filePaths.length - confinedFilePaths.length} path(s) resolving outside ${rootAbs}`,
+          `[confine] dropped ${filePaths.length - confinedFilePaths.length} path(s) resolving outside ${realRoot}`,
         );
       }
     }

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -304,10 +304,14 @@ export const searchFiles = async (
       // each match and drop anything outside the canonical root, or that cannot be
       // resolved at all (fail closed — an unresolvable path is never safe to pack).
       const realRoot = await fs.realpath(rootAbs).catch(() => rootAbs);
+      // A filesystem/drive root already ends in the separator (POSIX "/", Windows
+      // "C:\"), so appending another would make the prefix "//" and reject every
+      // child — build it only when the separator is missing.
+      const realRootPrefix = realRoot.endsWith(path.sep) ? realRoot : `${realRoot}${path.sep}`;
       const withinRealRoot = async (rel: string): Promise<boolean> => {
         try {
           const real = await fs.realpath(path.resolve(rootAbs, rel));
-          return real === realRoot || real.startsWith(realRoot + path.sep);
+          return real === realRoot || real.startsWith(realRootPrefix);
         } catch {
           return false;
         }

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -182,6 +182,19 @@ describe('fileSearch', () => {
       expect(result.filePaths).toEqual(['src/a.ts']);
     });
 
+    test('confineToBaseDir keeps children when the root is the filesystem root', async () => {
+      // A root that already ends in the separator ("/" on POSIX, "C:\\" on Windows)
+      // must not build a "//" prefix that rejects every child. --sandbox / is
+      // degenerate but must still return its files rather than silently nothing.
+      const mockConfig = createMockConfig({ output: { includeEmptyDirectories: false } });
+      vi.mocked(globby).mockResolvedValue(['etc/hosts', 'srv/app.ts'] as never);
+      vi.mocked(fs.realpath).mockImplementation((async (p: string) => p) as unknown as typeof fs.realpath);
+
+      const result = await searchFiles('/', mockConfig, undefined, true);
+
+      expect(result.filePaths).toEqual(['etc/hosts', 'srv/app.ts']);
+    });
+
     test('without confineToBaseDir, out-of-root matches are preserved (default CLI/library behavior)', async () => {
       // confineToBaseDir defaults to false so the documented ../ / absolute
       // include-pattern behavior is unchanged for normal CLI and library callers.

--- a/tests/core/file/fileSearch.test.ts
+++ b/tests/core/file/fileSearch.test.ts
@@ -172,6 +172,10 @@ describe('fileSearch', () => {
       // behind the sandbox's pattern guard.
       const mockConfig = createMockConfig({ output: { includeEmptyDirectories: false } });
       vi.mocked(globby).mockResolvedValue(['src/a.ts', '/etc/passwd', '../sibling/secret.txt'] as never);
+      // Identity realpath (no symlinks in this fixture): the confine check compares
+      // canonical paths, so a mock that returns its input models a symlink-free tree.
+      // The symlink-escape case is covered by a real-filesystem test elsewhere.
+      vi.mocked(fs.realpath).mockImplementation((async (p: string) => p) as unknown as typeof fs.realpath);
 
       const result = await searchFiles('/mock/root', mockConfig, undefined, true);
 

--- a/tests/core/file/fileSearchConfineSymlink.test.ts
+++ b/tests/core/file/fileSearchConfineSymlink.test.ts
@@ -1,0 +1,56 @@
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { searchFiles } from '../../../src/core/file/fileSearch.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+// Real-filesystem regression for the confineToBaseDir backstop against a SYMLINK
+// escape. A lexically in-root match can still point outside when an intermediate
+// component is a symlink: a glob whose static base names a symlinked directory
+// (e.g. "gateway/secret.txt" with gateway -> /outside) is read through by fast-glob
+// even with followSymbolicLinks:false, and a lexical path.resolve() check does not
+// catch it. confineToBaseDir must compare realpaths and drop such matches. These
+// tests use a real symlink so the real realpath wiring is exercised end-to-end.
+describe('searchFiles confineToBaseDir vs real symlink escape', () => {
+  let root = '';
+  let outside = '';
+
+  beforeEach(async () => {
+    if (process.platform === 'win32') return; // symlink creation needs privilege on Windows
+    root = await fsp.realpath(await fsp.mkdtemp(path.join(os.tmpdir(), 'confine-root-')));
+    outside = await fsp.realpath(await fsp.mkdtemp(path.join(os.tmpdir(), 'confine-outside-')));
+    await fsp.writeFile(path.join(outside, 'secret.txt'), 'HOST SECRET');
+    await fsp.mkdir(path.join(root, 'src'));
+    await fsp.writeFile(path.join(root, 'src', 'a.ts'), 'const x = 1;\n');
+    // A symlinked directory inside root pointing outside — the escape gateway.
+    await fsp.symlink(outside, path.join(root, 'gateway'), 'dir');
+  });
+
+  afterEach(async () => {
+    if (process.platform === 'win32') return;
+    await fsp.rm(root, { recursive: true, force: true });
+    await fsp.rm(outside, { recursive: true, force: true });
+  });
+
+  test('drops a file reached through a symlinked directory base', async () => {
+    if (process.platform === 'win32') return;
+    const config = createMockConfig({ include: ['gateway/secret.txt'] });
+    const result = await searchFiles(root, config, undefined, true);
+    expect(result.filePaths).not.toContain('gateway/secret.txt');
+  });
+
+  test('drops everything a symlinked directory glob would surface', async () => {
+    if (process.platform === 'win32') return;
+    const config = createMockConfig({ include: ['gateway/**'] });
+    const result = await searchFiles(root, config, undefined, true);
+    expect(result.filePaths.some((p) => p.startsWith('gateway/'))).toBe(false);
+  });
+
+  test('still returns genuine in-root files', async () => {
+    if (process.platform === 'win32') return;
+    const config = createMockConfig({ include: ['src/**'] });
+    const result = await searchFiles(root, config, undefined, true);
+    expect(result.filePaths).toContain('src/a.ts');
+  });
+});

--- a/tests/mcp/tools/sandbox.contract.test.ts
+++ b/tests/mcp/tools/sandbox.contract.test.ts
@@ -139,6 +139,51 @@ describe('sandbox contract', () => {
     });
   });
 
+  // A symlink is lexically clean (no "..", not absolute), so it passes the string
+  // checks; only realpath reveals that it points outside root. These drive REAL
+  // on-disk symlinks through the handlers to prove the real fs.realpath wiring
+  // rejects them — the pathScope unit tests stub realpath and cannot cover this.
+  describe('confinement: real symlink escapes are caught via realpath', () => {
+    let outside = '';
+    beforeEach(async () => {
+      outside = await fsp.realpath(await fsp.mkdtemp(path.join(os.tmpdir(), 'sbx-outside-')));
+      await fsp.writeFile(path.join(outside, 'secret.txt'), 'TOP SECRET');
+    });
+    afterEach(async () => {
+      await fsp.rm(outside, { recursive: true, force: true });
+    });
+
+    test('read_file through an in-root symlink to an outside file is rejected and leaks nothing', async () => {
+      if (process.platform === 'win32') return; // symlink creation needs privilege on Windows
+      await fsp.symlink(path.join(outside, 'secret.txt'), path.join(root, 'link.txt'), 'file');
+      const r = await readFile({ path: 'link.txt' });
+      expect(rejectedAsEscape(r), 'a symlink escaping root must be rejected').toBe(true);
+      expect(textOf(r)).not.toContain('TOP SECRET');
+      expect(JSON.stringify(r)).not.toContain(outside); // the resolved external target must not leak either
+      assertNoHostPath(r);
+    });
+
+    test('read_file through a symlinked directory used as a gateway is rejected', async () => {
+      if (process.platform === 'win32') return;
+      // realpath must resolve an INTERMEDIATE component, not just the leaf.
+      await fsp.symlink(outside, path.join(root, 'gateway'), 'dir');
+      const r = await readFile({ path: 'gateway/secret.txt' });
+      expect(rejectedAsEscape(r)).toBe(true);
+      expect(textOf(r)).not.toContain('TOP SECRET');
+      expect(JSON.stringify(r)).not.toContain(outside);
+      assertNoHostPath(r);
+    });
+
+    test('read_directory through an in-root symlink to an outside directory is rejected', async () => {
+      if (process.platform === 'win32') return;
+      await fsp.symlink(outside, path.join(root, 'linkdir'), 'dir');
+      const r = await readDir({ path: 'linkdir' });
+      expect(rejectedAsEscape(r), 'a symlinked directory escaping root must be rejected').toBe(true);
+      expect(JSON.stringify(r)).not.toContain(outside);
+      assertNoHostPath(r);
+    });
+  });
+
   describe('confinement: valid look-alike filenames are NOT over-rejected', () => {
     test.each(ALLOWED_TRICKY)('read_file reads %j (tilde/dots that are not escapes)', async (name) => {
       await fsp.writeFile(path.join(root, name), `body:${name}`);
@@ -185,6 +230,19 @@ describe('sandbox contract', () => {
     test.each(ALLOWED_PATTERNS)('pack ACCEPTS relative pattern %j (reaches runCli)', async (pattern) => {
       await pack({ directory: '.', includePatterns: pattern, compress: false, topFilesLength: 10, style: 'xml' });
       expect(runCli, `${pattern} should pass the guard`).toHaveBeenCalled();
+    });
+    test('a sandboxed pack locks down runCli: skips config, confines the search, disables git sort', async () => {
+      // The lockdown is what keeps a sandboxed pack from reading the workspace's own
+      // repomix.config / .git/config or matching outside root. gitSortByChanges:false
+      // in particular stops `git -C <workspace> log` from spawning gpg.program.
+      await pack({ directory: '.', compress: false, topFilesLength: 10, style: 'xml' });
+      const cliOptions = vi.mocked(runCli).mock.calls[0]?.[2];
+      expect(cliOptions).toMatchObject({
+        skipLocalConfig: true,
+        skipGlobalConfig: true,
+        confineToBaseDir: true,
+        gitSortByChanges: false,
+      });
     });
     test('pack on a mistyped in-root directory → actionable "directory not found", not "operation failed"', async () => {
       // "scr" (typo for "src") resolves in-root but does not exist; the pre-check


### PR DESCRIPTION
## Summary

Closes a symlink-based escape in the MCP `--sandbox` pack confinement (follow-up to #1753).

The `confineToBaseDir` backstop compared **lexical** paths only, so a match that is lexically in-root but reaches outside through a symlink was kept. A `pack_codebase` glob whose static base names a symlinked directory (e.g. `gateway/x` with `gateway -> /etc`) is read through by fast-glob even with `followSymbolicLinks: false`, letting a sandboxed pack surface files outside the workspace via `read_repomix_output`.

The fix canonicalizes each match with `realpath` and drops anything resolving outside the canonical root, or that cannot be resolved (fail closed).

`--sandbox` is new, opt-in, and unreleased (#1753), so **no released version is affected**.

## Changes

- `fileSearch.ts`: `confineToBaseDir` now compares realpaths instead of lexical paths.
- Add a real-filesystem symlink regression test for the pack search path.
- Add real on-disk symlink cases to the sandbox contract suite (the `pathScope` unit tests stub `realpath` and never exercised the real wiring end-to-end).
- Lock in the `runCli` sandbox lockdown options (including `gitSortByChanges: false`) with an explicit assertion.

## Checklist

- [x] `npm run lint`
- [x] `npm run test` (1729 passing)
