### PR TITLE
fix(core): accept explicit remote URLs whose repo name starts with a dot (e.g. .github)

### DIFF
--- a/src/core/git/gitRemoteParse.ts
+++ b/src/core/git/gitRemoteParse.ts
@@ -2,7 +2,7 @@ import gitUrlParse, { type GitUrl } from 'git-url-parse';
 import { RepomixError } from '../../shared/errorHandle.js';
 import { logger } from '../../shared/logger.js';
 import { assertNotMetadataEndpoint } from './gitMetadataEndpoint.js';
-import { isExplicitRemoteUrl, isValidShorthand } from './gitRemoteUrl.js';
+import { isExplicitRemoteUrl, isValidExplicitUrlOwnerRepo, isValidShorthand } from './gitRemoteUrl.js';
 
 interface IGitUrl extends GitUrl {
   commit: string | undefined;
@@ -93,10 +93,14 @@ const parseRemoteValueInternal = (
     const ownerSlashRepo =
       parsedFields.full_name.split('/').length > 1 ? parsedFields.full_name.split('/').slice(-2).join('/') : '';
 
-    // Only re-check the shorthand shape for ambiguous (non-URL) inputs. An explicit
-    // URL is already validated by git-url-parse and may lead/trail a name segment with
-    // `.`/`-`/`_` (e.g. the org-profile repo `owner/.github`), which the regex rejects.
-    if (ownerSlashRepo !== '' && !isExplicitRemoteUrl(remoteValue) && !isValidShorthand(ownerSlashRepo)) {
+    // An explicit URL's owner/repo may lead/trail a name segment with `.`/`-`/`_`
+    // (e.g. the org-profile repo `owner/.github`), which the shorthand regex rejects —
+    // but git-url-parse preserves malformed paths (doubled slashes, extra segments)
+    // in full_name, so explicit URLs still need their own segment check.
+    const isOwnerSlashRepoValid = isExplicitRemoteUrl(remoteValue)
+      ? isValidExplicitUrlOwnerRepo(ownerSlashRepo)
+      : isValidShorthand(ownerSlashRepo);
+    if (ownerSlashRepo !== '' && !isOwnerSlashRepoValid) {
       throw new RepomixError('Invalid owner/repo in repo URL');
     }
 

--- a/src/core/git/gitRemoteParse.ts
+++ b/src/core/git/gitRemoteParse.ts
@@ -2,7 +2,7 @@ import gitUrlParse, { type GitUrl } from 'git-url-parse';
 import { RepomixError } from '../../shared/errorHandle.js';
 import { logger } from '../../shared/logger.js';
 import { assertNotMetadataEndpoint } from './gitMetadataEndpoint.js';
-import { isValidShorthand } from './gitRemoteUrl.js';
+import { isExplicitRemoteUrl, isValidShorthand } from './gitRemoteUrl.js';
 
 interface IGitUrl extends GitUrl {
   commit: string | undefined;
@@ -93,7 +93,10 @@ const parseRemoteValueInternal = (
     const ownerSlashRepo =
       parsedFields.full_name.split('/').length > 1 ? parsedFields.full_name.split('/').slice(-2).join('/') : '';
 
-    if (ownerSlashRepo !== '' && !isValidShorthand(ownerSlashRepo)) {
+    // Only re-check the shorthand shape for ambiguous (non-URL) inputs. An explicit
+    // URL is already validated by git-url-parse and may lead/trail a name segment with
+    // `.`/`-`/`_` (e.g. the org-profile repo `owner/.github`), which the regex rejects.
+    if (ownerSlashRepo !== '' && !isExplicitRemoteUrl(remoteValue) && !isValidShorthand(ownerSlashRepo)) {
       throw new RepomixError('Invalid owner/repo in repo URL');
     }
 

--- a/src/core/git/gitRemoteUrl.ts
+++ b/src/core/git/gitRemoteUrl.ts
@@ -28,3 +28,17 @@ const validShorthandRegex = new RegExp(`^${VALID_NAME_PATTERN}/${VALID_NAME_PATT
 export const isValidShorthand = (remoteValue: string): boolean => {
   return validShorthandRegex.test(remoteValue);
 };
+
+// Unlike shorthand, an explicit URL's owner/repo may lead or trail a segment with
+// `.`/`-`/`_` (e.g. the org-profile repo `owner/.github`), so segments only need to
+// be non-empty — but there must be exactly two of them, rejecting doubled slashes
+// (`user//repo`) and extra path components (`user/repo/extra`).
+const EXPLICIT_URL_NAME_PATTERN = '[a-zA-Z0-9._-]+';
+const validExplicitUrlOwnerRepoRegex = new RegExp(`^${EXPLICIT_URL_NAME_PATTERN}/${EXPLICIT_URL_NAME_PATTERN}$`);
+
+/**
+ * Checks if an owner/repo pair extracted from an explicit remote URL is well-formed.
+ */
+export const isValidExplicitUrlOwnerRepo = (ownerSlashRepo: string): boolean => {
+  return validExplicitUrlOwnerRepoRegex.test(ownerSlashRepo);
+};

--- a/tests/core/git/gitRemoteParse.test.ts
+++ b/tests/core/git/gitRemoteParse.test.ts
@@ -73,6 +73,26 @@ describe('remoteAction functions', () => {
       });
     });
 
+    test('should accept explicit URLs whose repo name starts with a dot (e.g. .github)', () => {
+      expect(parseRemoteValue('https://github.com/microsoft/.github')).toEqual({
+        repoUrl: 'https://github.com/microsoft/.github.git',
+        remoteBranch: undefined,
+      });
+      expect(parseRemoteValue('git@github.com:microsoft/.github.git')).toEqual({
+        repoUrl: 'git@github.com:microsoft/.github.git',
+        remoteBranch: undefined,
+      });
+      expect(parseRemoteValue('https://gitlab.com/group/.foo')).toEqual({
+        repoUrl: 'https://gitlab.com/group/.foo.git',
+        remoteBranch: undefined,
+      });
+    });
+
+    test('should still reject shorthand whose repo name starts with a dot', () => {
+      expect(() => parseRemoteValue('user/.repo')).toThrowError();
+      expect(() => parseRemoteValue('.user/repo')).toThrowError();
+    });
+
     test('should handle Azure DevOps SSH URLs', () => {
       const azureDevOpsUrl = 'git@ssh.dev.azure.com:v3/organization/project/repo';
       const parsed = parseRemoteValue(azureDevOpsUrl);

--- a/tests/core/git/gitRemoteParse.test.ts
+++ b/tests/core/git/gitRemoteParse.test.ts
@@ -93,6 +93,33 @@ describe('remoteAction functions', () => {
       expect(() => parseRemoteValue('.user/repo')).toThrowError();
     });
 
+    test('should accept explicit URLs whose owner/repo name leads or trails with . - _', () => {
+      expect(parseRemoteValue('https://github.com/owner/repo.')).toEqual({
+        repoUrl: 'https://github.com/owner/repo..git',
+        remoteBranch: undefined,
+      });
+      expect(parseRemoteValue('https://github.com/owner/repo-')).toEqual({
+        repoUrl: 'https://github.com/owner/repo-.git',
+        remoteBranch: undefined,
+      });
+      expect(parseRemoteValue('https://github.com/owner/repo_')).toEqual({
+        repoUrl: 'https://github.com/owner/repo_.git',
+        remoteBranch: undefined,
+      });
+      expect(parseRemoteValue('https://github.com/-owner/repo')).toEqual({
+        repoUrl: 'https://github.com/-owner/repo.git',
+        remoteBranch: undefined,
+      });
+      expect(parseRemoteValue('https://github.com/_owner/repo')).toEqual({
+        repoUrl: 'https://github.com/_owner/repo.git',
+        remoteBranch: undefined,
+      });
+    });
+
+    test('should reject explicit URLs with a doubled slash (empty path segment)', () => {
+      expect(() => parseRemoteValue('https://github.com/user//repo')).toThrowError();
+    });
+
     test('should handle Azure DevOps SSH URLs', () => {
       const azureDevOpsUrl = 'git@ssh.dev.azure.com:v3/organization/project/repo';
       const parsed = parseRemoteValue(azureDevOpsUrl);


### PR DESCRIPTION
`parseRemoteValue` rejects some perfectly valid repositories with `Invalid remote repository URL or repository shorthand (owner/repo)`. The clearest example is an org profile repo — `https://github.com/microsoft/.github` throws, even though the repo exists and clones fine.

The cause is the owner/repo re-check after `git-url-parse` has already parsed the URL: it runs the parsed `owner/repo` back through `isValidShorthand`, whose regex forces every name segment to start and end with an alphanumeric. That rule is right for its real job — telling an ambiguous `owner/repo` shorthand apart from a local path — but it's wrong to reuse it on an explicit URL, since hosts happily allow names that lead or trail with `.`/`-`/`_` (`.github` being the obvious one). The two parsers already disagree here: `parseGitHubRepoInfo` extracts `{owner: "microsoft", repo: ".github"}` from the same input without complaint.

For public GitHub the archive fast-path hides this, but the clone path (non-GitHub hosts, or the archive→clone fallback) hits the throw and reports a misleading "invalid owner/repo" for a valid repo. `isValidRemoteValue` returns `false` for it too.

The fix only skips the shorthand re-check when the input is an explicit URL (`isExplicitRemoteUrl`); ambiguous shorthand still goes through the strict regex, so `user/.repo` and friends stay rejected as before. Added tests for the dotfile-name URL/SSH cases and a guard that shorthand `user/.repo` still throws.