### PR TITLE
fix(output): scope split directory trees to each part

### DIFF
--- a/src/core/output/outputSplit.ts
+++ b/src/core/output/outputSplit.ts
@@ -7,6 +7,7 @@ import type { FilesByRoot } from '../file/fileTreeGenerate.js';
 import type { ProcessedFile } from '../file/fileTypes.js';
 import type { GitDiffResult } from '../git/gitDiffHandle.js';
 import type { GitLogResult } from '../git/gitLogHandle.js';
+import { joinDisplayPath } from '../packager/rootDisplayPath.js';
 import type { generateOutput } from './outputGenerate.js';
 
 export interface OutputSplitGroup {
@@ -151,6 +152,11 @@ const renderGroups = async (
   const chunkProcessedFiles = groupsToRender.flatMap((g) => g.processedFiles);
   const chunkAllFilePaths = groupsToRender.flatMap((g) => g.allFilePaths);
   const chunkConfig = makeChunkConfig(baseConfig, partIndex);
+  const chunkFilePathSet = new Set(chunkAllFilePaths);
+  const chunkFilePathsByRoot = filePathsByRoot?.map(({ rootLabel, files }) => ({
+    rootLabel,
+    files: files.filter((file) => chunkFilePathSet.has(rootDirs.length > 1 ? joinDisplayPath(rootLabel, file) : file)),
+  }));
 
   return await generateOutput(
     rootDirs,
@@ -159,7 +165,7 @@ const renderGroups = async (
     chunkAllFilePaths,
     partIndex === 1 ? gitDiffResult : undefined,
     partIndex === 1 ? gitLogResult : undefined,
-    filePathsByRoot,
+    chunkFilePathsByRoot,
     emptyDirPaths,
   );
 };

--- a/tests/core/output/outputSplit.test.ts
+++ b/tests/core/output/outputSplit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { generateOutput } from '../../../src/core/output/outputGenerate.js';
 import {
   buildOutputSplitGroups,
   buildSplitOutputFilePath,
@@ -6,6 +7,7 @@ import {
   getRootEntry,
   subdivideSplitGroup,
 } from '../../../src/core/output/outputSplit.js';
+import { createMockConfig as createMergedConfig } from '../../testing/testUtils.js';
 
 describe('outputSplit', () => {
   describe('getRootEntry', () => {
@@ -114,6 +116,84 @@ describe('outputSplit', () => {
 
     const createMockDeps = (outputSize: number) => ({
       generateOutput: async () => 'x'.repeat(outputSize),
+    });
+
+    const getDirectoryTree = (content: string): string => {
+      const match = content.match(/Directory Structure\n=+\n([\s\S]*?)\n\n=+\nFiles/);
+      expect(match).not.toBeNull();
+      return match?.[1].trim() ?? '';
+    };
+
+    it('scopes each part directory tree to the files in that part', async () => {
+      const processedFiles = ['a/file.txt', 'b/file.txt', 'c/file.txt'].map((filePath, index) => ({
+        path: filePath,
+        content: String.fromCharCode(65 + index).repeat(2000),
+      }));
+      const allFilePaths = processedFiles.map((file) => file.path);
+      const baseConfig = createMergedConfig({
+        output: {
+          filePath: 'repomix-output.txt',
+          style: 'plain',
+          git: { sortByChanges: false, includeDiffs: false, includeLogs: false },
+        },
+      });
+
+      const result = await generateSplitOutputParts({
+        rootDirs: ['/repo'],
+        baseConfig,
+        processedFiles,
+        allFilePaths,
+        maxBytesPerPart: 5000,
+        gitDiffResult: undefined,
+        gitLogResult: undefined,
+        progressCallback: () => {},
+        filePathsByRoot: [{ rootLabel: 'repo', files: allFilePaths }],
+        deps: { generateOutput },
+      });
+
+      expect(result).toHaveLength(3);
+      expect(result.map((part) => getDirectoryTree(part.content))).toEqual([
+        'a/\n  file.txt',
+        'b/\n  file.txt',
+        'c/\n  file.txt',
+      ]);
+    });
+
+    it('preserves multi-root labels while scoping split directory trees', async () => {
+      const processedFiles = ['root-a/file.txt', 'root-b/file.txt'].map((filePath, index) => ({
+        path: filePath,
+        content: String.fromCharCode(65 + index).repeat(2000),
+      }));
+      const allFilePaths = processedFiles.map((file) => file.path);
+      const baseConfig = createMergedConfig({
+        output: {
+          filePath: 'repomix-output.txt',
+          style: 'plain',
+          git: { sortByChanges: false, includeDiffs: false, includeLogs: false },
+        },
+      });
+
+      const result = await generateSplitOutputParts({
+        rootDirs: ['/root-a', '/root-b'],
+        baseConfig,
+        processedFiles,
+        allFilePaths,
+        maxBytesPerPart: 5000,
+        gitDiffResult: undefined,
+        gitLogResult: undefined,
+        progressCallback: () => {},
+        filePathsByRoot: [
+          { rootLabel: 'root-a', files: ['file.txt'] },
+          { rootLabel: 'root-b', files: ['file.txt'] },
+        ],
+        deps: { generateOutput },
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result.map((part) => getDirectoryTree(part.content))).toEqual([
+        '[root-a]/\n  file.txt',
+        '[root-b]/\n  file.txt',
+      ]);
     });
 
     it('throws error when a single indivisible file exceeds maxBytesPerPart', async () => {


### PR DESCRIPTION
Fixes #1815.

## Summary

- Filter each root's file list against the files assigned to the current split part before rendering its directory structure.
- Preserve the full root mapping so multi-root outputs keep their root labels while empty roots are omitted from the rendered tree.
- Add regression coverage for both single-root and multi-root split output.

## Validation

- `npx vitest run tests/core/output/outputSplit.test.ts` (16 tests)
- `npx vitest run tests/core/output tests/core/packager` (155 tests)
- `npm run test -- --run` (1808 tests)
- `npm run lint`
- `npm run build`

The change only affects directory-tree metadata for split output. File contents, split grouping and size limits, single-file output, and git sections are unchanged.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`