### PR TITLE
fix(cli): Reject split sizes below one byte

### DIFF
--- a/src/shared/sizeParse.ts
+++ b/src/shared/sizeParse.ts
@@ -19,6 +19,10 @@ export const parseHumanSizeToBytes = (input: string): number => {
   const multiplier = unit === 'kb' ? 1024 : 1024 * 1024;
   const bytes = Math.floor(amount * multiplier);
 
+  if (bytes < 1) {
+    throw new RepomixError(`Invalid size: '${input}'. Resulting size must be at least 1 byte.`);
+  }
+
   if (!Number.isSafeInteger(bytes)) {
     throw new RepomixError(`Invalid size: '${input}'. Resulting byte value is too large.`);
   }

--- a/tests/shared/sizeParse.test.ts
+++ b/tests/shared/sizeParse.test.ts
@@ -24,6 +24,10 @@ describe('parseHumanSizeToBytes', () => {
     expect(() => parseHumanSizeToBytes('1gb')).toThrow(/Invalid size/i);
   });
 
+  it('rejects positive sizes that round down to zero bytes', () => {
+    expect(() => parseHumanSizeToBytes('0.0001kb')).toThrow(/at least 1 byte/i);
+  });
+
   it('rejects values that would overflow safe integer range', () => {
     // 8589934592 is a safe integer, but 8589934592 * 1024 * 1024 = 9007199254740992 exceeds MAX_SAFE_INTEGER
     expect(() => parseHumanSizeToBytes('8589934592mb')).toThrow(/too large/i);


### PR DESCRIPTION
<!-- Please include a summary of the changes -->

## Summary

- Reject positive split-size values that floor to zero bytes after unit conversion.
- Return a clear minimum-size error instead of allowing a zero-byte threshold.
- Add a regression test for a sub-byte kilobyte value.

## Validation

- [x] Run `npm run test` (152 files, 1807 tests)
- [x] Run `npm run lint`

## Risks

- Low. Valid sizes of at least one byte are unchanged.
