### PR TITLE
fix(browser): Support GitHub's new repository header for the Repomix button

### DIFF
--- a/browser/entrypoints/content.ts
+++ b/browser/entrypoints/content.ts
@@ -70,7 +70,12 @@ function extractRepositoryInfo(): RepositoryInfo | null {
 }
 
 function findNavigationContainer(): Element | null {
-  return document.querySelector('ul.pagehead-actions');
+  // GitHub is rolling out a React-based repository header that replaces the
+  // legacy `ul.pagehead-actions` list with `ul[data-testid="repo-header-actions"]`.
+  // Keep the legacy selector as a fallback while the rollout is in progress.
+  return (
+    document.querySelector('ul[data-testid="repo-header-actions"]') ?? document.querySelector('ul.pagehead-actions')
+  );
 }
 
 function isRepositoryPage(): boolean {

--- a/browser/entrypoints/content.ts
+++ b/browser/entrypoints/content.ts
@@ -1,3 +1,4 @@
+import { findNavigationContainer } from '../utils/github-navigation';
 import './styles.css';
 
 interface RepositoryInfo {
@@ -67,15 +68,6 @@ function extractRepositoryInfo(): RepositoryInfo | null {
     repo,
     url: `https://github.com/${owner}/${repo}`,
   };
-}
-
-function findNavigationContainer(): Element | null {
-  // GitHub is rolling out a React-based repository header that replaces the
-  // legacy `ul.pagehead-actions` list with `ul[data-testid="repo-header-actions"]`.
-  // Keep the legacy selector as a fallback while the rollout is in progress.
-  return (
-    document.querySelector('ul[data-testid="repo-header-actions"]') ?? document.querySelector('ul.pagehead-actions')
-  );
 }
 
 function isRepositoryPage(): boolean {

--- a/browser/tests/repomix-integration.test.ts
+++ b/browser/tests/repomix-integration.test.ts
@@ -44,4 +44,15 @@ describe('RepomixIntegration', () => {
     const navContainer = document.querySelector('ul.pagehead-actions');
     expect(navContainer).toBeTruthy();
   });
+
+  it('should find navigation container in the new React-based repo header', () => {
+    document.body.innerHTML = '';
+    const navActions = document.createElement('ul');
+    navActions.setAttribute('data-testid', 'repo-header-actions');
+    document.body.appendChild(navActions);
+
+    const navContainer =
+      document.querySelector('ul[data-testid="repo-header-actions"]') ?? document.querySelector('ul.pagehead-actions');
+    expect(navContainer).toBe(navActions);
+  });
 });

--- a/browser/tests/repomix-integration.test.ts
+++ b/browser/tests/repomix-integration.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
+import { findNavigationContainer } from '../utils/github-navigation';
 
 // Mock DOM environment
 Object.defineProperty(window, 'location', {
@@ -40,9 +41,9 @@ describe('RepomixIntegration', () => {
     expect(expectedUrl).toBe('https://repomix.com/?repo=https%3A%2F%2Fgithub.com%2Fyamadashy%2Frepomix');
   });
 
-  it('should find navigation container', () => {
-    const navContainer = document.querySelector('ul.pagehead-actions');
-    expect(navContainer).toBeTruthy();
+  it('should find navigation container in the legacy repo header', () => {
+    const navContainer = findNavigationContainer();
+    expect(navContainer).toBe(document.querySelector('ul.pagehead-actions'));
   });
 
   it('should find navigation container in the new React-based repo header', () => {
@@ -51,8 +52,19 @@ describe('RepomixIntegration', () => {
     navActions.setAttribute('data-testid', 'repo-header-actions');
     document.body.appendChild(navActions);
 
-    const navContainer =
-      document.querySelector('ul[data-testid="repo-header-actions"]') ?? document.querySelector('ul.pagehead-actions');
-    expect(navContainer).toBe(navActions);
+    expect(findNavigationContainer()).toBe(navActions);
+  });
+
+  it('should prefer the new repo header container when both are present', () => {
+    const newNavActions = document.createElement('ul');
+    newNavActions.setAttribute('data-testid', 'repo-header-actions');
+    document.body.appendChild(newNavActions);
+
+    expect(findNavigationContainer()).toBe(newNavActions);
+  });
+
+  it('should return null when no navigation container exists', () => {
+    document.body.innerHTML = '';
+    expect(findNavigationContainer()).toBeNull();
   });
 });

--- a/browser/utils/github-navigation.ts
+++ b/browser/utils/github-navigation.ts
@@ -1,0 +1,8 @@
+// GitHub is rolling out a React-based repository header that replaces the
+// legacy `ul.pagehead-actions` list with `ul[data-testid="repo-header-actions"]`.
+// Keep the legacy selector as a fallback while the rollout is in progress.
+export function findNavigationContainer(): Element | null {
+  return (
+    document.querySelector('ul[data-testid="repo-header-actions"]') ?? document.querySelector('ul.pagehead-actions')
+  );
+}


### PR DESCRIPTION
A user reported on Discord that the Repomix button no longer appears in the repository header (Firefox extension, ad blocker ruled out).

GitHub is rolling out a React-based repository header where the legacy `ul.pagehead-actions` action list is replaced by `ul[data-testid="repo-header-actions"]`. The content script only queried the legacy selector, so the button silently disappeared for users on the new header. Logged-out pages still serve the legacy DOM, which is why the breakage only affects some users.

This PR queries the new `data-testid` selector first and keeps the legacy selector as a fallback while the rollout is in progress. Same root cause and fix as yamadashy/github-deepwiki-button#15, except the legacy selector is retained here since the rollout is still partial.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)