### PR TITLE
chore(browser): Exclude WXT build output from biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -21,6 +21,8 @@
       "!**/website/client/.vitepress/cache",
       "!**/website/server/dist",
       "!**/browser/dist",
+      "!**/browser/.output",
+      "!**/browser/.wxt",
       "!**/browser/packages",
       "!.claude/worktrees",
       "!**/*.svg"


### PR DESCRIPTION
Adds `browser/.output` and `browser/.wxt` to biome's exclude list.

## Why

`biome.json` includes `browser/**` and excludes `browser/dist` and `browser/packages`, but not `.output/` or `.wxt/`. Both sit in the same `# Build output` block of `browser/.gitignore` as `dist/` and `packages/` — they are WXT's output from `wxt build` / `wxt zip` and `wxt prepare`.

The result: after running a browser-extension build, root `npm run lint` fails with 14 errors from `browser/.output/{edge-mv3,firefox-mv2}/background.js` — minified bundles nobody edits. CI never sees this because it does not build the extension before linting, so it only bites locally.

`.wxt/` is not failing today; it is excluded for the same reason, so a `wxt prepare` artifact cannot reintroduce the problem.

## Verification

`npm run lint` goes from 14 errors to exit 0 with the extension build present.

## Checklist

- [x] Run `npm run test` — not run; config-only change, no source touched
- [x] Run `npm run lint` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)