### PR TITLE
fix(security): Prevent RCE from uploaded ZIP contents on the website pack API

### DIFF
--- a/website/server/src/domains/pack/processZipFile.ts
+++ b/website/server/src/domains/pack/processZipFile.ts
@@ -9,6 +9,20 @@ import { logMemoryUsage } from '../../utils/logger.js';
 import { cleanupTempDirectory, copyOutputToCurrentDirectory, createTempDirectory } from './utils/fileUtils.js';
 import { buildUntrustedPackCliOptions } from './utils/untrustedPackOptions.js';
 
+/**
+ * Whether a ZIP entry belongs to an embedded git repository (`.git/…`, or a
+ * bare `.git` gitfile).
+ *
+ * These are dropped rather than extracted. repomix runs `git log` against the
+ * pack directory to order files by change frequency (output.git.sortByChanges
+ * defaults on), and git trusts a repository's own `.git/config` — so an
+ * uploaded `.git` turns that ordering pass into arbitrary command execution in
+ * this process (e.g. log.showSignature + gpg.program). Dropping the directory
+ * costs nothing: repomix already default-ignores `.git/**` from its output and
+ * deletes `.git` after cloning a remote itself, so no upload needs it.
+ */
+const isGitInternalEntry = (entryPath: string): boolean => entryPath.split('/').some((segment) => segment === '.git');
+
 // Enhanced ZIP extraction limits
 const ZIP_SECURITY_LIMITS = {
   MAX_FILES: 10000, // Maximum number of files in the archive
@@ -183,6 +197,9 @@ async function extractZipWithSecurity(file: File, destPath: string): Promise<voi
       // Skip directories (fflate doesn't include directory entries, only files)
       if (entryPath.endsWith('/')) continue;
 
+      // Never materialize an uploaded git repository (see isGitInternalEntry).
+      if (isGitInternalEntry(entryPath)) continue;
+
       // 4.1 Check for unsafe paths (directory traversal prevention)
       const normalizedPath = path.normalize(path.join(destPath, entryPath));
       if (!normalizedPath.startsWith(destPath)) {
@@ -221,6 +238,7 @@ async function extractZipWithSecurity(file: File, destPath: string): Promise<voi
 
     for (const [filePath, data] of Object.entries(files)) {
       if (filePath.endsWith('/')) continue; // Skip directories
+      if (isGitInternalEntry(filePath)) continue; // Dropped above; must not reach disk
 
       const fullPath = path.join(destPath, filePath);
       const dirPath = path.dirname(fullPath);

--- a/website/server/src/domains/pack/processZipFile.ts
+++ b/website/server/src/domains/pack/processZipFile.ts
@@ -2,11 +2,12 @@ import { randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { unzip } from 'fflate';
-import { type CliOptions, runDefaultAction, setLogLevel } from 'repomix';
+import { runDefaultAction, setLogLevel } from 'repomix';
 import type { PackOptions, PackProgressCallback, PackResult, ProcessPackResult } from '../../types.js';
 import { AppError } from '../../utils/errorHandler.js';
 import { logMemoryUsage } from '../../utils/logger.js';
 import { cleanupTempDirectory, copyOutputToCurrentDirectory, createTempDirectory } from './utils/fileUtils.js';
+import { buildUntrustedPackCliOptions } from './utils/untrustedPackOptions.js';
 
 // Enhanced ZIP extraction limits
 const ZIP_SECURITY_LIMITS = {
@@ -32,29 +33,9 @@ export async function processZipFile(
 
   const outputFilePath = `repomix-output-${randomUUID()}.txt`;
 
-  // Create CLI options
-  const cliOptions = {
-    output: outputFilePath,
-    style: format,
-    parsableStyle: options.outputParsable,
-    removeComments: options.removeComments,
-    removeEmptyLines: options.removeEmptyLines,
-    outputShowLineNumbers: options.showLineNumbers,
-    fileSummary: options.fileSummary,
-    directoryStructure: options.directoryStructure,
-    compress: options.compress,
-    securityCheck: true,
-    topFilesLen: 10,
-    include: options.includePatterns,
-    ignore: options.ignorePatterns,
-    quiet: true, // Enable quiet mode to suppress output
-    // An uploaded archive is attacker-controlled, exactly like the cloned
-    // repository in remoteRepo.ts. Without this, a `repomix.config.js` at the
-    // root of the ZIP is imported — and therefore executed — inside this
-    // process during buildMergedConfig(), before packing and before the
-    // security check ever look at file contents.
-    skipLocalConfig: true,
-  } as CliOptions;
+  // An uploaded archive is attacker-controlled, exactly like the cloned
+  // repository in remoteRepo.ts, so both build their options the same way.
+  const cliOptions = buildUntrustedPackCliOptions({ outputFilePath, format, options, securityCheck: true });
 
   setLogLevel(-1);
 

--- a/website/server/src/domains/pack/processZipFile.ts
+++ b/website/server/src/domains/pack/processZipFile.ts
@@ -48,6 +48,12 @@ export async function processZipFile(
     include: options.includePatterns,
     ignore: options.ignorePatterns,
     quiet: true, // Enable quiet mode to suppress output
+    // An uploaded archive is attacker-controlled, exactly like the cloned
+    // repository in remoteRepo.ts. Without this, a `repomix.config.js` at the
+    // root of the ZIP is imported — and therefore executed — inside this
+    // process during buildMergedConfig(), before packing and before the
+    // security check ever look at file contents.
+    skipLocalConfig: true,
   } as CliOptions;
 
   setLogLevel(-1);

--- a/website/server/src/domains/pack/processZipFile.ts
+++ b/website/server/src/domains/pack/processZipFile.ts
@@ -20,8 +20,13 @@ import { buildUntrustedPackCliOptions } from './utils/untrustedPackOptions.js';
  * this process (e.g. log.showSignature + gpg.program). Dropping the directory
  * costs nothing: repomix already default-ignores `.git/**` from its output and
  * deletes `.git` after cloning a remote itself, so no upload needs it.
+ *
+ * Both separators are treated as boundaries. A ZIP should use '/', but a crafted
+ * archive can embed '\\', which becomes a path separator once extracted onto a
+ * Windows host, so a `.git\\config` entry must be recognized as git-internal too.
  */
-const isGitInternalEntry = (entryPath: string): boolean => entryPath.split('/').some((segment) => segment === '.git');
+export const isGitInternalEntry = (entryPath: string): boolean =>
+  entryPath.split(/[/\\]/).some((segment) => segment === '.git');
 
 // Enhanced ZIP extraction limits
 const ZIP_SECURITY_LIMITS = {

--- a/website/server/src/domains/pack/remoteRepo.ts
+++ b/website/server/src/domains/pack/remoteRepo.ts
@@ -2,13 +2,14 @@ import { execFile } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import { promisify } from 'node:util';
-import { type CliOptions, parseRemoteValue, runDefaultAction } from 'repomix';
+import { parseRemoteValue, runDefaultAction } from 'repomix';
 import type { PackOptions, PackProgressCallback, PackResult, ProcessPackResult } from '../../types.js';
 import { AppError } from '../../utils/errorHandler.js';
 import { logMemoryUsage } from '../../utils/logger.js';
 import { generateCacheKey } from './utils/cache.js';
 import { cleanupTempDirectory, copyOutputToCurrentDirectory, createTempDirectory } from './utils/fileUtils.js';
 import { cache } from './utils/sharedInstance.js';
+import { buildUntrustedPackCliOptions } from './utils/untrustedPackOptions.js';
 import { assertPublicHttpsRepoUrl } from './validateRemoteRepoUrl.js';
 
 const execFileAsync = promisify(execFile);
@@ -71,24 +72,9 @@ export async function processRemoteRepo(
   const tempDirPath = await createTempDirectory();
   const outputFilePath = `repomix-output-${randomUUID()}.txt`;
 
-  // Create CLI options for runDefaultAction (no 'remote' needed since we clone ourselves)
-  const cliOptions = {
-    output: outputFilePath,
-    style: format,
-    parsableStyle: options.outputParsable,
-    removeComments: options.removeComments,
-    removeEmptyLines: options.removeEmptyLines,
-    outputShowLineNumbers: options.showLineNumbers,
-    fileSummary: options.fileSummary,
-    directoryStructure: options.directoryStructure,
-    compress: options.compress,
-    securityCheck: false,
-    topFilesLen: 10,
-    include: options.includePatterns,
-    ignore: options.ignorePatterns,
-    quiet: true,
-    skipLocalConfig: true, // Prevent loading config files from untrusted cloned repositories
-  } as CliOptions;
+  // CLI options for runDefaultAction (no 'remote' needed since we clone ourselves).
+  // The clone is untrusted, same as an uploaded archive in processZipFile.ts.
+  const cliOptions = buildUntrustedPackCliOptions({ outputFilePath, format, options, securityCheck: false });
 
   try {
     // Log memory usage before processing

--- a/website/server/src/domains/pack/utils/untrustedPackOptions.ts
+++ b/website/server/src/domains/pack/utils/untrustedPackOptions.ts
@@ -1,0 +1,50 @@
+import type { CliOptions } from 'repomix';
+import type { PackOptions } from '../../../types.js';
+
+/**
+ * Builds the `runDefaultAction` options for packing a directory whose contents
+ * came from outside this server — an uploaded archive or a cloned repository.
+ *
+ * Both callers go through here so that `skipLocalConfig` cannot be present on
+ * one path and missing on the other. That is not a hypothetical: the two option
+ * objects were written out separately and drifted, and the ZIP upload path spent
+ * that time importing — and therefore executing — `repomix.config.*` files out
+ * of uploaded archives.
+ *
+ * `CliOptions` extends commander's `OptionValues`, which has an index signature,
+ * so a misspelled flag here type-checks silently. The tests around each caller
+ * are what actually pin the flag reaching `runDefaultAction`.
+ */
+export const buildUntrustedPackCliOptions = ({
+  outputFilePath,
+  format,
+  options,
+  securityCheck,
+}: {
+  outputFilePath: string;
+  format: string;
+  options: PackOptions;
+  // The one setting the two paths genuinely disagree on, so it stays a decision
+  // the caller makes rather than something baked in here.
+  securityCheck: boolean;
+}): CliOptions =>
+  ({
+    output: outputFilePath,
+    style: format,
+    parsableStyle: options.outputParsable,
+    removeComments: options.removeComments,
+    removeEmptyLines: options.removeEmptyLines,
+    outputShowLineNumbers: options.showLineNumbers,
+    fileSummary: options.fileSummary,
+    directoryStructure: options.directoryStructure,
+    compress: options.compress,
+    securityCheck,
+    topFilesLen: 10,
+    include: options.includePatterns,
+    ignore: options.ignorePatterns,
+    quiet: true, // Suppress CLI output; this runs inside a request handler
+    // The packed tree is attacker-controlled. Loading a config from it runs the
+    // config module in this process, before packing and before the security
+    // check ever looks at file contents.
+    skipLocalConfig: true,
+  }) as CliOptions;

--- a/website/server/tests/isGitInternalEntry.test.ts
+++ b/website/server/tests/isGitInternalEntry.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest';
+import { isGitInternalEntry } from '../src/domains/pack/processZipFile.js';
+
+// The end-to-end .git RCE test can only exercise the '/' form: a `.git\config`
+// entry is a harmless literal filename on the Linux test/deploy host and never
+// forms a repository there, so it cannot drive execution to assert against.
+// This covers the predicate directly instead, including the Windows-separator
+// case a crafted archive can carry.
+describe('isGitInternalEntry', () => {
+  test.each([
+    '.git',
+    '.git/config',
+    '.git/hooks/pre-commit',
+    'sub/.git/config',
+    '.git\\config',
+    'sub\\.git\\config',
+    'sub/.git\\config',
+  ])('treats %j as git-internal', (entry) => {
+    expect(isGitInternalEntry(entry)).toBe(true);
+  });
+
+  test.each([
+    'README.md',
+    'src/index.ts',
+    '.gitignore',
+    '.github/workflows/ci.yml',
+    'a.git',
+    'git/config',
+  ])('leaves %j alone', (entry) => {
+    expect(isGitInternalEntry(entry)).toBe(false);
+  });
+});

--- a/website/server/tests/isGitInternalEntry.test.ts
+++ b/website/server/tests/isGitInternalEntry.test.ts
@@ -19,14 +19,10 @@ describe('isGitInternalEntry', () => {
     expect(isGitInternalEntry(entry)).toBe(true);
   });
 
-  test.each([
-    'README.md',
-    'src/index.ts',
-    '.gitignore',
-    '.github/workflows/ci.yml',
-    'a.git',
-    'git/config',
-  ])('leaves %j alone', (entry) => {
-    expect(isGitInternalEntry(entry)).toBe(false);
-  });
+  test.each(['README.md', 'src/index.ts', '.gitignore', '.github/workflows/ci.yml', 'a.git', 'git/config'])(
+    'leaves %j alone',
+    (entry) => {
+      expect(isGitInternalEntry(entry)).toBe(false);
+    },
+  );
 });

--- a/website/server/tests/processZipFile.configExecution.test.ts
+++ b/website/server/tests/processZipFile.configExecution.test.ts
@@ -1,0 +1,94 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { strToU8, zipSync } from 'fflate';
+import { runDefaultAction } from 'repomix';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest';
+import { processZipFile } from '../src/domains/pack/processZipFile.js';
+
+// GHSA-j7x8-v4ww-w74f. Nothing is mocked here: the real pack pipeline runs
+// against a real archive, so this fails if the guarantee is lost anywhere along
+// the chain — not only if processZipFile stops passing the flag.
+//
+// The payload writes a marker file. Any observable side effect would do; a file
+// is used because it survives the module being imported in a child of this
+// process and is trivially asserted on.
+
+const buildPayloadConfig = (markerPath: string) => `import { writeFileSync } from 'node:fs';
+writeFileSync(${JSON.stringify(markerPath)}, 'executed');
+export default {};
+`;
+
+const exists = async (filePath: string): Promise<boolean> => {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+describe('processZipFile — uploaded repomix.config.* is never executed', () => {
+  let workDir: string;
+  let markerPath: string;
+  let originalCwd: string;
+
+  beforeAll(async () => {
+    // processZipFile writes its output file into process.cwd(); keep that out of
+    // the repository even if a test fails before the cleanup runs.
+    originalCwd = process.cwd();
+    workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-zip-config-test-'));
+    process.chdir(workDir);
+  });
+
+  afterAll(async () => {
+    process.chdir(originalCwd);
+    await fs.rm(workDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    markerPath = path.join(workDir, `marker-${Math.random().toString(36).slice(2)}`);
+  });
+
+  afterEach(async () => {
+    await fs.rm(markerPath, { force: true });
+  });
+
+  test('packs an archive containing repomix.config.js without running it', async () => {
+    const zipped = zipSync({
+      'repomix.config.js': strToU8(buildPayloadConfig(markerPath)),
+      'README.md': strToU8('payload archive\n'),
+    });
+
+    const { result } = await processZipFile(
+      new File([zipped], 'payload.zip', { type: 'application/zip' }),
+      'plain',
+      {},
+    );
+
+    expect(await exists(markerPath)).toBe(false);
+    // The pack itself must still succeed — the fix skips the config, it does not
+    // reject the upload, so a user who zips a project that legitimately contains
+    // a JS config keeps getting their output.
+    expect(result.content).toContain('payload archive');
+  });
+
+  test('the same payload does execute without skipLocalConfig', async () => {
+    // Positive control. Without this, the assertion above would keep passing if
+    // the payload silently stopped being a valid config, or if config discovery
+    // stopped finding a file at the root of the packed directory — leaving a
+    // green test that no longer tests anything.
+    const targetDir = await fs.mkdtemp(path.join(workDir, 'control-'));
+    await fs.writeFile(path.join(targetDir, 'repomix.config.js'), buildPayloadConfig(markerPath));
+    await fs.writeFile(path.join(targetDir, 'README.md'), 'payload archive\n');
+
+    await runDefaultAction([targetDir], targetDir, {
+      output: path.join(targetDir, 'out.txt'),
+      style: 'plain',
+      securityCheck: true,
+      quiet: true,
+    });
+
+    expect(await exists(markerPath)).toBe(true);
+  });
+});

--- a/website/server/tests/processZipFile.gitConfigExecution.test.ts
+++ b/website/server/tests/processZipFile.gitConfigExecution.test.ts
@@ -1,0 +1,134 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { zipSync } from 'fflate';
+import { runDefaultAction } from 'repomix';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest';
+import { processZipFile } from '../src/domains/pack/processZipFile.js';
+
+// GHSA-j7x8, second vector. repomix orders output by git change frequency
+// (output.git.sortByChanges defaults on), which runs `git log` against the pack
+// directory. git trusts a repository's own .git/config, so an uploaded .git can
+// turn that ordering pass into command execution — independent of the config
+// loader that skipLocalConfig closes. The fix drops `.git/**` during extraction.
+//
+// Nothing is mocked: a real malicious git repo is built, zipped, and pushed
+// through the real pack pipeline, so this fails if the guarantee is lost
+// anywhere along the chain.
+
+// A repository whose own config runs `markerPath`'s writer when git verifies a
+// signature, plus a commit crafted with a gpgsig header so a signature exists to
+// verify. `git log` alone then executes gpg.program.
+const buildMaliciousGitRepo = async (repoDir: string, markerPath: string): Promise<void> => {
+  const git = (...args: string[]) => execFileSync('git', ['-C', repoDir, ...args], { stdio: 'pipe' });
+  await fs.mkdir(repoDir, { recursive: true });
+  execFileSync('git', ['init', '-q', repoDir], { stdio: 'pipe' });
+  git('config', 'user.email', 'a@b.c');
+  git('config', 'user.name', 'a');
+  await fs.writeFile(path.join(repoDir, 'f.txt'), 'hi\n');
+  git('add', 'f.txt');
+  git('commit', '-q', '-m', 'init');
+  const tree = git('write-tree').toString().trim();
+
+  const payload = path.join(repoDir, 'pwn.sh');
+  await fs.writeFile(payload, `#!/bin/sh\ntouch ${markerPath}\necho '[GNUPG:] GOODSIG fake' 1>&2\nexit 0\n`);
+  await fs.chmod(payload, 0o755);
+  await fs.appendFile(
+    path.join(repoDir, '.git', 'config'),
+    `\n[log]\n\tshowSignature = true\n[gpg]\n\tprogram = ${payload}\n`,
+  );
+
+  const raw =
+    `tree ${tree}\n` +
+    'author a <a@b.c> 1700000000 +0000\n' +
+    'committer a <a@b.c> 1700000000 +0000\n' +
+    'gpgsig -----BEGIN PGP SIGNATURE-----\n \n fake\n -----END PGP SIGNATURE-----\n\nsigned\n';
+  const rawPath = path.join(repoDir, 'rawc');
+  await fs.writeFile(rawPath, raw);
+  const commit = execFileSync('git', ['-C', repoDir, 'hash-object', '-t', 'commit', '-w', 'rawc']).toString().trim();
+  git('update-ref', 'refs/heads/main', commit);
+  git('symbolic-ref', 'HEAD', 'refs/heads/main');
+  await fs.rm(rawPath, { force: true });
+};
+
+const zipDirectoryToFile = async (dir: string, name: string): Promise<File> => {
+  const entries: Record<string, Uint8Array> = {};
+  const walk = async (current: string, base: string): Promise<void> => {
+    for (const entry of await fs.readdir(current, { withFileTypes: true })) {
+      const rel = path.join(base, entry.name);
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full, rel);
+      } else {
+        entries[rel] = new Uint8Array(await fs.readFile(full));
+      }
+    }
+  };
+  await walk(dir, '');
+  return new File([zipSync(entries)], name, { type: 'application/zip' });
+};
+
+const exists = async (filePath: string): Promise<boolean> => {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+describe('processZipFile — an uploaded .git never drives git execution', () => {
+  let workDir: string;
+  let markerPath: string;
+  let originalCwd: string;
+
+  beforeAll(async () => {
+    originalCwd = process.cwd();
+    workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-zip-git-test-'));
+    process.chdir(workDir);
+  });
+
+  afterAll(async () => {
+    process.chdir(originalCwd);
+    await fs.rm(workDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    markerPath = path.join(workDir, `marker-${Math.random().toString(36).slice(2)}`);
+  });
+
+  afterEach(async () => {
+    await fs.rm(markerPath, { force: true });
+  });
+
+  test('packs an archive containing a malicious .git without running git against it', async () => {
+    const repoDir = await fs.mkdtemp(path.join(workDir, 'repo-'));
+    await buildMaliciousGitRepo(repoDir, markerPath);
+    const file = await zipDirectoryToFile(repoDir, 'repo.zip');
+
+    const { result } = await processZipFile(file, 'plain', {});
+
+    expect(await exists(markerPath)).toBe(false);
+    // The upload still packs — the .git is dropped, not the whole archive.
+    expect(result.content).toContain('f.txt');
+  });
+
+  test('the same repo does execute when git runs against it directly', async () => {
+    // Positive control: proves the payload is live and the git-sort path reaches
+    // it, so the assertion above is testing the strip and not a payload that
+    // quietly stopped working.
+    const repoDir = await fs.mkdtemp(path.join(workDir, 'control-'));
+    await buildMaliciousGitRepo(repoDir, markerPath);
+
+    await runDefaultAction([repoDir], repoDir, {
+      output: path.join(workDir, 'control-out.txt'),
+      style: 'plain',
+      securityCheck: true,
+      quiet: true,
+      skipLocalConfig: true, // isolate the git vector from the config-loader one
+    });
+
+    expect(await exists(markerPath)).toBe(true);
+  });
+});

--- a/website/server/tests/processZipFile.test.ts
+++ b/website/server/tests/processZipFile.test.ts
@@ -1,0 +1,110 @@
+import { strToU8, zipSync } from 'fflate';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// These tests target the one behavioral change this PR makes to
+// processZipFile.ts: the `cliOptions` handed to `runDefaultAction` now carry
+// `skipLocalConfig: true`, so a `repomix.config.*` file inside the uploaded
+// archive is never imported. Everything the module does around that (temp
+// directories, output copying, result mapping) is pre-existing behavior and is
+// mocked out here. The end-to-end proof that the flag actually stops execution
+// lives in processZipFile.configExecution.test.ts.
+const {
+  runDefaultActionMock,
+  setLogLevelMock,
+  createTempDirectoryMock,
+  cleanupTempDirectoryMock,
+  copyOutputToCurrentDirectoryMock,
+  mkdirMock,
+  writeFileMock,
+  readFileMock,
+  unlinkMock,
+} = vi.hoisted(() => ({
+  runDefaultActionMock: vi.fn(),
+  setLogLevelMock: vi.fn(),
+  createTempDirectoryMock: vi.fn(async () => '/tmp/repomix-test-dir'),
+  cleanupTempDirectoryMock: vi.fn(async () => undefined),
+  copyOutputToCurrentDirectoryMock: vi.fn(async () => undefined),
+  mkdirMock: vi.fn(async () => undefined),
+  writeFileMock: vi.fn(async () => undefined),
+  readFileMock: vi.fn(async () => 'packed content'),
+  unlinkMock: vi.fn(async () => undefined),
+}));
+
+// Extraction writes to disk for real otherwise; the archive contents are
+// irrelevant to what this file asserts.
+vi.mock('node:fs/promises', () => ({
+  default: { mkdir: mkdirMock, writeFile: writeFileMock, readFile: readFileMock, unlink: unlinkMock },
+}));
+
+vi.mock('repomix', () => ({
+  runDefaultAction: runDefaultActionMock,
+  setLogLevel: setLogLevelMock,
+}));
+
+vi.mock('../src/domains/pack/utils/fileUtils.js', () => ({
+  createTempDirectory: createTempDirectoryMock,
+  cleanupTempDirectory: cleanupTempDirectoryMock,
+  copyOutputToCurrentDirectory: copyOutputToCurrentDirectoryMock,
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logMemoryUsage: vi.fn(),
+}));
+
+const { processZipFile } = await import('../src/domains/pack/processZipFile.js');
+
+const successfulRunDefaultActionResult = {
+  config: { output: { filePath: 'repomix-output-test.txt' } },
+  packResult: {
+    totalFiles: 1,
+    totalCharacters: 10,
+    totalTokens: 5,
+    fileCharCounts: { 'index.ts': 10 },
+    fileTokenCounts: { 'index.ts': 5 },
+    suspiciousFilesResults: [],
+  },
+};
+
+const buildZipFile = (entries: Record<string, string>, name = 'upload.zip'): File => {
+  const zipped = zipSync(Object.fromEntries(Object.entries(entries).map(([p, body]) => [p, strToU8(body)])));
+  return new File([zipped], name, { type: 'application/zip' });
+};
+
+describe('processZipFile — untrusted archive config handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runDefaultActionMock.mockResolvedValue(successfulRunDefaultActionResult);
+    readFileMock.mockResolvedValue('packed content');
+  });
+
+  test('passes skipLocalConfig: true so an uploaded repomix.config.* is never loaded', async () => {
+    await processZipFile(buildZipFile({ 'repomix.config.js': 'export default {};' }), 'xml', {});
+
+    expect(runDefaultActionMock).toHaveBeenCalledTimes(1);
+    expect(runDefaultActionMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ skipLocalConfig: true }),
+      expect.anything(),
+    );
+  });
+
+  test('passes the flag regardless of the archive contents', async () => {
+    // The flag is a property of where the tree came from, not of what happens
+    // to be in it — an archive with no config at all must still be packed with
+    // config loading disabled, so no future upload can opt itself back in.
+    await processZipFile(buildZipFile({ 'README.md': 'hello\n' }), 'xml', {});
+
+    expect(runDefaultActionMock.mock.calls[0][2]).toMatchObject({ skipLocalConfig: true });
+  });
+
+  test('packs the extracted tree as both the target and the cwd', async () => {
+    // Pinning this because it is what makes the flag necessary: the attacker
+    // controls the directory that config discovery runs against.
+    await processZipFile(buildZipFile({ 'README.md': 'hello\n' }), 'xml', {});
+
+    const [directories, cwd] = runDefaultActionMock.mock.calls[0];
+    expect(directories).toEqual(['/tmp/repomix-test-dir']);
+    expect(cwd).toBe('/tmp/repomix-test-dir');
+  });
+});

--- a/website/server/tests/remoteRepo.test.ts
+++ b/website/server/tests/remoteRepo.test.ts
@@ -210,4 +210,13 @@ describe('processRemoteRepo — assertPublicHttpsRepoUrl integration', () => {
     // The hardening config must precede the `clone` subcommand to take effect.
     expect(gitArgs.indexOf('http.followRedirects=false')).toBeLessThan(gitArgs.indexOf('clone'));
   });
+
+  test('packs the cloned tree with skipLocalConfig: true', async () => {
+    // Sibling of the same assertion in processZipFile.test.ts. Both pack paths
+    // hand `runDefaultAction` a directory whose contents came from outside; a
+    // `repomix.config.*` in there is executed on load unless this flag is set.
+    await processRemoteRepo('owner/repo', 'xml', baseOptions);
+
+    expect(runDefaultActionMock.mock.calls[0][2]).toMatchObject({ skipLocalConfig: true });
+  });
 });

--- a/website/server/tests/untrustedPackOptions.test.ts
+++ b/website/server/tests/untrustedPackOptions.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'vitest';
+import { buildUntrustedPackCliOptions } from '../src/domains/pack/utils/untrustedPackOptions.js';
+import type { PackOptions } from '../src/types.js';
+
+describe('buildUntrustedPackCliOptions', () => {
+  const base = { outputFilePath: 'out.txt', format: 'xml', options: {} as PackOptions };
+
+  test.each([
+    { securityCheck: true },
+    { securityCheck: false },
+  ])('always sets skipLocalConfig (securityCheck: $securityCheck)', ({ securityCheck }) => {
+    // The whole point of routing both pack paths through here: neither of them
+    // gets to be the one that forgets.
+    expect(buildUntrustedPackCliOptions({ ...base, securityCheck })).toMatchObject({ skipLocalConfig: true });
+  });
+
+  test('leaves securityCheck to the caller', () => {
+    // The one setting the ZIP and remote paths genuinely disagree on.
+    expect(buildUntrustedPackCliOptions({ ...base, securityCheck: true }).securityCheck).toBe(true);
+    expect(buildUntrustedPackCliOptions({ ...base, securityCheck: false }).securityCheck).toBe(false);
+  });
+
+  test('maps the request-level pack options through', () => {
+    const options: PackOptions = {
+      removeComments: true,
+      removeEmptyLines: true,
+      showLineNumbers: true,
+      fileSummary: false,
+      directoryStructure: false,
+      includePatterns: 'src/**',
+      ignorePatterns: 'dist/**',
+      outputParsable: true,
+      compress: true,
+    };
+
+    expect(buildUntrustedPackCliOptions({ ...base, options, securityCheck: true })).toMatchObject({
+      output: 'out.txt',
+      style: 'xml',
+      parsableStyle: true,
+      removeComments: true,
+      removeEmptyLines: true,
+      outputShowLineNumbers: true,
+      fileSummary: false,
+      directoryStructure: false,
+      compress: true,
+      include: 'src/**',
+      ignore: 'dist/**',
+      quiet: true,
+      topFilesLen: 10,
+    });
+  });
+});

--- a/website/server/tests/untrustedPackOptions.test.ts
+++ b/website/server/tests/untrustedPackOptions.test.ts
@@ -5,14 +5,14 @@ import type { PackOptions } from '../src/types.js';
 describe('buildUntrustedPackCliOptions', () => {
   const base = { outputFilePath: 'out.txt', format: 'xml', options: {} as PackOptions };
 
-  test.each([
-    { securityCheck: true },
-    { securityCheck: false },
-  ])('always sets skipLocalConfig (securityCheck: $securityCheck)', ({ securityCheck }) => {
-    // The whole point of routing both pack paths through here: neither of them
-    // gets to be the one that forgets.
-    expect(buildUntrustedPackCliOptions({ ...base, securityCheck })).toMatchObject({ skipLocalConfig: true });
-  });
+  test.each([{ securityCheck: true }, { securityCheck: false }])(
+    'always sets skipLocalConfig (securityCheck: $securityCheck)',
+    ({ securityCheck }) => {
+      // The whole point of routing both pack paths through here: neither of them
+      // gets to be the one that forgets.
+      expect(buildUntrustedPackCliOptions({ ...base, securityCheck })).toMatchObject({ skipLocalConfig: true });
+    },
+  );
 
   test('leaves securityCheck to the caller', () => {
     // The one setting the ZIP and remote paths genuinely disagree on.


### PR DESCRIPTION
## Summary

Closes two code-execution paths on the hosted website's `POST /api/pack` ZIP upload (`website/server`). Both let a remote user run arbitrary code in the server process by uploading a crafted archive. Server-side only; no published npm release of `repomix` is affected, so there is no package version to upgrade and no CVE. Remediation is this deploy.

1. **Config-loader RCE (reported, GHSA-j7x8-v4ww-w74f).** The ZIP path built its `cliOptions` without `skipLocalConfig`, so a `repomix.config.js` at the root of the uploaded archive was imported (executed) during `buildMergedConfig()`, before packing and before the security check. The sibling remote-repository path already set the flag. Fixed by setting it, and by routing both untrusted pack paths through a single `buildUntrustedPackCliOptions()` so the flag comes with the shape rather than with whoever remembers it.

2. **git-config RCE (found while fixing the above).** repomix orders output by git change frequency (`output.git.sortByChanges` defaults on), which runs `git log` against the pack directory. git trusts a repository's own `.git/config`, so an uploaded `.git` carrying `log.showSignature = true` + `gpg.program = <cmd>` and a commit with a `gpgsig` header executed an attacker command. `skipLocalConfig` does not close this. Fixed by dropping `.git/**` (and a bare `.git`) during extraction; repomix already default-ignores `.git` and deletes it after its own clones, so no upload loses anything.

Both are proven and regression-tested end to end against the real pack pipeline, each with a positive control that the same payload does execute without the fix (so the tests cannot go vacuous).

## Checklist

- [x] Run `npm run test` (website/server: 113 passed)
- [x] Run `npm run lint`