### PR TITLE
chore(browser): Bump extension version to 1.0.2

### DIFF
--- a/browser/wxt.config.ts
+++ b/browser/wxt.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   manifest: {
     name: 'Repomix',
     short_name: 'repomix',
-    version: '1.0.1',
+    version: '1.0.2',
     description: '__MSG_appDescription__',
     default_locale: 'en',
     icons: {


### PR DESCRIPTION
Bumps the browser extension version for the store release containing #1779 (support for GitHub's new repository header).

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)