### PR TITLE
fix(cli): Respect directory boundaries when classifying paths

### DIFF
--- a/src/cli/cliReport.ts
+++ b/src/cli/cliReport.ts
@@ -11,7 +11,11 @@ import { reportTokenCountTree } from './reporters/tokenCountTreeReporter.js';
  * Convert an absolute path to a relative path if it's under cwd, otherwise return as-is.
  */
 export const getDisplayPath = (absolutePath: string, cwd: string): string => {
-  return absolutePath.startsWith(cwd) ? path.relative(cwd, absolutePath) : absolutePath;
+  const relativePath = path.relative(cwd, absolutePath);
+  const isWithinCwd =
+    relativePath === '' ||
+    (relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath));
+  return isWithinCwd ? relativePath : absolutePath;
 };
 
 export interface ReportOptions {

--- a/src/cli/prompts/skillPrompts.ts
+++ b/src/cli/prompts/skillPrompts.ts
@@ -153,5 +153,9 @@ export const resolveAndPrepareSkillDir = async (skillOutput: string, cwd: string
  */
 export const getSkillLocation = (skillDir: string): SkillLocation => {
   const personalSkillsBase = getSkillBaseDir('', 'personal');
-  return skillDir.startsWith(personalSkillsBase) ? 'personal' : 'project';
+  const relativePath = path.relative(personalSkillsBase, skillDir);
+  const isPersonal =
+    relativePath === '' ||
+    (relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath));
+  return isPersonal ? 'personal' : 'project';
 };

--- a/tests/cli/cliReport.test.ts
+++ b/tests/cli/cliReport.test.ts
@@ -1,6 +1,12 @@
 import path from 'node:path';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { reportCompletion, reportSecurityCheck, reportSummary, reportTopFiles } from '../../src/cli/cliReport.js';
+import {
+  getDisplayPath,
+  reportCompletion,
+  reportSecurityCheck,
+  reportSummary,
+  reportTopFiles,
+} from '../../src/cli/cliReport.js';
 import type { SuspiciousFileResult } from '../../src/core/security/securityCheck.js';
 import type { PackResult } from '../../src/index.js';
 import { logger } from '../../src/shared/logger.js';
@@ -21,6 +27,15 @@ vi.mock('picocolors', () => ({
 describe('cliReport', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+  });
+
+  describe('getDisplayPath', () => {
+    test('should keep paths in a sibling directory with the same prefix absolute', () => {
+      const cwd = path.join(path.parse(process.cwd()).root, 'workspace', 'app');
+      const siblingPath = path.join(path.dirname(cwd), 'application', 'output.xml');
+
+      expect(getDisplayPath(siblingPath, cwd)).toBe(siblingPath);
+    });
   });
 
   describe('reportSummary', () => {

--- a/tests/cli/prompts/skillPrompts.test.ts
+++ b/tests/cli/prompts/skillPrompts.test.ts
@@ -240,5 +240,16 @@ describe('skillPrompts', () => {
       expect(getSkillLocation('/project/.claude/skills/my-skill')).toBe('project');
       expect(getSkillLocation('/some/other/path')).toBe('project');
     });
+
+    test('should not treat a sibling directory with the same prefix as personal skills', () => {
+      const personalSkillsBase = getSkillBaseDir('', 'personal');
+      const siblingPath = path.join(
+        path.dirname(personalSkillsBase),
+        `${path.basename(personalSkillsBase)}-backup`,
+        'skill',
+      );
+
+      expect(getSkillLocation(siblingPath)).toBe('project');
+    });
   });
 });


### PR DESCRIPTION
<!-- Please include a summary of the changes -->

## Summary

- Use `path.relative()` results to determine whether output and skill paths are inside their base directories.
- Keep sibling directories with matching string prefixes outside the base directory.
- Add regression tests for CLI display paths and personal skill location classification.

## Validation

- [x] Run `npm run test` (152 files, 1808 tests)
- [x] Run `npm run lint`

## Risks

- Low. Paths genuinely inside the configured base directory keep their existing behavior.
