### PR TITLE
fix(skill): Derive repository names from GitHub URLs

### DIFF
--- a/src/core/skill/skillUtils.ts
+++ b/src/core/skill/skillUtils.ts
@@ -124,6 +124,18 @@ export const extractRepoName = (url: string): string => {
     cleanUrl = cleanUrl.slice(0, -4);
   }
 
+  try {
+    const parsedUrl = new URL(cleanUrl);
+    if (parsedUrl.hostname === 'github.com' || parsedUrl.hostname === 'www.github.com') {
+      const pathParts = parsedUrl.pathname.split('/').filter(Boolean);
+      if (pathParts.length >= 2) {
+        return pathParts[1].replace(/\.git$/, '');
+      }
+    }
+  } catch {
+    // Fall through to shorthand and SSH URL handling.
+  }
+
   // Try to match the last path segment
   const lastSlashIndex = cleanUrl.lastIndexOf('/');
   if (lastSlashIndex !== -1 && lastSlashIndex < cleanUrl.length - 1) {

--- a/tests/core/skill/skillUtils.test.ts
+++ b/tests/core/skill/skillUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import {
+  extractRepoName,
   generateProjectName,
   generateProjectNameFromUrl,
   generateSkillDescription,
@@ -130,6 +131,16 @@ describe('skillUtils', () => {
 
     test('should handle trailing slash with .git suffix', () => {
       expect(generateProjectNameFromUrl('https://github.com/vitejs/vite.git/')).toBe('Vite');
+    });
+  });
+
+  describe('extractRepoName', () => {
+    test('should extract the repository name from a GitHub branch URL', () => {
+      expect(extractRepoName('https://github.com/yamadashy/repomix/tree/main')).toBe('repomix');
+    });
+
+    test('should extract the repository name from a GitHub commit URL', () => {
+      expect(extractRepoName('https://github.com/yamadashy/repomix/commit/abc123')).toBe('repomix');
     });
   });
 


### PR DESCRIPTION
<!-- Please include a summary of the changes -->

## Summary

- Parse standard GitHub URLs by owner and repository before deriving remote skill names.
- Preserve the existing shorthand and SSH URL fallbacks.
- Add regression coverage for GitHub branch and commit URLs.

## Validation

- [x] Run `npm run test` (152 files, 1808 tests)
- [x] Run `npm run lint`

## Risks

- Low. The URL-specific path only applies to `github.com`; other remote formats continue through the existing fallback logic.
