### PR TITLE
fix(security): Keep dependency code out of the npm-publishing job

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,13 +6,16 @@ name: npm-publish
 #   tree (vitest, the linters' native binaries, everything `src/` imports),
 #   so it holds no publish permission and never touches the tarball.
 # - build produces the tarball. It only runs `npm ci` and `npm pack`, so the
-#   code that can reach the package contents is limited to npm itself, the
-#   install scripts, and the TypeScript compiler. Dev-only dependencies have
-#   no other path to end users, which is why they are kept out of this job.
+#   code that executes there is limited to npm itself, the install scripts,
+#   and `prepare` (rimraf + tsc, run by both commands). The full dependency
+#   tree is still installed, but no other dev-only dependency is executed,
+#   and executing here is their only path to the package contents.
 # - publish holds `id-token: write`. That permission puts the OIDC minting
 #   credentials in the job environment, and anything running there can
-#   exchange them for an npm publish token, so this job runs nothing but
-#   `npm publish` on the tarball the build job handed over.
+#   exchange them for an npm publish token. This job therefore has no
+#   checkout and no `npm ci`: apart from the artifact download and Node setup
+#   actions, it only verifies the tarball digest and the npm version, then
+#   runs `npm publish` on the tarball.
 
 on:
   workflow_dispatch:
@@ -45,8 +48,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # `lint` runs biome and oxlint in write mode. The build job packs the
+      # committed tree from its own checkout, so any auto-fix here would mean
+      # the tested code and the published code differ: fail instead, as ci.yml
+      # does.
       - name: Lint
-        run: node --run lint
+        run: node --run lint && git diff --exit-code
 
       - name: Test
         run: node --run test-coverage

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,10 +1,18 @@
 name: npm-publish
 
-# Split into two jobs on purpose: `id-token: write` puts the OIDC minting
-# credentials in the job environment, and anything running there can exchange
-# them for an npm publish token. The build job installs and runs ~400 packages
-# (npm ci, lint, tests, build) and therefore must not hold that permission; the
-# publish job holds it and runs nothing but `npm publish` on the packed tarball.
+# Split into three jobs on purpose:
+#
+# - check runs lint and the test suite. This executes the whole dependency
+#   tree (vitest, the linters' native binaries, everything `src/` imports),
+#   so it holds no publish permission and never touches the tarball.
+# - build produces the tarball. It only runs `npm ci` and `npm pack`, so the
+#   code that can reach the package contents is limited to npm itself, the
+#   install scripts, and the TypeScript compiler. Dev-only dependencies have
+#   no other path to end users, which is why they are kept out of this job.
+# - publish holds `id-token: write`. That permission puts the OIDC minting
+#   credentials in the job environment, and anything running there can
+#   exchange them for an npm publish token, so this job runs nothing but
+#   `npm publish` on the tarball the build job handed over.
 
 on:
   workflow_dispatch:
@@ -18,6 +26,31 @@ on:
 permissions: {}
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .tool-versions
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: node --run lint
+
+      - name: Test
+        run: node --run test-coverage
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -67,15 +100,6 @@ jobs:
           fi
           echo "Version ${PACKAGE_VERSION} is not yet published"
 
-      - name: Lint
-        run: node --run lint
-
-      - name: Test
-        run: node --run test-coverage
-
-      - name: Build
-        run: node --run build
-
       - name: Verify npm audit signatures
         run: npm audit signatures
         env:
@@ -83,9 +107,9 @@ jobs:
           npm_config_min_release_age: 0
 
       # Runs prepack + prepare (`npm run build`) + postpack, the same lifecycle
-      # scripts `npm publish` from the directory runs today. Publishing the
-      # resulting tarball streams it verbatim, so the package contents are
-      # unchanged by the split.
+      # scripts `npm publish` from the directory runs today, so there is no
+      # separate build step. Publishing the resulting tarball streams it
+      # verbatim, so the package contents are unchanged by the split.
       - name: Pack
         id: pack
         env:
@@ -104,7 +128,9 @@ jobs:
           retention-days: 1
 
   publish:
-    needs: build
+    # `check` is the only thing gating the publish on lint and tests passing:
+    # the build job no longer runs them, so it must stay listed here.
+    needs: [build, check]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,5 +1,11 @@
 name: npm-publish
 
+# Split into two jobs on purpose: `id-token: write` puts the OIDC minting
+# credentials in the job environment, and anything running there can exchange
+# them for an npm publish token. The build job installs and runs ~400 packages
+# (npm ci, lint, tests, build) and therefore must not hold that permission; the
+# publish job holds it and runs nothing but `npm publish` on the packed tarball.
+
 on:
   workflow_dispatch:
     inputs:
@@ -9,13 +15,17 @@ on:
         default: false
         type: boolean
 
+permissions: {}
+
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
-      id-token: write # Required for OIDC trusted publishing
+    outputs:
+      node-version: ${{ steps.meta.outputs.node-version }}
+      tarball: ${{ steps.meta.outputs.tarball }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -26,17 +36,26 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .tool-versions
-          registry-url: 'https://registry.npmjs.org'
 
-      - name: Update npm to latest version
-        run: npm install -g npm@latest
+      # The publish job has no checkout, so the values it needs are passed as
+      # job outputs rather than read from the working tree.
+      - name: Resolve versions
+        id: meta
+        run: |
+          NODE_VERSION=$(sed -n 's/^nodejs[[:space:]]\{1,\}//p' .tool-versions)
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          test -n "${NODE_VERSION}"
+          echo "node-version=${NODE_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "package-version=${PACKAGE_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "tarball=repomix-${PACKAGE_VERSION}.tgz" >> "${GITHUB_OUTPUT}"
 
       - name: Install dependencies
         run: npm ci
 
       - name: Check if version already published
+        env:
+          PACKAGE_VERSION: ${{ steps.meta.outputs.package-version }}
         run: |
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
           if npm view "repomix@${PACKAGE_VERSION}" version 2>/dev/null; then
             echo "::error::Version ${PACKAGE_VERSION} is already published to npm"
             exit 1
@@ -58,10 +77,65 @@ jobs:
           # Disable min-release-age during audit to avoid ETARGET errors for recently published dependencies
           npm_config_min_release_age: 0
 
+      # Runs prepack + prepare (`npm run build`) + postpack, the same lifecycle
+      # scripts `npm publish` from the directory runs today. Publishing the
+      # resulting tarball streams it verbatim, so the package contents are
+      # unchanged by the split.
+      - name: Pack
+        env:
+          TARBALL: ${{ steps.meta.outputs.tarball }}
+        run: |
+          npm pack --pack-destination .
+          test -f "${TARBALL}"
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-tarball
+          path: ${{ steps.meta.outputs.tarball }}
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write # Required for OIDC trusted publishing
+    steps:
+      # Deliberately no actions/checkout and no `npm ci`: provenance is derived
+      # from the GitHub Actions environment (GITHUB_WORKFLOW_REF, GITHUB_SHA,
+      # ...), never from a .git directory, so this job needs no repository
+      # contents and runs no third-party code.
+      - name: Download tarball
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-tarball
+          path: .
+
+      # Node 24.15.0 bundles npm 11.12.1, which covers trusted publishing
+      # (>= 11.5.1) and provenance (>= 9.5.0), so no global npm install is
+      # needed here. Trusted publishing matches on the workflow filename, not
+      # the job, so splitting the file into two jobs needs no npm-side change.
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ needs.build.outputs.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      # `--provenance` is passed explicitly: trusted publishing auto-enables it,
+      # but that path is wrapped in a try/catch and would fail silently, leaving
+      # the release unattested.
       - name: Publish (dry-run)
         if: ${{ inputs.dry-run }}
-        run: npm publish --provenance --access public --dry-run
+        env:
+          TARBALL: ${{ needs.build.outputs.tarball }}
+        run: npm publish "./${TARBALL}" --provenance --access public --dry-run
 
       - name: Publish
         if: ${{ !inputs.dry-run }}
-        run: npm publish --provenance --access public
+        env:
+          TARBALL: ${{ needs.build.outputs.tarball }}
+        run: npm publish "./${TARBALL}" --provenance --access public

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -26,6 +26,9 @@ jobs:
     outputs:
       node-version: ${{ steps.meta.outputs.node-version }}
       tarball: ${{ steps.meta.outputs.tarball }}
+      # Job outputs travel over the Actions control plane rather than the
+      # artifact store, so the publish job can check what it downloaded.
+      tarball-sha256: ${{ steps.pack.outputs.sha256 }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -42,7 +45,7 @@ jobs:
       - name: Resolve versions
         id: meta
         run: |
-          NODE_VERSION=$(sed -n 's/^nodejs[[:space:]]\{1,\}//p' .tool-versions)
+          NODE_VERSION=$(awk '$1 == "nodejs" { print $2; exit }' .tool-versions)
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           test -n "${NODE_VERSION}"
           {
@@ -84,11 +87,13 @@ jobs:
       # resulting tarball streams it verbatim, so the package contents are
       # unchanged by the split.
       - name: Pack
+        id: pack
         env:
           TARBALL: ${{ steps.meta.outputs.tarball }}
         run: |
           npm pack --pack-destination .
           test -f "${TARBALL}"
+          echo "sha256=$(sha256sum "${TARBALL}" | cut -d' ' -f1)" >> "${GITHUB_OUTPUT}"
 
       - name: Upload tarball
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -103,7 +108,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: read
+      # No contents: read — this job never checks out, and a same-run artifact
+      # download authenticates with ACTIONS_RUNTIME_TOKEN, not GITHUB_TOKEN.
       id-token: write # Required for OIDC trusted publishing
     steps:
       # Deliberately no actions/checkout and no `npm ci`: provenance is derived
@@ -116,16 +122,32 @@ jobs:
           name: npm-tarball
           path: .
 
-      # Node 24.15.0 bundles npm 11.12.1, which covers trusted publishing
-      # (>= 11.5.1) and provenance (>= 9.5.0), so no global npm install is
-      # needed here. Trusted publishing matches on the workflow filename, not
-      # the job, so splitting the file into two jobs needs no npm-side change.
+      # The artifact name is the only thing tying this download to the build
+      # job, so check the digest the build job recorded before publishing it.
+      - name: Verify tarball digest
+        env:
+          TARBALL: ${{ needs.build.outputs.tarball }}
+          EXPECTED: ${{ needs.build.outputs.tarball-sha256 }}
+        run: echo "${EXPECTED}  ${TARBALL}" | sha256sum --check --strict
+
+      # The Node version comes from .tool-versions at runtime, so assert the npm
+      # floor next to the step that depends on it rather than in a comment that
+      # would silently drift. Trusted publishing matches on the workflow
+      # filename, not the job, so splitting this file into two jobs needs no
+      # npm-side change.
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ needs.build.outputs.node-version }}
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
+
+      - name: Verify npm supports trusted publishing
+        run: |
+          NPM_VERSION=$(npm --version)
+          echo "npm ${NPM_VERSION}"
+          printf '11.5.1\n%s\n' "${NPM_VERSION}" | sort -V -C \
+            || { echo "::error::npm >= 11.5.1 required for trusted publishing, got ${NPM_VERSION}"; exit 1; }
 
       # `--provenance` is passed explicitly: trusted publishing auto-enables it,
       # but that path is wrapped in a try/catch and would fail silently, leaving

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -45,9 +45,11 @@ jobs:
           NODE_VERSION=$(sed -n 's/^nodejs[[:space:]]\{1,\}//p' .tool-versions)
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           test -n "${NODE_VERSION}"
-          echo "node-version=${NODE_VERSION}" >> "${GITHUB_OUTPUT}"
-          echo "package-version=${PACKAGE_VERSION}" >> "${GITHUB_OUTPUT}"
-          echo "tarball=repomix-${PACKAGE_VERSION}.tgz" >> "${GITHUB_OUTPUT}"
+          {
+            echo "node-version=${NODE_VERSION}"
+            echo "package-version=${PACKAGE_VERSION}"
+            echo "tarball=repomix-${PACKAGE_VERSION}.tgz"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
A security review of the release workflows found that `npm-publish.yml` holds `id-token: write` while running ~400 third-party packages.

## Problem

`id-token: write` puts `ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN` in the job environment, and any code running there can exchange them for an npm publish token. The single job held that permission while running:

- `npm install -g npm@latest` (unpinned, floating)
- `npm ci` (~400 packages, lifecycle scripts enabled)
- lint, the test suite, and the build

all **before** `npm publish`. One compromised dev dependency could have published a malicious `repomix` release carrying valid provenance.

## Change

Split into three jobs in the same file:

- **`check`** — `contents: read` only. Runs lint and the test suite, which is where the whole dependency tree actually executes (vitest, the linters' native binaries, everything `src/` imports). Never touches the tarball.
- **`build`** — `contents: read` only. Runs `npm ci` and `npm pack`, nothing else. The code that can reach the package contents is reduced to npm itself, the install scripts (only `esbuild` on linux), and `tsc` via `prepare`. Dev-only dependencies have no other path to end users, so keeping them out of this job is what narrows the build-time tampering risk rather than only the token-minting risk.
- **`publish`** — `needs: [build, check]`, holds `id-token: write`, and runs nothing but `npm publish <tgz> --provenance`. No checkout, no `npm ci`, no global npm install. `check` in `needs` is the only gate on lint/tests now that `build` does not run them.

Also drops `npm install -g npm@latest`: Node 24.15.0 bundles npm 11.12.1, past the 11.5.1 trusted-publishing floor, and a floating global install inside the credentialed job was itself worth removing.

## Verification

Checked against the npm CLI source rather than assumed, since a mistake here breaks releases:

- **Provenance needs no checkout.** `libnpmpublish/lib/provenance.js` builds the attestation entirely from GitHub Actions env vars (`GITHUB_WORKFLOW_REF`, `GITHUB_SHA`, ...); it never reads `.git`. The only `readFile` in that module belongs to `--provenance-file`, which is not used here.
- **Tarball contents are unchanged.** `npm publish <tgz>` streams the file verbatim (`pacote/lib/file.js`), and the digest is computed from the manifest, not the CLI argument. `files` and `.npmignore` are resolved at pack time in the build job exactly as they are today.
- **Lifecycle scripts are preserved.** The only relevant script is `prepare: npm run build`, which now runs during `npm pack` in the build job. Summed across the two jobs the set is identical to today; the publish job runs none.
- **Trusted publishing still matches.** The npm-side config keys on the workflow *filename*, and `GITHUB_WORKFLOW_REF` is per-file rather than per-job, so keeping both jobs in `npm-publish.yml` needs no change on npm. (Moving `publish` into a reusable workflow *would* break it, so that was avoided.)

## Known cosmetic change

`gitHead` disappears from the registry manifest — it is populated only on the directory publish path. The commit is still bound, more strongly, by the provenance attestation's `resolvedDependencies[0].digest.gitCommit`. `_npmVersion` also goes from `12.0.2` to `11.12.1`.

## Not included

Binding the job to a GitHub environment was also recommended. That needs a repo settings change plus a matching entry in the npm trusted-publisher config, and referencing an environment that does not exist yet auto-creates it with no protection rules. It should be done deliberately rather than as a side effect of this PR.

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
