### PR TITLE
test(security): Pin that a remote clone's .git is always removed

### DIFF
--- a/src/core/git/gitCommand.ts
+++ b/src/core/git/gitCommand.ts
@@ -185,7 +185,13 @@ export const execGitShallowClone = async (
     await deps.execFileAsync('git', ['clone', '--depth', '1', '--', url, directory], gitRemoteOpts);
   }
 
-  // Clean up .git directory
+  // Drop the clone's .git. This keeps git internals out of the packed output, but
+  // it is also load-bearing for safety, so keep it unconditional. Packing runs
+  // `git -C <dir> log` by default (output.git.sortByChanges), and git honors the
+  // repository's own .git/config — so a retained .git would let a cloned repo
+  // execute commands on this host through keys such as gpg.program (reached via
+  // log.showSignature). Making the removal conditional, for example to support
+  // diffs on a remote repo, would reopen that path.
   await fs.rm(path.join(directory, '.git'), { recursive: true, force: true });
 };
 

--- a/tests/core/git/gitCommand.test.ts
+++ b/tests/core/git/gitCommand.test.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import {
   execGitDiff,
@@ -126,6 +129,28 @@ file2.ts
   });
 
   describe('execGitShallowClone', () => {
+    // The .git removal is load-bearing for safety, not just tidiness: packing runs
+    // `git log` inside the clone by default and git honors that repository's own
+    // .git/config, so a retained .git would be a host command-execution vector.
+    // Unlike the sibling tests this one touches a real directory, because the
+    // guarantee is about what is left on disk rather than which git args ran.
+    test('removes the clone .git so a cloned repository cannot supply git config', async () => {
+      const mockFileExecAsync = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
+      const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-clone-git-'));
+      await fs.mkdir(path.join(directory, '.git'), { recursive: true });
+      await fs.writeFile(path.join(directory, '.git', 'config'), '[log]\n\tshowSignature = true\n');
+
+      try {
+        await execGitShallowClone('https://github.com/user/repo.git', directory, undefined, {
+          execFileAsync: mockFileExecAsync,
+        });
+
+        await expect(fs.access(path.join(directory, '.git'))).rejects.toThrow();
+      } finally {
+        await fs.rm(directory, { recursive: true, force: true });
+      }
+    });
+
     test('should execute without branch option if not specified by user', async () => {
       const mockFileExecAsync = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
       const url = 'https://github.com/user/repo.git';


### PR DESCRIPTION
## Summary

`execGitShallowClone` deletes the clone's `.git` before the pack runs. The comment called this "Clean up .git directory", which reads as tidiness, but the removal is load-bearing for safety: packing runs `git -C <dir> log` by default (`output.git.sortByChanges`), and git honors a repository's own `.git/config`. If the clone kept its `.git`, a remote repository could reach host command execution through keys such as `gpg.program` via `log.showSignature`.

Nothing guarded that. No comment explained it and no test pinned it, so a reasonable-looking change (keeping `.git` so diffs work on remote repos, for instance) would have reopened the path silently.

This adds the missing why, and a test that fails if the removal goes away.

## Changes

- `src/core/git/gitCommand.ts`: explain what the removal protects and why it must stay unconditional
- `tests/core/git/gitCommand.test.ts`: assert `.git` is gone after `execGitShallowClone`. Unlike its sibling tests, this one uses a real temporary directory, because the guarantee is about what is left on disk rather than which git arguments ran

The same reasoning is already spelled out where the sandboxed MCP path disables git sorting (`src/mcp/tools/packCodebaseTool.ts`) and where the website drops `.git` from uploads. This brings the third site in line.

## Verification

- Deleting the `fs.rm` call turns the new test red, so it is not passing vacuously
- Full suite green: 1798 tests across 151 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)