### PR TITLE
fix(core): Preserve data URI parameters when truncating base64

### DIFF
--- a/src/core/file/truncateBase64.ts
+++ b/src/core/file/truncateBase64.ts
@@ -7,7 +7,7 @@ const MIN_CHAR_TYPE_COUNT = 3;
 
 // Pre-compiled regex patterns (avoid re-creation per file)
 const dataUriPattern = new RegExp(
-  `data:([a-zA-Z0-9\\/\\-\\+]+)(;[a-zA-Z0-9\\-=]+)*;base64,([A-Za-z0-9+/=]{${MIN_BASE64_LENGTH_DATA_URI},})`,
+  `data:([a-zA-Z0-9\\/\\-\\+]+)((?:;[a-zA-Z0-9\\-=]+)*);base64,([A-Za-z0-9+/=]{${MIN_BASE64_LENGTH_DATA_URI},})`,
   'g',
 );
 const standaloneBase64Pattern = new RegExp(`([A-Za-z0-9+/]{${MIN_BASE64_LENGTH_STANDALONE},}={0,2})`, 'g');

--- a/tests/core/file/truncateBase64.test.ts
+++ b/tests/core/file/truncateBase64.test.ts
@@ -20,6 +20,12 @@ describe('truncateBase64Content', () => {
     expect(result).toBe('src="data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53..."');
   });
 
+  it('should preserve all data URI parameters when truncating base64 payloads', () => {
+    const input = `src="data:image/svg+xml;charset=utf-8;foo=bar;base64,${longBase64}"`;
+    const result = truncateBase64Content(input);
+    expect(result).toBe('src="data:image/svg+xml;charset=utf-8;foo=bar;base64,DTJXfKHG6xA1Wn+kye4TOF2Cp8zxFjtg..."');
+  });
+
   it('should truncate standalone base64 strings longer than 256 chars', () => {
     const input = `const data = "${longBase64}";`;
     const result = truncateBase64Content(input);


### PR DESCRIPTION
Fixes #1819

## Summary

- Preserve the full data URI parameter run before `;base64,` when truncating long base64 payloads.
- Add regression coverage for data URIs with multiple parameters.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`
