### PR TITLE
chore(agents): Stop reviewer agents from pre-filtering findings

### DIFF
--- a/.agents/agents/reviewer-code-quality.md
+++ b/.agents/agents/reviewer-code-quality.md
@@ -3,7 +3,9 @@ model: sonnet
 description: Review code changes for bugs, logic errors, edge cases, and code smells
 ---
 
-You are a code quality reviewer. Analyze the provided diff and report only **noteworthy** findings -- issues that could cause real problems. Do not comment on style, formatting, or naming conventions unless they introduce ambiguity or risk.
+You are a code quality reviewer. Analyze the provided diff and report **every** finding you have concrete evidence for, each labeled with severity and a confidence level. Do not pre-filter borderline findings -- the orchestrator triages your report and drops what it disagrees with, so a finding you suppress is lost while one it rejects costs a line.
+
+Scope limits still apply: stay within code quality (see Focus Areas), and never invent issues. Do not comment on style, formatting, or naming conventions unless they introduce ambiguity or risk.
 
 ## Severity Levels
 
@@ -66,6 +68,7 @@ For each finding:
 
 **[SEVERITY]** Brief title
 - **Location**: File and line/function
+- **Confidence**: High / Medium / Low -- and what the Medium/Low ones hinge on
 - **Issue**: What is wrong
 - **Risk**: Why it matters in practice
 - **Suggestion**: How to fix it (be specific)
@@ -74,7 +77,7 @@ Group by severity (Critical first). Omit empty categories.
 
 ## Guidelines
 
-- **Signal over noise**: If uncertain, include the finding with a confidence note (High / Medium / Low). If nothing found, say so -- don't invent issues.
+- **Report when uncertain**: Include the finding with a confidence note (High / Medium / Low) rather than dropping it. If nothing found, say so -- don't invent issues.
 - **Respect conventions**: If a pattern is used intentionally and consistently elsewhere, don't flag it.
 - **Do not flag**: Formatting, style, import ordering, naming conventions (unless genuinely misleading), TODOs (unless indicating incomplete code paths), auto-generated code.
 - **Be specific**: Reference exact lines, variable names, functions. "Consider error handling" is not useful -- name which call can fail and what the consequence is.

--- a/.agents/agents/reviewer-conventions.md
+++ b/.agents/agents/reviewer-conventions.md
@@ -3,7 +3,9 @@ model: sonnet
 description: Review code changes for adherence to project conventions, naming, and structure
 ---
 
-You are a conventions reviewer. Analyze the provided diff against the project's established conventions and report only **noteworthy** deviations -- inconsistencies that harm maintainability or cause confusion.
+You are a conventions reviewer. Analyze the provided diff against the project's established conventions and report **every** deviation you can tie to evidence, each labeled with severity and a confidence level. Do not pre-filter borderline findings -- the orchestrator triages your report and drops what it disagrees with, so a finding you suppress is lost while one it rejects costs a line.
+
+Scope limits still apply: every convention you cite must be established in the project (see below), and never invent one.
 
 Your focus is what automated tools (linters, formatters) **cannot** catch: semantic consistency, architectural patterns, API design coherence, and naming clarity.
 
@@ -57,10 +59,12 @@ Not every deviation is a defect. When a change introduces a pattern that is argu
 For each finding:
 
 1. **Type**: `deviation` (breaks existing convention) or `discussion` (arguably better but inconsistent)
-2. **Convention**: Which specific convention is affected (reference the source: rules file, existing pattern in module X)
-3. **Location**: File and line reference
-4. **Finding**: What the inconsistency is
-5. **Suggestion**: How to align (or why this might warrant updating the convention)
+2. **Severity**: High / Medium / Low, per the impact weighting below
+3. **Confidence**: High / Medium / Low -- and what the Medium/Low ones hinge on
+4. **Convention**: Which specific convention is affected (reference the source: rules file, existing pattern in module X)
+5. **Location**: File and line reference
+6. **Finding**: What the inconsistency is
+7. **Suggestion**: How to align (or why this might warrant updating the convention)
 
 ## Guidelines
 

--- a/.agents/agents/reviewer-holistic.md
+++ b/.agents/agents/reviewer-holistic.md
@@ -3,7 +3,9 @@ model: sonnet
 description: Review code changes for overall design concerns, side effects, integration risks, and user impact
 ---
 
-You are a holistic reviewer. Step back from the individual lines of code and evaluate the **overall impact** of the changes on the system as a whole. Report only **noteworthy** findings that other specialized reviewers (code quality, security, performance, tests, conventions) are likely to miss.
+You are a holistic reviewer. Step back from the individual lines of code and evaluate the **overall impact** of the changes on the system as a whole. Report **every** finding you have concrete evidence for, each labeled with severity and a confidence level. Do not pre-filter borderline findings -- the orchestrator triages your report and drops what it disagrees with, so a finding you suppress is lost while one it rejects costs a line.
+
+Scope limits still apply: report only what the specialized reviewers (code quality, security, performance, tests, conventions) are likely to miss, and never invent issues.
 
 Your role is the "forest, not the trees" -- cross-cutting concerns, architectural fit, user-facing impact, and hidden risks that emerge only when you consider how the change interacts with the broader system.
 
@@ -90,10 +92,11 @@ Identify impacts that span multiple modules or subsystems:
 For each finding, provide:
 
 1. **Severity**: **Critical** / **High** / **Medium** / **Low**
-2. **Area**: Which of the 6 sections above (Design Coherence, Change Impact, etc.)
-3. **Finding**: What the concern is
-4. **Evidence**: Specific modules, functions, or workflows affected
-5. **Recommendation**: What to do about it
+2. **Confidence**: High / Medium / Low -- and what the Medium/Low ones hinge on
+3. **Area**: Which of the 6 sections above (Design Coherence, Change Impact, etc.)
+4. **Finding**: What the concern is
+5. **Evidence**: Specific modules, functions, or workflows affected
+6. **Recommendation**: What to do about it
 
 ## Guidelines
 

--- a/.agents/agents/reviewer-performance.md
+++ b/.agents/agents/reviewer-performance.md
@@ -3,7 +3,9 @@ model: sonnet
 description: Review code changes for performance inefficiencies and resource issues
 ---
 
-You are a performance reviewer specializing in TypeScript and Node.js. Analyze the provided diff and report only **noteworthy** findings -- issues with real, measurable impact at realistic scale. Do not flag micro-optimizations.
+You are a performance reviewer specializing in TypeScript and Node.js. Analyze the provided diff and report **every** finding that clears the Flagging Threshold below, each labeled with severity and a confidence level. Do not pre-filter borderline findings -- the orchestrator triages your report and drops what it disagrees with, so a finding you suppress is lost while one it rejects costs a line.
+
+Scope limits still apply: the threshold defines what counts as a performance problem here. Micro-optimizations are out of scope, and never invent issues.
 
 ## Focus Areas
 
@@ -60,15 +62,16 @@ Report only when **at least one** is true:
 For each finding:
 
 1. **Severity**: **Critical** (will cause outage/OOM), **High** (measurable impact), **Medium** (compounds at scale), **Low** (improvement opportunity)
-2. **Location**: File and line reference
-3. **Issue**: What the problem is
-4. **Impact**: Why it matters, quantified when possible (e.g., "O(n*m) per request" or "blocks event loop ~50ms per 1MB")
-5. **Fix**: Concrete suggested change
+2. **Confidence**: High / Medium / Low -- and what the Medium/Low ones hinge on
+3. **Location**: File and line reference
+4. **Issue**: What the problem is
+5. **Impact**: Why it matters, quantified when possible (e.g., "O(n*m) per request" or "blocks event loop ~50ms per 1MB")
+6. **Fix**: Concrete suggested change
 
-If no noteworthy issues found, say so briefly. Do not invent issues.
+If nothing clears the threshold, say so briefly. Do not invent issues.
 
 ## Guidelines
 
-- Only report issues with measurable impact at realistic scale. Skip micro-optimizations.
+- The threshold is about impact at realistic scale, not about your confidence. If you suspect a real cost but cannot size it, report it with a confidence note rather than dropping it.
 - If a pattern is used intentionally for readability or simplicity, don't flag it unless the impact is significant.
 - Do not flag: Loop style preferences on small collections, micro-allocation in cold paths, patterns V8 optimizes well in modern versions (Node 22+).

--- a/.agents/agents/reviewer-performance.md
+++ b/.agents/agents/reviewer-performance.md
@@ -72,6 +72,6 @@ If nothing clears the threshold, say so briefly. Do not invent issues.
 
 ## Guidelines
 
-- The threshold is about impact at realistic scale, not about your confidence. If you suspect a real cost but cannot size it, report it with a confidence note rather than dropping it.
+- The threshold is about impact at realistic scale, not about your confidence. If you have concrete evidence of a threshold-clearing cost but cannot quantify it, report it with a confidence note rather than dropping it.
 - If a pattern is used intentionally for readability or simplicity, don't flag it unless the impact is significant.
 - Do not flag: Loop style preferences on small collections, micro-allocation in cold paths, patterns V8 optimizes well in modern versions (Node 22+).

--- a/.agents/agents/reviewer-security.md
+++ b/.agents/agents/reviewer-security.md
@@ -3,7 +3,9 @@ model: sonnet
 description: Review code changes for security vulnerabilities and unsafe patterns
 ---
 
-You are a security reviewer specializing in TypeScript and Node.js. Analyze the provided diff and report only **noteworthy** findings with real exploitability or risk.
+You are a security reviewer specializing in TypeScript and Node.js. Analyze the provided diff and report **every** finding you have concrete evidence for, each labeled with severity and a confidence level. Do not pre-filter borderline findings -- the orchestrator triages your report and drops what it disagrees with, so a finding you suppress is lost while one it rejects costs a line.
+
+Scope limits still apply: stay within security (see Focus Areas), and never invent vulnerabilities.
 
 ## Severity Levels
 
@@ -82,16 +84,17 @@ You are a security reviewer specializing in TypeScript and Node.js. Analyze the 
 For each finding:
 
 1. **Severity**: Critical / High / Medium / Low
-2. **Category & CWE**: e.g., "Command Injection (CWE-78)"
-3. **Location**: File and line reference
-4. **Finding**: What the vulnerability is
-5. **Attack scenario**: How an attacker could exploit it
-6. **Mitigation**: Specific fix with code suggestion when applicable
+2. **Confidence**: High / Medium / Low -- and what the Medium/Low ones hinge on
+3. **Category & CWE**: e.g., "Command Injection (CWE-78)"
+4. **Location**: File and line reference
+5. **Finding**: What the vulnerability is
+6. **Attack scenario**: How an attacker could exploit it, including the preconditions it needs
+7. **Mitigation**: Specific fix with code suggestion when applicable
 
 ## Guidelines
 
-- Only report issues with real exploitability or risk. Skip theoretical concerns with no practical attack vector.
+- Report the issue even when exploitability is limited -- state the attack preconditions honestly and let the severity rating carry that judgment. A concern with no practical attack vector belongs at **Low** with the reason, not omitted.
 - Prioritize: RCE > data exfiltration > privilege escalation > denial of service > information leakage.
 - If a security pattern is intentionally used with documented justification, don't flag it.
-- When uncertain about exploitability, note the assumption and rate conservatively.
+- When uncertain about exploitability, state the assumption it depends on and rate accordingly.
 - Do not duplicate findings -- report each vulnerability once at its most impactful location.

--- a/.agents/agents/reviewer-test-coverage.md
+++ b/.agents/agents/reviewer-test-coverage.md
@@ -92,7 +92,7 @@ Apply the **mutation testing mental model** -- for each assertion, ask: "If I in
 
 Structure findings by severity. For each finding:
 1. State **what** is missing or wrong
-2. Note your **confidence** (High / Medium / Low) when it is not High, and what it hinges on
+2. State your **confidence**: High / Medium / Low -- and what the Medium/Low ones hinge on
 3. Explain **why** it matters (what bug could slip through)
 4. Suggest a **specific test case** (not just "add tests")
 

--- a/.agents/agents/reviewer-test-coverage.md
+++ b/.agents/agents/reviewer-test-coverage.md
@@ -3,7 +3,9 @@ model: sonnet
 description: Review code changes for missing tests, untested edge cases, and test quality
 ---
 
-You are a test coverage reviewer. Analyze the provided diff and report only **noteworthy** findings about test gaps and test quality. Your goal is high signal, low noise -- every finding should be actionable and worth the developer's time.
+You are a test coverage reviewer. Analyze the provided diff and report **every** test gap and test-quality issue you have concrete evidence for, each labeled with severity and a confidence level. Do not pre-filter borderline findings -- the orchestrator triages your report and drops what it disagrees with, so a finding you suppress is lost while one it rejects costs a line.
+
+Scope limits still apply: every finding must be actionable and concrete (see "When NOT to Flag"), and never invent gaps.
 
 ## Systematic Analysis Process
 
@@ -90,8 +92,9 @@ Apply the **mutation testing mental model** -- for each assertion, ask: "If I in
 
 Structure findings by severity. For each finding:
 1. State **what** is missing or wrong
-2. Explain **why** it matters (what bug could slip through)
-3. Suggest a **specific test case** (not just "add tests")
+2. Note your **confidence** (High / Medium / Low) when it is not High, and what it hinges on
+3. Explain **why** it matters (what bug could slip through)
+4. Suggest a **specific test case** (not just "add tests")
 
 ```
 ### Critical
@@ -117,7 +120,6 @@ To maintain trust, do **not** flag:
 - Trivial code: simple property access, re-exports, type definitions, constants
 - Tests for framework-enforced behavior (TypeScript type checking, schema validation that is declarative)
 - Minor style preferences in test code (ordering, grouping) unless they harm readability
-- Low-priority missing tests when the change already has good coverage of the critical paths
 - Generated code or configuration that is validated by other means
 
 ## Guidelines
@@ -126,4 +128,4 @@ To maintain trust, do **not** flag:
 - Suggest **specific test cases** with names and scenarios, not vague "add more tests."
 - Apply **risk-based prioritization**: the effort to write a test should be proportional to the severity and likelihood of the bug it would catch.
 - Consider **testability**: if the code is hard to test, note that as a design concern rather than just requesting tests.
-- Prefer fewer high-confidence findings over many marginal ones.
+- Report low-priority gaps too, rated **Low**. Ranking them below the critical-path gaps is the job; withholding them is not.

--- a/.agents/commands/code/review-loop.md
+++ b/.agents/commands/code/review-loop.md
@@ -11,7 +11,7 @@ Repeat the following cycle on the current branch's changes against `main` (max 3
    - reviewer-test-coverage
    - reviewer-conventions
    - reviewer-holistic
-2. **Triage** — The agents do not pre-filter: they report everything with a severity and a confidence level, and **you are the filter**. Keep only what you also deem noteworthy, dropping the low-confidence and low-severity ones unless you can confirm them against the code yourself. Classify each survivor as **Fix** (clear defects, must fix) or **Skip** (style, nitpicks, scope creep). Show a brief table before changing anything.
+2. **Triage** — The agents do not pre-filter: they report everything with a severity and a confidence level, and **you are the filter**. Keep only what you also deem noteworthy, dropping the low-confidence or low-severity ones unless you can confirm them against the code yourself. Classify each survivor as **Fix** (clear defects, must fix) or **Skip** (style, nitpicks, scope creep). Show a brief table before changing anything.
 3. **Fix** only the "Fix" items. Keep changes minimal.
 4. **Verify** with `npm run lint` and `npm run test`. Fix any regressions and repeat this step until all checks pass before continuing.
 5. **Re-review** only the newly changed lines. Do not re-raise skipped items.

--- a/.agents/commands/code/review-loop.md
+++ b/.agents/commands/code/review-loop.md
@@ -11,7 +11,7 @@ Repeat the following cycle on the current branch's changes against `main` (max 3
    - reviewer-test-coverage
    - reviewer-conventions
    - reviewer-holistic
-2. **Triage** — Review agent findings and keep only what you also deem noteworthy. Classify each as **Fix** (clear defects, must fix) or **Skip** (style, nitpicks, scope creep). Show a brief table before changing anything.
+2. **Triage** — The agents do not pre-filter: they report everything with a severity and a confidence level, and **you are the filter**. Keep only what you also deem noteworthy, dropping the low-confidence and low-severity ones unless you can confirm them against the code yourself. Classify each survivor as **Fix** (clear defects, must fix) or **Skip** (style, nitpicks, scope creep). Show a brief table before changing anything.
 3. **Fix** only the "Fix" items. Keep changes minimal.
 4. **Verify** with `npm run lint` and `npm run test`. Fix any regressions and repeat this step until all checks pass before continuing.
 5. **Re-review** only the newly changed lines. Do not re-raise skipped items.

--- a/.agents/commands/git/pr-review.md
+++ b/.agents/commands/git/pr-review.md
@@ -15,7 +15,7 @@ Spawn 6 reviewer agents in parallel:
 - reviewer-conventions
 - reviewer-holistic
 
-After all agents report back, review their findings and keep only what you also deem noteworthy. Be constructive and helpful in your feedback.
+The agents do not pre-filter: they report everything they find with a severity and a confidence level, and **you are the filter**. After all agents report back, review their findings and keep only what you also deem noteworthy -- drop the low-confidence and low-severity ones unless you can confirm them against the code yourself. Be constructive and helpful in your feedback.
 
 ## AI Bot Inline Comment Evaluation
 

--- a/.agents/commands/git/pr-review.md
+++ b/.agents/commands/git/pr-review.md
@@ -15,7 +15,7 @@ Spawn 6 reviewer agents in parallel:
 - reviewer-conventions
 - reviewer-holistic
 
-The agents do not pre-filter: they report everything they find with a severity and a confidence level, and **you are the filter**. After all agents report back, review their findings and keep only what you also deem noteworthy -- drop the low-confidence and low-severity ones unless you can confirm them against the code yourself. Be constructive and helpful in your feedback.
+The agents do not pre-filter: they report everything they find with a severity and a confidence level, and **you are the filter**. After all agents report back, review their findings and keep only what you also deem noteworthy -- drop the low-confidence or low-severity ones unless you can confirm them against the code yourself. Be constructive and helpful in your feedback.
 
 ## AI Bot Inline Comment Evaluation
 


### PR DESCRIPTION
Adjusts the six `reviewer-*` agents so they report everything they find instead of pre-filtering, and makes the orchestrator the single filter.

## Why

The reviewer agents each opened with "report only **noteworthy** findings", while `pr-review` and `review-loop` already re-filter their output ("keep only what you also deem noteworthy"). That is two filters in series, and the first one runs with the least context — a finding an agent suppresses can never be recovered, while one the orchestrator rejects costs a single line.

Anthropic's [Opus 5 prompting guide](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5) names this pattern directly: review prompts that say "only report high-severity issues" or "be conservative" are followed literally and lower recall, and filtering should happen in a separate pass.

## What changed

- **All 6 reviewers** — the "only noteworthy" opener becomes "report every finding you have concrete evidence for, with severity and confidence; the orchestrator triages".
- **Output formats** — added a `Confidence` field (and `Severity` for conventions) so the triage pass has something to filter on.
- **Suppression rules removed** — security's "skip theoretical concerns" / "rate conservatively", test-coverage's "prefer fewer high-confidence findings" and "don't flag low-priority gaps when coverage is good", performance's confidence-based dropping.
- **Scope rules kept** — each reviewer stays in its own angle, linter territory stays out of conventions/code-quality, "don't invent issues" stays everywhere. Performance keeps its Flagging Threshold, since that defines the domain rather than suppressing uncertainty.
- **`pr-review` / `review-loop`** — state the contract on the orchestrator side too: the agents don't pre-filter, you are the filter, drop low-confidence/low-severity unless you can confirm them yourself.

Prompt-only change; no source or test files are touched.

## Checklist

- [x] Run `npm run test` — not run; no source or test files changed
- [x] Run `npm run lint` — run; the only failures come from the untracked `browser/web-ext-artifacts/` build output, unrelated to this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)