### PR TITLE
fix(security): Neutralize untrusted repo git config in log and diff subprocesses

### DIFF
--- a/src/core/git/gitCommand.ts
+++ b/src/core/git/gitCommand.ts
@@ -8,6 +8,20 @@ import { redactErrorMessage, redactUrl } from '../../shared/urlRedact.js';
 
 const execFileAsync = promisify(execFile);
 
+// A repository's own .git/config can name executables that git will run while
+// merely reading history: gpg.program (reached through log.showSignature),
+// diff.external, per-attribute textconv drivers, and core.fsmonitor. repomix
+// runs these read-only git commands inside directories it did not create — a
+// local pack of an untrusted checkout, or any working directory — so a malicious
+// repository could otherwise turn `git log`/`git diff` into command execution on
+// this host. Every such invocation is neutralized: the command flags disable the
+// log/diff drivers and core.fsmonitor (which has no flag) is overridden to empty.
+// Verified against git 2.53 to block all four vectors while leaving output for a
+// legitimate repository byte-for-byte unchanged.
+const GIT_UNTRUSTED_CONFIG_ARGS = ['-c', 'core.fsmonitor='];
+const GIT_LOG_HARDENING_ARGS = ['--no-show-signature'];
+const GIT_DIFF_HARDENING_ARGS = ['--no-ext-diff', '--no-textconv'];
+
 const GIT_REMOTE_TIMEOUT = 30000;
 const gitRemoteEnv = { ...process.env, GIT_TERMINAL_PROMPT: '0' };
 const gitRemoteOpts = { timeout: GIT_REMOTE_TIMEOUT, env: gitRemoteEnv };
@@ -29,7 +43,9 @@ export const execGitLogFilenames = async (
     const result = await deps.execFileAsync('git', [
       '-C',
       directory,
+      ...GIT_UNTRUSTED_CONFIG_ARGS,
       'log',
+      ...GIT_LOG_HARDENING_ARGS,
       '--pretty=format:',
       '--name-only',
       '-n',
@@ -54,7 +70,9 @@ export const execGitDiff = async (
     const result = await deps.execFileAsync('git', [
       '-C',
       directory,
+      ...GIT_UNTRUSTED_CONFIG_ARGS,
       'diff',
+      ...GIT_DIFF_HARDENING_ARGS,
       '--no-color', // Avoid ANSI color codes
       ...options,
     ]);
@@ -207,7 +225,9 @@ export const execGitLog = async (
     const result = await deps.execFileAsync('git', [
       '-C',
       directory,
+      ...GIT_UNTRUSTED_CONFIG_ARGS,
       'log',
+      ...GIT_LOG_HARDENING_ARGS,
       `--pretty=format:${gitSeparator}%ad|%s`,
       '--date=iso',
       '--name-only',

--- a/tests/core/git/gitCommand.test.ts
+++ b/tests/core/git/gitCommand.test.ts
@@ -1,7 +1,9 @@
+import { execFile, execFileSync } from 'node:child_process';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import {
   execGitDiff,
   execGitLog,
@@ -46,10 +48,15 @@ file2.ts
       const result = await execGitLogFilenames('/test/dir', 5, { execFileAsync: mockFileExecAsync });
 
       expect(result).toEqual(['file1.ts', 'file2.ts', 'file1.ts', 'file3.ts', 'file2.ts']);
+      // core.fsmonitor= and --no-show-signature neutralize executable keys the
+      // target directory's own .git/config could set (see gitCommand.ts).
       expect(mockFileExecAsync).toHaveBeenCalledWith('git', [
         '-C',
         '/test/dir',
+        '-c',
+        'core.fsmonitor=',
         'log',
+        '--no-show-signature',
         '--pretty=format:',
         '--name-only',
         '-n',
@@ -75,7 +82,18 @@ file2.ts
       const result = await execGitDiff('/test/dir', [], { execFileAsync: mockFileExecAsync });
 
       expect(result).toBe(mockDiff);
-      expect(mockFileExecAsync).toHaveBeenCalledWith('git', ['-C', '/test/dir', 'diff', '--no-color']);
+      // core.fsmonitor=, --no-ext-diff and --no-textconv neutralize executable
+      // keys the target directory's own .git/config could set (see gitCommand.ts).
+      expect(mockFileExecAsync).toHaveBeenCalledWith('git', [
+        '-C',
+        '/test/dir',
+        '-c',
+        'core.fsmonitor=',
+        'diff',
+        '--no-ext-diff',
+        '--no-textconv',
+        '--no-color',
+      ]);
     });
 
     test('should throw error when git diff fails', async () => {
@@ -358,7 +376,10 @@ test/feature.test.ts`;
       expect(mockFileExecAsync).toHaveBeenCalledWith('git', [
         '-C',
         '/test/dir',
+        '-c',
+        'core.fsmonitor=',
         'log',
+        '--no-show-signature',
         '--pretty=format:%x00%ad|%s',
         '--date=iso',
         '--name-only',
@@ -379,7 +400,10 @@ file1.txt`;
       expect(mockFileExecAsync).toHaveBeenCalledWith('git', [
         '-C',
         '/test/dir',
+        '-c',
+        'core.fsmonitor=',
         'log',
+        '--no-show-signature',
         `--pretty=format:${customSeparator}%ad|%s`,
         '--date=iso',
         '--name-only',
@@ -409,7 +433,10 @@ file.txt`;
       expect(mockFileExecAsync).toHaveBeenCalledWith('git', [
         '-C',
         '/test/dir',
+        '-c',
+        'core.fsmonitor=',
         'log',
+        '--no-show-signature',
         `--pretty=format:${separator}%ad|%s`,
         '--date=iso',
         '--name-only',
@@ -503,5 +530,96 @@ c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8\trefs/tags/v1.0.0
       ).rejects.toThrow('Invalid repository URL. URL contains potentially dangerous parameters');
       expect(mockFileExecAsync).not.toHaveBeenCalled();
     });
+  });
+});
+
+// End-to-end, nothing mocked: a real repository carrying a malicious .git/config
+// is built and pushed through the real git subprocess. git honors a repository's
+// own config, so without the hardening args a plain `git log` here would run the
+// configured gpg.program. This proves the hardening holds against real git,
+// including whichever executable-config behaviors the installed git version has.
+describe('gitCommand — an untrusted repository cannot execute code through git', () => {
+  const realExec = promisify(execFile);
+  let workDir: string;
+  let markerPath: string;
+
+  beforeAll(async () => {
+    workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-git-untrusted-'));
+  });
+
+  afterAll(async () => {
+    await fs.rm(workDir, { recursive: true, force: true });
+  });
+
+  // A repository whose own config runs `markerPath`'s writer when git verifies a
+  // signature, plus a commit crafted with a gpgsig header so a signature exists to
+  // verify. `git log` alone then invokes gpg.program.
+  const buildMaliciousRepo = async (repoDir: string, marker: string): Promise<void> => {
+    const git = (...args: string[]) => execFileSync('git', ['-C', repoDir, ...args], { stdio: 'pipe' });
+    await fs.mkdir(repoDir, { recursive: true });
+    execFileSync('git', ['init', '-q', repoDir], { stdio: 'pipe' });
+    git('config', 'user.email', 'a@b.c');
+    git('config', 'user.name', 'a');
+    await fs.writeFile(path.join(repoDir, 'f.txt'), 'hi\n');
+    git('add', 'f.txt');
+    git('commit', '-q', '-m', 'init');
+    const tree = git('write-tree').toString().trim();
+
+    const payload = path.join(repoDir, 'pwn.sh');
+    await fs.writeFile(payload, `#!/bin/sh\ntouch ${marker}\necho '[GNUPG:] GOODSIG fake' 1>&2\nexit 0\n`);
+    await fs.chmod(payload, 0o755);
+    await fs.appendFile(
+      path.join(repoDir, '.git', 'config'),
+      `\n[log]\n\tshowSignature = true\n[gpg]\n\tprogram = ${payload}\n`,
+    );
+
+    const raw =
+      `tree ${tree}\n` +
+      'author a <a@b.c> 1700000000 +0000\n' +
+      'committer a <a@b.c> 1700000000 +0000\n' +
+      'gpgsig -----BEGIN PGP SIGNATURE-----\n \n fake\n -----END PGP SIGNATURE-----\n\nsigned\n';
+    const rawPath = path.join(repoDir, 'rawc');
+    await fs.writeFile(rawPath, raw);
+    const commit = execFileSync('git', ['-C', repoDir, 'hash-object', '-t', 'commit', '-w', 'rawc']).toString().trim();
+    git('update-ref', 'refs/heads/main', commit);
+    git('symbolic-ref', 'HEAD', 'refs/heads/main');
+    await fs.rm(rawPath, { force: true });
+  };
+
+  const exists = async (filePath: string): Promise<boolean> => {
+    try {
+      await fs.access(filePath);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  test('execGitLogFilenames does not run gpg.program from the repo .git/config', async () => {
+    const repoDir = await fs.mkdtemp(path.join(workDir, 'repo-'));
+    markerPath = path.join(workDir, `marker-log-${path.basename(repoDir)}`);
+    await buildMaliciousRepo(repoDir, markerPath);
+
+    // Uses the real execFileAsync (no deps override), so this exercises the
+    // hardened argument list against the installed git.
+    const files = await execGitLogFilenames(repoDir, 100, { execFileAsync: realExec });
+
+    expect(await exists(markerPath)).toBe(false);
+    // The command still works — it lists the repository's files, it just does
+    // not honor the malicious signature-verification config.
+    expect(files).toContain('f.txt');
+  });
+
+  test('the same repo does execute when git runs with its config honored', async () => {
+    // Positive control: proves the payload is live and reachable by `git log` on
+    // this host, so the assertion above is testing the hardening and not a
+    // payload that quietly stopped working on this git version.
+    const repoDir = await fs.mkdtemp(path.join(workDir, 'control-'));
+    const controlMarker = path.join(workDir, `marker-control-${path.basename(repoDir)}`);
+    await buildMaliciousRepo(repoDir, controlMarker);
+
+    await realExec('git', ['-C', repoDir, 'log', '--pretty=format:', '--name-only', '-n', '100']);
+
+    expect(await exists(controlMarker)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Packing runs `git log` inside the target directory by default (`output.git.sortByChanges`), and `git diff` when `output.git.includeDiffs`/`includeLogs` are on. git honors a repository's own `.git/config` while merely reading history, so when the packed directory is not one the user created (a downloaded checkout, or an agent packing an arbitrary repo), that config can name executables git will run:

- `gpg.program` via `log.showSignature` — reported in GHSA-4p5g, reproduced end to end against `repomix` 1.18.0 (a plain `repomix` in a crafted directory wrote the payload marker with the user's privileges)
- `diff.external`, per-attribute `textconv` drivers, and `core.fsmonitor` — found firing the same way while scoping the fix

This is the same class of bug already closed for the website ZIP upload and the sandboxed MCP path; this brings the CLI's own git calls in line.

## Fix

Every git command that runs inside the target directory is hardened:

- log: `-c core.fsmonitor=` + `--no-show-signature`
- diff: `-c core.fsmonitor=` + `--no-ext-diff --no-textconv`

Command flags disable the log/diff drivers; `core.fsmonitor` has no flag so it is overridden to empty.

## Not a breaking change

Verified against git 2.53 that the hardened commands produce **byte-for-byte identical output on a legitimate repository** (both `log --name-only` and `diff`). `sortByChanges` stays on by default; nothing about normal use changes.

Flipping `sortByChanges` to default-off was considered and rejected: it degrades output quality for everyone, is itself a breaking change, and an attacker's own `repomix.config` could turn it back on — so it would not actually close the vector.

## Tests

- Updated the mocked assertions to pin the exact hardened argument lists.
- Added an end-to-end test (nothing mocked): a real repository carrying a malicious `.git/config` is pushed through `execGitLogFilenames`, asserting the payload does **not** run, with a positive control proving the payload is live on the host. Removing the hardening turns this test red.
- Full suite green: 1800 tests.

## Note on the report

The advisory claims `sortByChanges` became default-`true` only in 1.18.0; it has actually been default-`true` since v0.2.41 (2025-03-16). The report appears to have read the CLI-option schema (no default) rather than the config schema. This is a long-standing default, not a 1.18.0 regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)