### PR TITLE
chore(ci): Use self-repository syntax for in-repo action references

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,10 @@
+# actionlint configuration
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md
+
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      # GitHub's self-repository syntax (`uses: $/path`, July 2026) is not yet
+      # understood by actionlint (rhysd/actionlint#711). zizmor's
+      # `self-repository` audit requires it, so suppress only this message.
+      - 'specifying action "\$/.+" in invalid format because ref is missing'

--- a/.github/workflows/pack-repository.yml
+++ b/.github/workflows/pack-repository.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
 
       - name: Pack repository with Repomix
-        uses: ./.github/actions/repomix
+        uses: $/.github/actions/repomix
         with:
           output: repomix-output.xml
 

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -30,14 +30,14 @@ jobs:
 
       - name: Run Repomix Action (Minimal)
         if: matrix['test-case'] == 'minimal'
-        uses: ./.github/actions/repomix
+        uses: $/.github/actions/repomix
         with:
           node-version: ${{ matrix.node-version }}
           output: "repomix-minimal-output.txt"
 
       - name: Run Repomix Action (Basic)
         if: matrix['test-case'] == 'basic'
-        uses: ./.github/actions/repomix
+        uses: $/.github/actions/repomix
         with:
           node-version: ${{ matrix.node-version }}
           directories: "src"
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run Repomix Action (Full)
         if: matrix['test-case'] == 'full'
-        uses: ./.github/actions/repomix
+        uses: $/.github/actions/repomix
         with:
           node-version: ${{ matrix.node-version }}
           directories: "src tests"


### PR DESCRIPTION
## Summary

Replace `uses: ./.github/actions/repomix` with `uses: $/.github/actions/repomix` in `pack-repository.yml` and `test-action.yml`.

zizmor 1.30 (pulled in by zizmor-action v0.6.3 in #1846) adds the `self-repository` audit, which flags the workspace-relative form and fails CI on that PR. The `$/` form resolves the action from the workflow's own ref instead of the checked-out filesystem, and GitHub treats it as pinned.

Behavior is unchanged: both workflows call the action right after checking out the same ref.

## Checklist

- [ ] Run `npm run test` (workflow-only change; verified with `uvx zizmor@latest` locally: 0 findings)
- [ ] Run `npm run lint` (not applicable)

Unblocks #1846.

🤖 Generated with [Claude Code](https://claude.com/claude-code)