### PR TITLE
chore(website): Pin the Cloud Run server to a dedicated runtime service account

### DIFF
--- a/website/server/cloudbuild.yaml
+++ b/website/server/cloudbuild.yaml
@@ -50,6 +50,12 @@ steps:
       - '--ingress'
       - 'all'
       - '--allow-unauthenticated'
+      # Dedicated runtime identity. Its only permission is secretAccessor on the
+      # four secrets below, so a compromise of the server process cannot reach
+      # the rest of the project. Keep this pinned: without it a deploy would fall
+      # back to the default compute service account, which holds project editor.
+      - '--service-account'
+      - 'repomix-server-run@$PROJECT_ID.iam.gserviceaccount.com'
       - '--set-env-vars'
       - 'NODE_ENV=production'
       - '--set-secrets'


### PR DESCRIPTION
## Summary

The hosted server (`repomix-server-us`) used to run as the default compute service account, which holds project `roles/editor`. That made a server compromise a project-wide problem: the ZIP-upload RCE fixed in #1795 executed with that identity available from the metadata server.

It now runs as a dedicated `repomix-server-run@` service account whose only permission is `secretmanager.secretAccessor` on the four secrets the service mounts. Nothing else. The server needs nothing more: it uses no Google Cloud SDK, and its logs go to stdout, which Cloud Run collects on its own.

The live service was already switched over (revision `repomix-server-us-00193-4mr`, healthy and serving 100%). This PR pins the flag in `cloudbuild.yaml` so it stays that way, because `gcloud run deploy` without `--service-account` falls back to the default compute account.

## Out-of-band setup (already applied)

- Created `repomix-server-run@repomix.iam.gserviceaccount.com`, with no project-level roles
- Granted it `roles/secretmanager.secretAccessor` on `upstash-redis-rest-url`, `upstash-redis-rest-token`, `cloudflare-origin-secret`, `turnstile-secret-key`
- Granted the Cloud Build service account `roles/iam.serviceAccountUser` on it so deploys can act as it

## Verification

- `GET /health` returns 200 on the new revision, so the container starts and all four secrets resolve under the new identity
- `POST /api/pack` returns the bot-guard 403, which only happens after the Cloudflare origin-secret check passes, confirming `CLOUDFLARE_ORIGIN_SECRET` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)