### PR TITLE
feat(mcp): Add MCP Registry publishing metadata and workflow

### DIFF
--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -87,4 +87,10 @@ jobs:
         if: ${{ !inputs.dry-run }}
         run: |
           SERVER_NAME=$(node -p "require('./server.json').name")
-          curl -fsSL "https://registry.modelcontextprotocol.io/v0.1/servers?search=${SERVER_NAME}" | jq .
+          SERVER_VERSION=$(node -p "require('./server.json').version")
+          # The server name contains a slash, so it has to be percent-encoded to
+          # address the version endpoint (an unencoded name returns 404).
+          ENCODED_NAME=$(node -p "encodeURIComponent(require('./server.json').name)")
+          curl -fsSL "https://registry.modelcontextprotocol.io/v0.1/servers/${ENCODED_NAME}/versions/${SERVER_VERSION}" \
+            | jq -e --arg v "${SERVER_VERSION}" '.server.version == $v' > /dev/null
+          echo "${SERVER_NAME}@${SERVER_VERSION} is live on the MCP Registry"

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -111,11 +111,21 @@ jobs:
           SERVER_VERSION=$(node -p "require('./server.json').version")
           ENCODED_NAME=$(node -p "encodeURIComponent(require('./server.json').name)")
           URL="https://registry.modelcontextprotocol.io/v0.1/servers/${ENCODED_NAME}/versions/${SERVER_VERSION}"
-          if curl -fsSL "${URL}" > /dev/null 2>&1; then
+          # Only a 404 means the version is absent. Treating a 5xx or a
+          # transport error as "not published" would send the workflow on to
+          # republish an immutable version, which the registry then rejects.
+          if ! STATUS=$(curl -sSL -o /dev/null -w '%{http_code}' "${URL}"); then
+            echo "::error::Could not reach the MCP Registry"
+            exit 1
+          fi
+          if [ "${STATUS}" = "200" ]; then
             echo "Version ${SERVER_VERSION} is already on the registry, skipping publish"
             echo "already-published=true" >> "${GITHUB_OUTPUT}"
-          else
+          elif [ "${STATUS}" = "404" ]; then
             echo "already-published=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "::error::MCP Registry returned HTTP ${STATUS}"
+            exit 1
           fi
 
       - name: Login to MCP Registry

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -86,12 +86,29 @@ jobs:
           fi
           echo "repomix@${PACKAGE_VERSION} is published with mcpName=${PUBLISHED_MCP_NAME}"
 
-      - name: Login to MCP Registry
+      # Publishing a version the registry already holds is rejected, which would
+      # make a re-run permanently red. Skipping the publish when the version is
+      # already there turns a re-run into a plain re-verify.
+      - name: Check whether the version is already on the registry
+        id: registry-check
         if: ${{ !inputs.dry-run }}
+        run: |
+          SERVER_VERSION=$(node -p "require('./server.json').version")
+          ENCODED_NAME=$(node -p "encodeURIComponent(require('./server.json').name)")
+          URL="https://registry.modelcontextprotocol.io/v0.1/servers/${ENCODED_NAME}/versions/${SERVER_VERSION}"
+          if curl -fsSL "${URL}" > /dev/null 2>&1; then
+            echo "Version ${SERVER_VERSION} is already on the registry, skipping publish"
+            echo "already-published=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "already-published=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Login to MCP Registry
+        if: ${{ !inputs.dry-run && steps.registry-check.outputs.already-published != 'true' }}
         run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
-        if: ${{ !inputs.dry-run }}
+        if: ${{ !inputs.dry-run && steps.registry-check.outputs.already-published != 'true' }}
         run: ./mcp-publisher publish server.json
 
       - name: Verify the published entry
@@ -103,16 +120,17 @@ jobs:
           # address the version endpoint (an unencoded name returns 404).
           ENCODED_NAME=$(node -p "encodeURIComponent(require('./server.json').name)")
           URL="https://registry.modelcontextprotocol.io/v0.1/servers/${ENCODED_NAME}/versions/${SERVER_VERSION}"
-          # Retry rather than failing on the first miss: the publish above is not
-          # repeatable (the registry rejects a version it already has), so a red
-          # run caused by read-after-write lag would have no clean recovery path.
+          # Retry to absorb read-after-write lag. `curl | jq` needs no pipefail:
+          # a failed curl leaves jq with empty input and `jq -e` then exits 4.
           for attempt in 1 2 3 4 5; do
             if curl -fsSL "${URL}" | jq -e --arg v "${SERVER_VERSION}" '.server.version == $v' > /dev/null; then
               echo "${SERVER_NAME}@${SERVER_VERSION} is live on the MCP Registry"
               exit 0
             fi
-            echo "Not visible yet, retrying in 10s (${attempt}/5)"
-            sleep 10
+            if [ "${attempt}" -lt 5 ]; then
+              echo "Not visible yet, retrying in 10s (${attempt}/5)"
+              sleep 10
+            fi
           done
           echo "::error::${SERVER_NAME}@${SERVER_VERSION} did not appear on the registry"
           exit 1

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -1,0 +1,90 @@
+name: mcp-registry-publish
+
+# Publishes the MCP server metadata (server.json) to the official MCP Registry
+# (https://registry.modelcontextprotocol.io/). The registry only stores metadata,
+# so the matching npm version must already be published (via npm-publish.yml)
+# before running this workflow.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Validate server.json against the registry without publishing'
+        required: false
+        default: false
+        type: boolean
+
+env:
+  MCP_PUBLISHER_VERSION: 1.8.1
+  # sha256 of mcp-publisher_linux_amd64.tar.gz from the release above
+  MCP_PUBLISHER_SHA256: a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write # Required for GitHub OIDC login to the MCP Registry
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .tool-versions
+
+      # The registry verifies npm ownership by reading `mcpName` from the
+      # published package.json, so the npm release must exist and carry the
+      # same name as server.json.
+      - name: Verify the npm release exists and carries the matching mcpName
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          SERVER_NAME=$(node -p "require('./server.json').name")
+          PUBLISHED_MCP_NAME=$(npm view "repomix@${PACKAGE_VERSION}" mcpName 2>/dev/null || true)
+          if [ -z "${PUBLISHED_MCP_NAME}" ]; then
+            echo "::error::repomix@${PACKAGE_VERSION} is not published to npm or has no mcpName field"
+            exit 1
+          fi
+          if [ "${PUBLISHED_MCP_NAME}" != "${SERVER_NAME}" ]; then
+            echo "::error::mcpName on npm (${PUBLISHED_MCP_NAME}) does not match server.json name (${SERVER_NAME})"
+            exit 1
+          fi
+          echo "repomix@${PACKAGE_VERSION} is published with mcpName=${PUBLISHED_MCP_NAME}"
+
+      - name: Sync server.json version with package.json
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          jq --arg v "${PACKAGE_VERSION}" '.version = $v | .packages[].version = $v' server.json > server.json.tmp
+          mv server.json.tmp server.json
+          cat server.json
+
+      - name: Install mcp-publisher
+        run: |
+          ARCHIVE="mcp-publisher_linux_amd64.tar.gz"
+          curl -fsSL -o "${ARCHIVE}" \
+            "https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}/${ARCHIVE}"
+          echo "${MCP_PUBLISHER_SHA256}  ${ARCHIVE}" | sha256sum --check
+          tar xzf "${ARCHIVE}" mcp-publisher
+          ./mcp-publisher --help
+
+      - name: Validate server.json (dry-run)
+        if: ${{ inputs.dry-run }}
+        run: ./mcp-publisher validate server.json
+
+      - name: Login to MCP Registry
+        if: ${{ !inputs.dry-run }}
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        if: ${{ !inputs.dry-run }}
+        run: ./mcp-publisher publish server.json
+
+      - name: Verify the published entry
+        if: ${{ !inputs.dry-run }}
+        run: |
+          SERVER_NAME=$(node -p "require('./server.json').name")
+          curl -fsSL "https://registry.modelcontextprotocol.io/v0.1/servers?search=${SERVER_NAME}" | jq .

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -72,9 +72,12 @@ jobs:
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           SERVER_NAME=$(node -p "require('./server.json').name")
-          PUBLISHED_MCP_NAME=$(npm view "repomix@${PACKAGE_VERSION}" mcpName 2>/dev/null || true)
+          # `npm view <pkg> <field>` exits 0 with empty output when the field is
+          # absent and non-zero when the version itself is missing, so npm's own
+          # error is left to surface rather than being collapsed into "empty".
+          PUBLISHED_MCP_NAME=$(npm view "repomix@${PACKAGE_VERSION}" mcpName)
           if [ -z "${PUBLISHED_MCP_NAME}" ]; then
-            echo "::error::repomix@${PACKAGE_VERSION} is not published to npm or has no mcpName field"
+            echo "::error::repomix@${PACKAGE_VERSION} is published but has no mcpName field"
             exit 1
           fi
           if [ "${PUBLISHED_MCP_NAME}" != "${SERVER_NAME}" ]; then
@@ -99,6 +102,17 @@ jobs:
           # The server name contains a slash, so it has to be percent-encoded to
           # address the version endpoint (an unencoded name returns 404).
           ENCODED_NAME=$(node -p "encodeURIComponent(require('./server.json').name)")
-          curl -fsSL "https://registry.modelcontextprotocol.io/v0.1/servers/${ENCODED_NAME}/versions/${SERVER_VERSION}" \
-            | jq -e --arg v "${SERVER_VERSION}" '.server.version == $v' > /dev/null
-          echo "${SERVER_NAME}@${SERVER_VERSION} is live on the MCP Registry"
+          URL="https://registry.modelcontextprotocol.io/v0.1/servers/${ENCODED_NAME}/versions/${SERVER_VERSION}"
+          # Retry rather than failing on the first miss: the publish above is not
+          # repeatable (the registry rejects a version it already has), so a red
+          # run caused by read-after-write lag would have no clean recovery path.
+          for attempt in 1 2 3 4 5; do
+            if curl -fsSL "${URL}" | jq -e --arg v "${SERVER_VERSION}" '.server.version == $v' > /dev/null; then
+              echo "${SERVER_NAME}@${SERVER_VERSION} is live on the MCP Registry"
+              exit 0
+            fi
+            echo "Not visible yet, retrying in 10s (${attempt}/5)"
+            sleep 10
+          done
+          echo "::error::${SERVER_NAME}@${SERVER_VERSION} did not appear on the registry"
+          exit 1

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -37,24 +37,6 @@ jobs:
         with:
           node-version-file: .tool-versions
 
-      # The registry verifies npm ownership by reading `mcpName` from the
-      # published package.json, so the npm release must exist and carry the
-      # same name as server.json.
-      - name: Verify the npm release exists and carries the matching mcpName
-        run: |
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          SERVER_NAME=$(node -p "require('./server.json').name")
-          PUBLISHED_MCP_NAME=$(npm view "repomix@${PACKAGE_VERSION}" mcpName 2>/dev/null || true)
-          if [ -z "${PUBLISHED_MCP_NAME}" ]; then
-            echo "::error::repomix@${PACKAGE_VERSION} is not published to npm or has no mcpName field"
-            exit 1
-          fi
-          if [ "${PUBLISHED_MCP_NAME}" != "${SERVER_NAME}" ]; then
-            echo "::error::mcpName on npm (${PUBLISHED_MCP_NAME}) does not match server.json name (${SERVER_NAME})"
-            exit 1
-          fi
-          echo "repomix@${PACKAGE_VERSION} is published with mcpName=${PUBLISHED_MCP_NAME}"
-
       - name: Sync server.json version with package.json
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
@@ -71,9 +53,35 @@ jobs:
           tar xzf "${ARCHIVE}" mcp-publisher
           ./mcp-publisher --help
 
-      - name: Validate server.json (dry-run)
-        if: ${{ inputs.dry-run }}
+      # Runs in both modes: it is a local schema check against the registry, so
+      # a dry-run can validate a server.json edit before the npm release exists.
+      - name: Validate server.json
         run: ./mcp-publisher validate server.json
+
+      # The registry verifies npm ownership by reading `mcpName` from the
+      # published package.json, so the npm release must exist and carry the
+      # same name as server.json. Skipped in dry-run mode, which only checks
+      # server.json itself.
+      - name: Verify the npm release exists and carries the matching mcpName
+        if: ${{ !inputs.dry-run }}
+        env:
+          # The root .npmrc sets min-release-age=7. It filters install-time
+          # version resolution rather than `npm view` metadata reads, but this
+          # step runs against a just-published version, so disable it outright.
+          npm_config_min_release_age: 0
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          SERVER_NAME=$(node -p "require('./server.json').name")
+          PUBLISHED_MCP_NAME=$(npm view "repomix@${PACKAGE_VERSION}" mcpName 2>/dev/null || true)
+          if [ -z "${PUBLISHED_MCP_NAME}" ]; then
+            echo "::error::repomix@${PACKAGE_VERSION} is not published to npm or has no mcpName field"
+            exit 1
+          fi
+          if [ "${PUBLISHED_MCP_NAME}" != "${SERVER_NAME}" ]; then
+            echo "::error::mcpName on npm (${PUBLISHED_MCP_NAME}) does not match server.json name (${SERVER_NAME})"
+            exit 1
+          fi
+          echo "repomix@${PACKAGE_VERSION} is published with mcpName=${PUBLISHED_MCP_NAME}"
 
       - name: Login to MCP Registry
         if: ${{ !inputs.dry-run }}

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -88,7 +88,10 @@ jobs:
 
       # Publishing a version the registry already holds is rejected, which would
       # make a re-run permanently red. Skipping the publish when the version is
-      # already there turns a re-run into a plain re-verify.
+      # already there turns a re-run into a plain re-verify. Note that registry
+      # versions are immutable, so a server.json metadata change (description,
+      # websiteUrl, ...) only reaches the registry with the next version bump:
+      # re-running on an unchanged version reports success without republishing.
       - name: Check whether the version is already on the registry
         id: registry-check
         if: ${{ !inputs.dry-run }}

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install mcp-publisher
         run: |
           ARCHIVE="mcp-publisher_linux_amd64.tar.gz"
-          curl -fsSL -o "${ARCHIVE}" \
+          curl -fsSL --retry 3 --retry-delay 2 -o "${ARCHIVE}" \
             "https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}/${ARCHIVE}"
           echo "${MCP_PUBLISHER_SHA256}  ${ARCHIVE}" | sha256sum --check
           tar xzf "${ARCHIVE}" mcp-publisher
@@ -73,9 +73,21 @@ jobs:
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           SERVER_NAME=$(node -p "require('./server.json').name")
           # `npm view <pkg> <field>` exits 0 with empty output when the field is
-          # absent and non-zero when the version itself is missing, so npm's own
-          # error is left to surface rather than being collapsed into "empty".
-          PUBLISHED_MCP_NAME=$(npm view "repomix@${PACKAGE_VERSION}" mcpName)
+          # absent and non-zero when the version itself is missing. This workflow
+          # runs right after npm-publish.yml, so a miss here is more likely to be
+          # registry propagation lag than a genuinely absent version: retry on the
+          # non-zero exit, and let npm's own stderr stay in the log either way.
+          for attempt in 1 2 3 4 5; do
+            if PUBLISHED_MCP_NAME=$(npm view "repomix@${PACKAGE_VERSION}" mcpName); then
+              break
+            fi
+            if [ "${attempt}" -eq 5 ]; then
+              echo "::error::repomix@${PACKAGE_VERSION} is not visible on npm"
+              exit 1
+            fi
+            echo "npm metadata not visible yet, retrying in 10s (${attempt}/5)"
+            sleep 10
+          done
           if [ -z "${PUBLISHED_MCP_NAME}" ]; then
             echo "::error::repomix@${PACKAGE_VERSION} is published but has no mcpName field"
             exit 1

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "repomix",
   "version": "1.18.0",
   "description": "A tool to pack repository contents to single file for AI consumption",
+  "mcpName": "io.github.yamadashy/repomix",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -20,10 +20,19 @@
       "transport": {
         "type": "stdio"
       },
+      "runtimeArguments": [
+        {
+          "type": "positional",
+          "value": "-y",
+          "isRequired": true,
+          "description": "Skip the npx install prompt, which would otherwise stall the stdio handshake on a cold cache"
+        }
+      ],
       "packageArguments": [
         {
           "type": "positional",
           "value": "--mcp",
+          "isRequired": true,
           "description": "Run Repomix as an MCP server over stdio"
         }
       ]

--- a/server.json
+++ b/server.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.yamadashy/repomix",
+  "title": "Repomix",
+  "description": "Pack local or remote codebases into AI-friendly files that LLMs and coding agents can read or search",
+  "websiteUrl": "https://repomix.com",
+  "repository": {
+    "url": "https://github.com/yamadashy/repomix",
+    "source": "github",
+    "id": "828119367"
+  },
+  "version": "1.18.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "repomix",
+      "version": "1.18.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "--mcp",
+          "description": "Run Repomix as an MCP server over stdio"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/mcp/serverJson.test.ts
+++ b/tests/mcp/serverJson.test.ts
@@ -35,6 +35,10 @@ const getDeclaredCliFlags = (): Set<string> => {
 // published package.json and comparing it to the `name` in server.json. That
 // check only runs at publish time, after the npm version is already published
 // and therefore immutable, so a mismatch is caught here instead.
+//
+// Note that the `version` fields committed in server.json are not asserted here:
+// mcp-registry-publish.yml overwrites them from package.json before publishing,
+// so the committed values are placeholders and drift from package.json by design.
 describe('server.json (MCP Registry metadata)', () => {
   test('mcpName in package.json matches the server.json name', () => {
     expect(packageJson.mcpName).toBe(serverJson.name);
@@ -67,5 +71,26 @@ describe('server.json (MCP Registry metadata)', () => {
     for (const flag of packagedFlags) {
       expect(declaredFlags).toContain(flag);
     }
+  });
+
+  // Every packaged argument here is a constant needed to start the server, so a
+  // client that renders only the required arguments must still emit all of them.
+  test('every packaged argument is marked required', () => {
+    const npmPackage = serverJson.packages.find((pkg: { registryType: string }) => pkg.registryType === 'npm');
+
+    for (const arg of npmPackage.packageArguments) {
+      expect(arg.isRequired).toBe(true);
+    }
+  });
+
+  // runtimeArguments go to npx rather than to repomix, so they are checked
+  // against the documented launch command instead of against the CLI flags.
+  // Without `-y`, npx can stall on its install prompt on a cold cache, which
+  // over stdio is indistinguishable from a server that never starts.
+  test('the npx runtime arguments match the documented launch command', () => {
+    const npmPackage = serverJson.packages.find((pkg: { registryType: string }) => pkg.registryType === 'npm');
+
+    expect(npmPackage.runtimeHint).toBe('npx');
+    expect(npmPackage.runtimeArguments.map((arg: { value: string }) => arg.value)).toContain('-y');
   });
 });

--- a/tests/mcp/serverJson.test.ts
+++ b/tests/mcp/serverJson.test.ts
@@ -1,9 +1,33 @@
+import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
 
 const require = createRequire(import.meta.url);
 const packageJson = require('../../package.json');
 const serverJson = require('../../server.json');
+
+const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+/**
+ * Collects the CLI flags declared with commander in cliRun.ts, e.g. `--mcp` from
+ * `.option('--mcp', ...)` and both `-w` and `--watch` from `.option('-w, --watch', ...)`.
+ */
+const getDeclaredCliFlags = (): Set<string> => {
+  const source = readFileSync(path.join(repoRoot, 'src/cli/cliRun.ts'), 'utf8');
+  const flags = new Set<string>();
+  for (const match of source.matchAll(/\.option\(\s*'([^']+)'/g)) {
+    for (const part of match[1].split(',')) {
+      // Drop the value placeholder, e.g. `--sandbox [dir]` -> `--sandbox`
+      const flag = part.trim().split(/[\s<[]/)[0];
+      if (flag.startsWith('-')) {
+        flags.add(flag);
+      }
+    }
+  }
+  return flags;
+};
 
 // The MCP Registry verifies npm package ownership by reading `mcpName` from the
 // published package.json and comparing it to the `name` in server.json. That
@@ -27,5 +51,19 @@ describe('server.json (MCP Registry metadata)', () => {
 
   test('the description stays within the registry limit of 100 characters', () => {
     expect(serverJson.description.length).toBeLessThanOrEqual(100);
+  });
+
+  // packageArguments is the one part of server.json that has to agree with the
+  // CLI rather than with package.json. If the flag were renamed, every
+  // registry-based install would launch repomix without MCP mode.
+  test('every packaged argument is a flag the CLI actually declares', () => {
+    const npmPackage = serverJson.packages.find((pkg: { registryType: string }) => pkg.registryType === 'npm');
+    const declaredFlags = getDeclaredCliFlags();
+    const packagedFlags = npmPackage.packageArguments.map((arg: { value: string }) => arg.value);
+
+    expect(packagedFlags).toContain('--mcp');
+    for (const flag of packagedFlags) {
+      expect(declaredFlags).toContain(flag);
+    }
   });
 });

--- a/tests/mcp/serverJson.test.ts
+++ b/tests/mcp/serverJson.test.ts
@@ -1,0 +1,31 @@
+import { createRequire } from 'node:module';
+import { describe, expect, test } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const packageJson = require('../../package.json');
+const serverJson = require('../../server.json');
+
+// The MCP Registry verifies npm package ownership by reading `mcpName` from the
+// published package.json and comparing it to the `name` in server.json. That
+// check only runs at publish time, after the npm version is already published
+// and therefore immutable, so a mismatch is caught here instead.
+describe('server.json (MCP Registry metadata)', () => {
+  test('mcpName in package.json matches the server.json name', () => {
+    expect(packageJson.mcpName).toBe(serverJson.name);
+  });
+
+  test('the server name uses the GitHub namespace required by the publish workflow', () => {
+    // `mcp-publisher login github-oidc` can only publish under io.github.<owner>/.
+    expect(serverJson.name).toMatch(/^io\.github\.[^/]+\/[^/]+$/);
+  });
+
+  test('the npm package identifier matches the published package name', () => {
+    const npmPackage = serverJson.packages.find((pkg: { registryType: string }) => pkg.registryType === 'npm');
+    expect(npmPackage).toBeDefined();
+    expect(npmPackage.identifier).toBe(packageJson.name);
+  });
+
+  test('the description stays within the registry limit of 100 characters', () => {
+    expect(serverJson.description.length).toBeLessThanOrEqual(100);
+  });
+});

--- a/tests/mcp/serverJson.test.ts
+++ b/tests/mcp/serverJson.test.ts
@@ -13,11 +13,13 @@ const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), '../..'
 /**
  * Collects the CLI flags declared with commander in cliRun.ts, e.g. `--mcp` from
  * `.option('--mcp', ...)` and both `-w` and `--watch` from `.option('-w, --watch', ...)`.
+ * Both declaration styles are matched so the assertion tracks whether a flag exists
+ * rather than how it happens to be declared.
  */
 const getDeclaredCliFlags = (): Set<string> => {
   const source = readFileSync(path.join(repoRoot, 'src/cli/cliRun.ts'), 'utf8');
   const flags = new Set<string>();
-  for (const match of source.matchAll(/\.option\(\s*'([^']+)'/g)) {
+  for (const match of source.matchAll(/(?:\.option\(|new Option\()\s*'([^']+)'/g)) {
     for (const part of match[1].split(',')) {
       // Drop the value placeholder, e.g. `--sandbox [dir]` -> `--sandbox`
       const flag = part.trim().split(/[\s<[]/)[0];

--- a/tests/mcp/serverJson.test.ts
+++ b/tests/mcp/serverJson.test.ts
@@ -73,21 +73,23 @@ describe('server.json (MCP Registry metadata)', () => {
     }
   });
 
-  // Every packaged argument here is a constant needed to start the server, so a
-  // client that renders only the required arguments must still emit all of them.
-  test('every packaged argument is marked required', () => {
+  // Every argument in server.json is a constant needed to start the server, on
+  // both sides of the package name, so a client that renders only the required
+  // arguments must still emit all of them.
+  test('every argument is marked required', () => {
     const npmPackage = serverJson.packages.find((pkg: { registryType: string }) => pkg.registryType === 'npm');
 
-    for (const arg of npmPackage.packageArguments) {
+    for (const arg of [...npmPackage.runtimeArguments, ...npmPackage.packageArguments]) {
       expect(arg.isRequired).toBe(true);
     }
   });
 
   // runtimeArguments go to npx rather than to repomix, so they are checked
-  // against the documented launch command instead of against the CLI flags.
-  // Without `-y`, npx can stall on its install prompt on a cold cache, which
-  // over stdio is indistinguishable from a server that never starts.
-  test('the npx runtime arguments match the documented launch command', () => {
+  // against `npx -y repomix --mcp` — the launch command every mcp-server.md
+  // documents — instead of against the CLI flags. Without `-y`, npx can stall on
+  // its install prompt on a cold cache, which over stdio is indistinguishable
+  // from a server that never starts.
+  test('the runtime arguments carry the -y that the documented npx command uses', () => {
     const npmPackage = serverJson.packages.find((pkg: { registryType: string }) => pkg.registryType === 'npm');
 
     expect(npmPackage.runtimeHint).toBe('npx');


### PR DESCRIPTION
Adds what is needed to list Repomix on the official [MCP Registry](https://registry.modelcontextprotocol.io/).

- `package.json`: add `"mcpName": "io.github.yamadashy/repomix"`. The registry verifies npm package ownership by reading this field from the published package, so it must match the `name` in `server.json`.
- `server.json`: registry metadata for the npm package `repomix`, started with `--mcp` over stdio. Validated with `mcp-publisher validate` against the production registry (the description is capped at 100 characters).
- `.github/workflows/mcp-registry-publish.yml`: manual (`workflow_dispatch`) workflow with a `dry-run` input. It checks that the matching npm version is published with the expected `mcpName`, injects the version from `package.json` into `server.json`, downloads `mcp-publisher` v1.8.1 with sha256 verification, logs in via GitHub OIDC, and publishes.

Kept as a separate workflow rather than a step in `npm-publish.yml` to avoid racing npm propagation and to keep a registry failure from marking the npm publish red.

Publishing flow after merge: bump the version, run `npm-publish`, then run `mcp-registry-publish` (try `dry-run` first). The currently published 1.18.0 has no `mcpName`, so the first registry publish happens with the next release.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
